### PR TITLE
Move ban table creation to database

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -263,6 +263,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS `lia_config`;
     DROP TABLE IF EXISTS `lia_data`;
     DROP TABLE IF EXISTS `lia_logs`;
+    DROP TABLE IF EXISTS `lia_bans`;
 ]])
             local done = 0
             for i = 1, #queries do
@@ -289,6 +290,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS lia_config;
     DROP TABLE IF EXISTS lia_data;
     DROP TABLE IF EXISTS lia_logs;
+    DROP TABLE IF EXISTS lia_bans;
 ]], realCallback)
     end
 end
@@ -371,6 +373,13 @@ function lia.db.loadTables()
                 PRIMARY KEY (_key, _folder, _map)
             );
 
+            CREATE TABLE IF NOT EXISTS lia_bans (
+                _steamID TEXT,
+                _banStart INTEGER,
+                _banDuration INTEGER,
+                _reason TEXT
+            );
+
             CREATE TABLE IF NOT EXISTS lia_logs (
                 _id INTEGER PRIMARY KEY AUTOINCREMENT,
                 _timestamp DATETIME,
@@ -450,6 +459,14 @@ function lia.db.loadTables()
                 `_map` VARCHAR(255) NULL DEFAULT NULL COLLATE 'utf8mb4_general_ci',
                 `_value` TEXT NULL COLLATE 'utf8mb4_general_ci',
                 PRIMARY KEY (`_key`, `_folder`, `_map`)
+            );
+
+            CREATE TABLE IF NOT EXISTS `lia_bans` (
+                `_steamID` varchar(64) NOT NULL,
+                `_banStart` int(32) NOT NULL,
+                `_banDuration` int(32) NOT NULL,
+                `_reason` varchar(512) DEFAULT '',
+                PRIMARY KEY (`_steamID`)
             );
 
             CREATE TABLE IF NOT EXISTS `lia_logs` (

--- a/modules/admina/libraries/server.lua
+++ b/modules/admina/libraries/server.lua
@@ -166,24 +166,6 @@ function meta:banPlayer(reason, duration)
 	self:Kick(L("banMessage", self, duration or 0, reason or L("genericReason", self)))
 end
 
-lia.admin.bans.sqlite_createTables = [[
-CREATE TABLE IF NOT EXISTS `lia_bans` (
-	`_steamID` TEXT,
-	`_banStart` INTEGER,
-	`_banDuration` INTEGER,
-	`_reason` TEXT
-);
-]]
-lia.admin.bans.mysql_createTables = [[
-CREATE TABLE IF NOT EXISTS `lia_bans` (
-	`_steamID` varchar(64) NOT NULL,
-	`_banStart` int(32) NOT NULL,
-	`_banDuration` int(32) NOT NULL,
-	`_reason` varchar(512) DEFAULT '',
-	PRIMARY KEY (`_steamID`)
-);
-]]
-hook.Add("OnLoadTables", "lia.admin.bans.setupDatabase", function() lia.db.query(lia.db.object and lia.admin.bans.mysql_createTables or lia.admin.bans.sqlite_createTables) end)
 hook.Add("OnDatabaseLoaded", "lia.admin.bans.loadBanlist", function()
 	lia.db.query("SELECT * FROM lia_bans", function(data)
 		if data and istable(data) then


### PR DESCRIPTION
## Summary
- shift ban table creation from admin module to main database generation
- remove ban setup hook from admin module
- ensure wipeTables also drops `lia_bans`

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873649d3c2883279a0a20c2e32a40c1