### PR TITLE
Add extra details to charlist

### DIFF
--- a/modules/administration/submodules/permissions/libraries/client.lua
+++ b/modules/administration/submodules/permissions/libraries/client.lua
@@ -53,6 +53,19 @@ end
 net.Receive("DisplayCharList", function()
     local sendData = net.ReadTable()
     local targetSteamIDsafe = net.ReadString()
+
+    local extraColumns, extraOrder = {}, {}
+    for _, v in pairs(sendData or {}) do
+        if istable(v.extraDetails) then
+            for k in pairs(v.extraDetails) do
+                if not extraColumns[k] then
+                    extraColumns[k] = true
+                    table.insert(extraOrder, k)
+                end
+            end
+        end
+    end
+
     local fr = vgui.Create("DFrame")
     fr:SetTitle("Charlist for SteamID64: " .. targetSteamIDsafe)
     fr:SetSize(1000, 500)
@@ -69,8 +82,13 @@ net.Receive("DisplayCharList", function()
     listView:AddColumn("BanningAdminSteamID")
     listView:AddColumn("BanningAdminRank")
     listView:AddColumn("CharMoney")
+    for _, name in ipairs(extraOrder) do
+        listView:AddColumn(name)
+    end
+
     for _, v in pairs(sendData or {}) do
-        local Line = listView:AddLine(v.ID, v.Name, v.Desc, v.Faction, v.Banned, v.BanningAdminName, v.BanningAdminSteamID, v.BanningAdminRank, v.Money)
+        local lineValues = {v.ID, v.Name, v.Desc, v.Faction, v.Banned, v.BanningAdminName, v.BanningAdminSteamID, v.BanningAdminRank, v.Money}
+        local Line = listView:AddLine(unpack(lineValues))
         if v.Banned == "Yes" then
             Line.DoPaint = Line.Paint
             Line.Paint = function(pnl, w, h)
@@ -78,6 +96,12 @@ net.Receive("DisplayCharList", function()
                 surface.DrawRect(0, 0, w, h)
                 pnl:DoPaint(w, h)
             end
+        end
+
+        local colIndex = 10
+        for _, name in ipairs(extraOrder) do
+            Line:SetColumnText(colIndex, tostring(v.extraDetails and v.extraDetails[name] or ""))
+            colIndex = colIndex + 1
         end
 
         Line.CharID = v.ID


### PR DESCRIPTION
## Summary
- store banning admin fields consistently on offline bans
- include every registered char var in `charlist` results
- allow hooks to add custom `extraDetails` for charlist rows
- use Nick in charBanInfo and clear it on unbans

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68738a9aa2dc832780ec90f6fb4df183