### PR TITLE
Add last online info to faction commands

### DIFF
--- a/modules/teams/module.lua
+++ b/modules/teams/module.lua
@@ -49,9 +49,11 @@ else
         list:SetMultiSelect(false)
         list:AddColumn("ID")
         list:AddColumn("Name")
+        list:AddColumn("Last Online")
+        list:AddColumn("Hours Played")
         for _, data in ipairs(characterData) do
             if data.faction == factionID and data.id ~= character:getID() then
-                local line = list:AddLine(data.id, data.name)
+                local line = list:AddLine(data.id, data.name, data.lastOnline, data.hoursPlayed)
                 line.steamID = data.steamID
             end
         end


### PR DESCRIPTION
## Summary
- show Last Online and Hours Played in roster and factionmanagement commands
- display these new columns in the faction management UI

## Testing
- `luacheck modules/teams/commands.lua modules/teams/module.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687394abddd883278a2c9521c161b2d5