### PR TITLE
Add basic admin commands

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -762,6 +762,7 @@ local TalkRanges = {
 function GM:PlayerCanHearPlayersVoice(listener, speaker)
     if not IsValid(listener) and IsValid(speaker) or listener == speaker then return false, false end
     if speaker:getNetVar("IsDeadRestricted", false) then return false, false end
+    if speaker:getNetVar("liaGagged") then return false, false end
     local char = speaker:getChar()
     if not (char and not char:getData("VoiceBan", false)) then return false, false end
     if not lia.config.get("IsVoiceEnabled", true) then return false, false end

--- a/modules/admina/commands.lua
+++ b/modules/admina/commands.lua
@@ -141,3 +141,293 @@ lia.command.add("grpsetposition", {
 		end
 	end
 })
+
+lia.command.add("plyunban", {
+        adminOnly = true,
+        syntax = "<string steamid>",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local steamid = arguments[1]
+                        if steamid and steamid ~= "" then
+                                lia.admin.bans.remove(steamid)
+                                client:notify("Player unbanned")
+                        end
+                end
+        end
+})
+
+lia.command.add("plyfreeze", {
+        adminOnly = true,
+        syntax = "<string name> [number duration]",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local target = lia.command.findPlayer(client, arguments[1])
+                        if IsValid(target) then
+                                target:Freeze(true)
+                                local dur = tonumber(arguments[2]) or 0
+                                if dur > 0 then
+                                        timer.Simple(dur, function() if IsValid(target) then target:Freeze(false) end end)
+                                end
+                        end
+                end
+        end
+})
+
+lia.command.add("plyunfreeze", {
+        adminOnly = true,
+        syntax = "<string name>",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local target = lia.command.findPlayer(client, arguments[1])
+                        if IsValid(target) then target:Freeze(false) end
+                end
+        end
+})
+
+lia.command.add("plyslay", {
+        adminOnly = true,
+        syntax = "<string name>",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local target = lia.command.findPlayer(client, arguments[1])
+                        if IsValid(target) then target:Kill() end
+                end
+        end
+})
+
+lia.command.add("plyrespawn", {
+        adminOnly = true,
+        syntax = "<string name>",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local target = lia.command.findPlayer(client, arguments[1])
+                        if IsValid(target) then target:Spawn() end
+                end
+        end
+})
+
+lia.command.add("plyblind", {
+        adminOnly = true,
+        syntax = "<string name>",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local target = lia.command.findPlayer(client, arguments[1])
+                        if IsValid(target) then
+                                net.Start("blindTarget")
+                                net.WriteBool(true)
+                                net.Send(target)
+                        end
+                end
+        end
+})
+
+lia.command.add("plyunblind", {
+        adminOnly = true,
+        syntax = "<string name>",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local target = lia.command.findPlayer(client, arguments[1])
+                        if IsValid(target) then
+                                net.Start("blindTarget")
+                                net.WriteBool(false)
+                                net.Send(target)
+                        end
+                end
+        end
+})
+
+lia.command.add("plygag", {
+        adminOnly = true,
+        syntax = "<string name>",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local target = lia.command.findPlayer(client, arguments[1])
+                        if IsValid(target) then target:setNetVar("liaGagged", true) end
+                end
+        end
+})
+
+lia.command.add("plyungag", {
+        adminOnly = true,
+        syntax = "<string name>",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local target = lia.command.findPlayer(client, arguments[1])
+                        if IsValid(target) then target:setNetVar("liaGagged", false) end
+                end
+        end
+})
+
+lia.command.add("plymute", {
+        adminOnly = true,
+        syntax = "<string name>",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local target = lia.command.findPlayer(client, arguments[1])
+                        if IsValid(target) and target:getChar() then
+                                target:getChar():setData("VoiceBan", true)
+                        end
+                end
+        end
+})
+
+lia.command.add("plyunmute", {
+        adminOnly = true,
+        syntax = "<string name>",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local target = lia.command.findPlayer(client, arguments[1])
+                        if IsValid(target) and target:getChar() then
+                                target:getChar():setData("VoiceBan", false)
+                        end
+                end
+        end
+})
+
+lia.command.add("plybring", {
+        adminOnly = true,
+        syntax = "<string name>",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local target = lia.command.findPlayer(client, arguments[1])
+                        if IsValid(target) then
+                                lia.admin.returnPositions[target] = target:GetPos()
+                                target:SetPos(client:GetPos() + client:GetForward() * 50)
+                        end
+                end
+        end
+})
+
+lia.command.add("plygoto", {
+        adminOnly = true,
+        syntax = "<string name>",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local target = lia.command.findPlayer(client, arguments[1])
+                        if IsValid(target) then
+                                lia.admin.returnPositions[client] = client:GetPos()
+                                client:SetPos(target:GetPos() + target:GetForward() * 50)
+                        end
+                end
+        end
+})
+
+lia.command.add("plyreturn", {
+        adminOnly = true,
+        syntax = "<string name>",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local target = lia.command.findPlayer(client, arguments[1])
+                        target = IsValid(target) and target or client
+                        local pos = lia.admin.returnPositions[target]
+                        if pos then target:SetPos(pos) lia.admin.returnPositions[target] = nil end
+                end
+        end
+})
+
+lia.command.add("plyjail", {
+        adminOnly = true,
+        syntax = "<string name> [number duration]",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local target = lia.command.findPlayer(client, arguments[1])
+                        if IsValid(target) then
+                                target:Lock()
+                                target:Freeze(true)
+                        end
+                end
+        end
+})
+
+lia.command.add("plyunjail", {
+        adminOnly = true,
+        syntax = "<string name>",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local target = lia.command.findPlayer(client, arguments[1])
+                        if IsValid(target) then
+                                target:UnLock()
+                                target:Freeze(false)
+                        end
+                end
+        end
+})
+
+lia.command.add("plycloak", {
+        adminOnly = true,
+        syntax = "<string name>",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local target = lia.command.findPlayer(client, arguments[1])
+                        if IsValid(target) then target:SetNoDraw(true) end
+                end
+        end
+})
+
+lia.command.add("plyuncloak", {
+        adminOnly = true,
+        syntax = "<string name>",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local target = lia.command.findPlayer(client, arguments[1])
+                        if IsValid(target) then target:SetNoDraw(false) end
+                end
+        end
+})
+
+lia.command.add("plygod", {
+        adminOnly = true,
+        syntax = "<string name>",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local target = lia.command.findPlayer(client, arguments[1])
+                        if IsValid(target) then target:GodEnable() end
+                end
+        end
+})
+
+lia.command.add("plyungod", {
+        adminOnly = true,
+        syntax = "<string name>",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local target = lia.command.findPlayer(client, arguments[1])
+                        if IsValid(target) then target:GodDisable() end
+                end
+        end
+})
+
+lia.command.add("plyignite", {
+        adminOnly = true,
+        syntax = "<string name> [number duration]",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local target = lia.command.findPlayer(client, arguments[1])
+                        if IsValid(target) then
+                                target:Ignite(tonumber(arguments[2]) or 5)
+                        end
+                end
+        end
+})
+
+lia.command.add("plyextinguish", {
+        adminOnly = true,
+        syntax = "<string name>",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local target = lia.command.findPlayer(client, arguments[1])
+                        if IsValid(target) then target:Extinguish() end
+                end
+        end
+})
+
+lia.command.add("plystrip", {
+        adminOnly = true,
+        syntax = "<string name>",
+        onRun = function(client, arguments)
+                if SERVER then
+                        local target = lia.command.findPlayer(client, arguments[1])
+                        if IsValid(target) then target:StripWeapons() end
+                end
+        end
+})

--- a/modules/admina/libraries/client.lua
+++ b/modules/admina/libraries/client.lua
@@ -19,73 +19,94 @@ local function quote(str)
 end
 
 hook.Add("RunAdminSystemCommand", "liaAdmin", function(cmd, _, victim, dur, reason)
-	if cmd == "kick" then
-		RunConsoleCommand("say", "/plykick " .. quote(id) .. (reason and " " .. quote(reason) or ""))
-		return true
-	elseif cmd == "ban" then
-		RunConsoleCommand("say", "/plyban " .. quote(id) .. " " .. tostring(dur or 0) .. (reason and " " .. quote(reason) or ""))
-		return true
-	elseif cmd == "unban" then
-		RunConsoleCommand("say", "/plyunban " .. quote(id))
-		return true
-	elseif cmd == "mute" then
-		RunConsoleCommand("sam", "mute", victim:SteamID(), tostring(dur or 0), reason or "")
-		return true
-	elseif cmd == "unmute" then
-		RunConsoleCommand("sam", "unmute", victim:SteamID())
-		return true
-	elseif cmd == "gag" then
-		RunConsoleCommand("sam", "gag", victim:SteamID(), tostring(dur or 0), reason or "")
-		return true
-	elseif cmd == "ungag" then
-		RunConsoleCommand("sam", "ungag", victim:SteamID())
-		return true
-	elseif cmd == "freeze" then
-		RunConsoleCommand("sam", "freeze", victim:SteamID(), tostring(dur or 0))
-		return true
-	elseif cmd == "unfreeze" then
-		RunConsoleCommand("sam", "unfreeze", victim:SteamID())
-		return true
-	elseif cmd == "slay" then
-		RunConsoleCommand("sam", "slay", victim:SteamID())
-		return true
-	elseif cmd == "bring" then
-		RunConsoleCommand("sam", "bring", victim:SteamID())
-		return true
-	elseif cmd == "goto" then
-		RunConsoleCommand("sam", "goto", victim:SteamID())
-		return true
-	elseif cmd == "return" then
-		RunConsoleCommand("sam", "return", victim:SteamID())
-		return true
-	elseif cmd == "jail" then
-		RunConsoleCommand("sam", "jail", victim:SteamID(), tostring(dur or 0))
-		return true
-	elseif cmd == "unjail" then
-		RunConsoleCommand("sam", "unjail", victim:SteamID())
-		return true
-	elseif cmd == "cloak" then
-		RunConsoleCommand("sam", "cloak", victim:SteamID())
-		return true
-	elseif cmd == "uncloak" then
-		RunConsoleCommand("sam", "uncloak", victim:SteamID())
-		return true
-	elseif cmd == "god" then
-		RunConsoleCommand("sam", "god", victim:SteamID())
-		return true
-	elseif cmd == "ungod" then
-		RunConsoleCommand("sam", "ungod", victim:SteamID())
-		return true
-	elseif cmd == "ignite" then
-		RunConsoleCommand("sam", "ignite", victim:SteamID(), tostring(dur or 0))
-		return true
-	elseif cmd == "extinguish" or cmd == "unignite" then
-		RunConsoleCommand("sam", "extinguish", victim:SteamID())
-		return true
-	elseif cmd == "strip" then
-		RunConsoleCommand("sam", "strip", victim:SteamID())
-		return true
-	end
+        local id = IsValid(victim) and victim:SteamID() or tostring(victim)
+        if cmd == "kick" then
+                RunConsoleCommand("say", "/plykick " .. quote(id) .. (reason and " " .. quote(reason) or ""))
+                return true
+        elseif cmd == "ban" then
+                RunConsoleCommand("say", "/plyban " .. quote(id) .. " " .. tostring(dur or 0) .. (reason and " " .. quote(reason) or ""))
+                return true
+        elseif cmd == "unban" then
+                RunConsoleCommand("say", "/plyunban " .. quote(id))
+                return true
+        elseif cmd == "mute" then
+                RunConsoleCommand("say", "/plymute " .. quote(id) .. " " .. tostring(dur or 0) .. (reason and " " .. quote(reason) or ""))
+                return true
+        elseif cmd == "unmute" then
+                RunConsoleCommand("say", "/plyunmute " .. quote(id))
+                return true
+        elseif cmd == "gag" then
+                RunConsoleCommand("say", "/plygag " .. quote(id) .. " " .. tostring(dur or 0) .. (reason and " " .. quote(reason) or ""))
+                return true
+        elseif cmd == "ungag" then
+                RunConsoleCommand("say", "/plyungag " .. quote(id))
+                return true
+        elseif cmd == "freeze" then
+                RunConsoleCommand("say", "/plyfreeze " .. quote(id) .. " " .. tostring(dur or 0))
+                return true
+        elseif cmd == "unfreeze" then
+                RunConsoleCommand("say", "/plyunfreeze " .. quote(id))
+                return true
+        elseif cmd == "slay" then
+                RunConsoleCommand("say", "/plyslay " .. quote(id))
+                return true
+        elseif cmd == "bring" then
+                RunConsoleCommand("say", "/plybring " .. quote(id))
+                return true
+        elseif cmd == "goto" then
+                RunConsoleCommand("say", "/plygoto " .. quote(id))
+                return true
+        elseif cmd == "return" then
+                RunConsoleCommand("say", "/plyreturn " .. quote(id))
+                return true
+        elseif cmd == "jail" then
+                RunConsoleCommand("say", "/plyjail " .. quote(id) .. " " .. tostring(dur or 0))
+                return true
+        elseif cmd == "unjail" then
+                RunConsoleCommand("say", "/plyunjail " .. quote(id))
+                return true
+        elseif cmd == "cloak" then
+                RunConsoleCommand("say", "/plycloak " .. quote(id))
+                return true
+        elseif cmd == "uncloak" then
+                RunConsoleCommand("say", "/plyuncloak " .. quote(id))
+                return true
+        elseif cmd == "god" then
+                RunConsoleCommand("say", "/plygod " .. quote(id))
+                return true
+        elseif cmd == "ungod" then
+                RunConsoleCommand("say", "/plyungod " .. quote(id))
+                return true
+        elseif cmd == "ignite" then
+                RunConsoleCommand("say", "/plyignite " .. quote(id) .. " " .. tostring(dur or 0))
+                return true
+        elseif cmd == "extinguish" or cmd == "unignite" then
+                RunConsoleCommand("say", "/plyextinguish " .. quote(id))
+                return true
+        elseif cmd == "strip" then
+                RunConsoleCommand("say", "/plystrip " .. quote(id))
+                return true
+        elseif cmd == "respawn" then
+                RunConsoleCommand("say", "/plyrespawn " .. quote(id))
+                return true
+        elseif cmd == "blind" then
+                RunConsoleCommand("say", "/plyblind " .. quote(id))
+                return true
+        elseif cmd == "unblind" then
+                RunConsoleCommand("say", "/plyunblind " .. quote(id))
+                return true
+        end
 end)
 
 net.Receive("lilia_updateAdminPermissions", function() lia.admin.permissions = net.ReadTable() end)
+
+net.Receive("blindTarget", function()
+        local enabled = net.ReadBool()
+        if enabled then
+                hook.Add("HUDPaint", "blindTarget", function()
+                        draw.RoundedBox(0, 0, 0, ScrW(), ScrH(), Color(0, 0, 0, 255))
+                end)
+        else
+                hook.Remove("HUDPaint", "blindTarget")
+        end
+end)

--- a/modules/admina/libraries/server.lua
+++ b/modules/admina/libraries/server.lua
@@ -1,5 +1,6 @@
 local MODULE = MODULE
 local meta = FindMetaTable("Player")
+util.AddNetworkString("blindTarget")
 function lia.admin.save(network)
         file.Write("nutscript/admin_permissions.txt", util.TableToJSON(lia.admin.permissions))
         if network then
@@ -192,11 +193,17 @@ hook.Add("OnDatabaseLoaded", "lia.admin.bans.loadBanlist", function()
 end)
 
 function MODULE:CheckPassword(steamid64, ipAddress, svPassword, clPassword, name)
-	local banned = lia.admin.bans.isBanned(steamid64)
-	local hasExpired = lia.admin.bans.hasExpired(steamid64)
-	if banned and not hasExpired then
+        local banned = lia.admin.bans.isBanned(steamid64)
+        local hasExpired = lia.admin.bans.hasExpired(steamid64)
+        if banned and not hasExpired then
                return false, L("banMessage", banned.duration / 60, banned.reason)
-	elseif banned and hasExpired then
-		lia.admin.bans.remove(steamid64)
-	end
+        elseif banned and hasExpired then
+                lia.admin.bans.remove(steamid64)
+        end
 end
+
+lia.admin.returnPositions = lia.admin.returnPositions or {}
+
+hook.Add("PlayerSay", "liaAdminGag", function(client)
+        if client:getNetVar("liaGagged") then return "" end
+end)


### PR DESCRIPTION
## Summary
- extend liaAdmin client hook to support more commands
- implement numerous admin commands server-side
- add blind net message and gag check
- block voice from gagged players
- use `blindTarget` net message for blinding logic

## Testing
- `luacheck modules/admina/libraries/client.lua modules/admina/libraries/server.lua modules/admina/commands.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68737a7da6448327bb0f56dfec2f613e