### PR TITLE
Convert admina module to Lilia style

### DIFF
--- a/modules/admina/cl_permissions.lua
+++ b/modules/admina/cl_permissions.lua
@@ -1,4 +1,4 @@
-local PLUGIN = PLUGIN
+local MODULE = MODULE
 lia.admin = lia.admin or {}
 lia.admin.permissions = lia.admin.permissions or {}
 
@@ -6,6 +6,6 @@ netstream.Hook("nutscript_updateAdminPermissions", function(info)
 	lia.admin.permissions = info
 end)
 
-function PLUGIN:InitPostEntity()
+function MODULE:InitPostEntity()
 	netstream.Start("nutscript_requestAdminPermissions")
 end

--- a/modules/admina/cl_plugin.lua
+++ b/modules/admina/cl_plugin.lua
@@ -1,4 +1,4 @@
-local PLUGIN = PLUGIN
+local MODULE = MODULE
 lia.admin = lia.admin or {}
 lia.admin.menu = lia.admin.menu or {}
 lia.admin.menu.tabs = lia.admin.menu.tabs or {}

--- a/modules/admina/module.lua
+++ b/modules/admina/module.lua
@@ -1,8 +1,8 @@
-local PLUGIN = PLUGIN
-PLUGIN.name = "Admin"
-PLUGIN.author = "rusty"
-PLUGIN.desc = "Stop using paid admin mods, idiots."
-PLUGIN.language = "english"
+local MODULE = MODULE
+MODULE.name = "Admin"
+MODULE.author = "rusty"
+MODULE.desc = "Stop using paid admin mods, idiots."
+MODULE.language = "english"
 
 lia.admin = lia.admin or {}
 lia.admin.commands = lia.admin.commands or {noclip = true}
@@ -18,10 +18,9 @@ if SERVER then
 	lia.util.include("sv_bans.lua")
 end
 
-local PLUGIN = PLUGIN
 
 
-function PLUGIN:PlayerNoClip(client, state)
+function MODULE:PlayerNoClip(client, state)
 	if (client:hasPermission("noclip")) then
 		if SERVER then
 			if (state) then
@@ -62,7 +61,7 @@ function PLUGIN:PlayerNoClip(client, state)
 	end
 end
 
-function PLUGIN:InitializedPlugins()
+function MODULE:InitializedModules()
 	for cmd,info in next, lia.command.list do
 		if info.group or info.superAdminOnly or info.adminOnly then
 			info.onCheckAccess = function(client)

--- a/modules/admina/sh_commands.lua
+++ b/modules/admina/sh_commands.lua
@@ -1,4 +1,4 @@
-local PLUGIN = PLUGIN
+local MODULE = MODULE
 lia.admin = lia.admin or {}
 
 

--- a/modules/admina/sh_permissions.lua
+++ b/modules/admina/sh_permissions.lua
@@ -1,4 +1,4 @@
-local PLUGIN = PLUGIN
+local MODULE = MODULE
 local meta = FindMetaTable("Player")
 lia.admin = lia.admin or {}
 lia.admin.permissions = lia.admin.permissions or {}

--- a/modules/admina/sv_bans.lua
+++ b/modules/admina/sv_bans.lua
@@ -1,10 +1,10 @@
-local PLUGIN = PLUGIN
+local MODULE = MODULE
 lia.admin = lia.admin or {}
 lia.admin.bans = lia.admin.bans or {}
 lia.admin.bans.list = lia.admin.bans.list or {}
 
 function lia.admin.bans.add(steamid, reason, duration)
-	local genericReason = lia.lang.stored[PLUGIN.language].genericReason
+	local genericReason = lia.lang.stored[MODULE.language].genericReason
 	if !steamid then
 		Error("[NutScript Admin] lia.admin.bans.add: no steam id specified!")
 	end
@@ -96,12 +96,12 @@ hook.Add("OnDatabaseLoaded", "lia.admin.bans.loadBanlist", function()
 	end)
 end)
 
-function PLUGIN:CheckPassword(steamid64, ipAddress, svPassword, clPassword, name)
+function MODULE:CheckPassword(steamid64, ipAddress, svPassword, clPassword, name)
 	local banned = lia.admin.bans.isBanned(steamid64)
 	local hasExpired = lia.admin.bans.hasExpired(steamid64)
 	
 	if banned and !hasExpired then
-		return false, Format(lia.lang.stored[PLUGIN.language].banMessage, banned.duration / 60, banned.reason)
+		return false, Format(lia.lang.stored[MODULE.language].banMessage, banned.duration / 60, banned.reason)
 	elseif banned and hasExpired then
 		lia.admin.bans.remove(steamid64)
 	end

--- a/modules/admina/sv_permissions.lua
+++ b/modules/admina/sv_permissions.lua
@@ -1,4 +1,4 @@
-local PLUGIN = PLUGIN
+local MODULE = MODULE
 local meta = FindMetaTable("Player")
 lia.admin = lia.admin or {}
 lia.admin.permissions = lia.admin.permissions or {}
@@ -133,15 +133,15 @@ function lia.admin.setGroupPosition(groupName, position)
 	end
 end
 
-function PLUGIN:InitPostEntity()
+function MODULE:InitPostEntity()
 	lia.admin.load()
 end
 
-function PLUGIN:ShutDown()
+function MODULE:ShutDown()
 	lia.admin.save()
 end
 
-function PLUGIN:PlayerAuthed(ply, steamid, uid)
+function MODULE:PlayerAuthed(ply, steamid, uid)
 	lia.db.query(Format("SELECT _userGroup FROM nut_players WHERE _steamID = %s", util.SteamIDTo64(steamid)), function(data)
 		ply:SetUserGroup(data[1]._userGroup)
 	end)


### PR DESCRIPTION
## Summary
- migrate `admina` plugin to a proper Lilia module
- rename `sh_plugin.lua` to `module.lua`
- update all files to reference `MODULE` instead of `PLUGIN`
- rename hook `InitializedPlugins` to `InitializedModules`

## Testing
- `apt-get update` *(fails: repository signatures cannot be verified)*

------
https://chatgpt.com/codex/tasks/task_e_68735c9de6788327a725ee5864f569b8