### PR TITLE
Remove legacy admin panels

### DIFF
--- a/documentation/docs/definitions/panels.md
+++ b/documentation/docs/definitions/panels.md
@@ -60,8 +60,6 @@ Panels provide the building blocks for Lilia's user interface. Most derive from 
 | `liaSmallButton` | `DButton` | Compact button for tight layouts. |
 | `liaMiniButton` | `DButton` | Very small button variant. |
 | `liaNoBGButton` | `DButton` | Text-only button with no background. |
-| `DAdminWorldMenu` | `DPanel` | Context panel for admin world actions. |
-| `DAdminMenu` | `DFrame` | Frame for managing admin tabs. |
 
 ---
 
@@ -633,24 +631,3 @@ Text-only button that still shows the underline animation.
 
 ---
 
-### `DAdminWorldMenu`
-
-**Base Panel:**
-
-`DPanel`
-
-**Description:**
-
-Container panel used for context-sensitive admin actions in the world.
-
----
-
-### `DAdminMenu`
-
-**Base Panel:**
-
-`DFrame`
-
-**Description:**
-
-Main window for the administrator interface. Populates its property sheet from `lia.admin.menu.tabs`.

--- a/gamemode/core/derma/panels/panels.lua
+++ b/gamemode/core/derma/panels/panels.lua
@@ -122,38 +122,3 @@ function Derma_Install_Convar_Functions(PANEL)
     end
 end
 
-PANEL = {}
-function PANEL:Init()
-    self:Dock(FILL)
-end
-
-function PANEL:Paint(w, h)
-    surface.SetDrawColor(255, 0, 0)
-    surface.DrawOutlinedRect(0, 0, w, h)
-end
-
-vgui.Register("DAdminWorldMenu", PANEL, "DPanel")
-PANEL = {}
-function PANEL:Init()
-    self:SetTitle(L("adminMenuTitle"))
-    self:SetSize(ScrW() / 2, ScrH() / 1.5)
-    self:Center()
-    self:MakePopup()
-    self.menuTabs = self:Add("DPropertySheet")
-    self.menuTabs:Dock(FILL)
-    self.menuTabs.childTabs = {}
-    for _, info in next, lia.admin.menu.tabs do
-        local icon = info.icon
-        local panelClass = info.panelClass
-        local title = L(info.title)
-        local panel = self.menuTabs:Add(panelClass)
-        self.menuTabs:AddSheet(title, panel, icon)
-        self.menuTabs.childTabs[#self.menuTabs.childTabs + 1] = panel
-    end
-end
-
-vgui.Register("DAdminMenu", PANEL, "DFrame")
-
-concommand.Add("open_admin_menu", function() 
-    vgui.Create("DAdminMenu") 
-end)


### PR DESCRIPTION
## Summary
- delete DAdminMenu and DAdminWorldMenu panels
- remove documentation for those panels

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6873ce9440748327bde0193735ffd57a