### PR TITLE
Fix admin library usage

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -229,7 +229,7 @@ function GM:CheckPassword(steamID64, _, serverPassword, clientPassword, playerNa
     local banExpired = lia.admin.hasBanExpired(steamID64)
     if banRecord then
         if not banExpired then return false, L("banMessage", banRecord.duration / 60, banRecord.reason) end
-        lia.admin.bans.remove(steamID64)
+        lia.admin.removeBan(steamID64)
     end
 
     local convertingMessage = lia.config.isConverting and L("serverConvertingConfig") or lia.data.isConverting and L("serverConvertingData") or lia.log.isConverting and L("serverConvertingLogs")

--- a/modules/administration/commands.lua
+++ b/modules/administration/commands.lua
@@ -46,10 +46,10 @@ lia.command.add("plysetgroup", {
     onRun = function(client, arguments)
         if SERVER then
             local target = lia.command.findPlayer(client, arguments[1])
-            if IsValid(target) and lia.admin.permissions[arguments[2]] then
+            if IsValid(target) and lia.admin.groups[arguments[2]] then
                 lia.admin.setPlayerGroup(target, arguments[2])
                 client:notifyLocalized("plyGroupSet")
-            elseif IsValid(target) and not lia.admin.permissions[arguments[2]] then
+            elseif IsValid(target) and not lia.admin.groups[arguments[2]] then
                 client:notifyLocalized("groupNotExists")
             end
         end


### PR DESCRIPTION
## Summary
- switch admin ban removal call to `lia.admin.removeBan`
- use `lia.admin.groups` for group checks

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68740511cc6c83278a7eed61d3397ae0