### PR TITLE
Ensure admin ranks and privilege tracking

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -1,8 +1,17 @@
 lia.admin = lia.admin or {}
 lia.admin.bans = lia.admin.bans or {}
 lia.admin.groups = lia.admin.groups or {}
+lia.admin.privileges = lia.admin.privileges or {}
 function lia.admin.load()
     lia.admin.groups = lia.data.get("admin_groups", {}, true, true)
+    for name, priv in pairs(CAMI.GetPrivileges() or {}) do
+        lia.admin.privileges[name] = priv
+    end
+    if table.Count(lia.admin.groups) == 0 then
+        lia.admin.createGroup("admin")
+        lia.admin.createGroup("superadmin")
+        lia.admin.save(true)
+    end
 end
 
 function lia.admin.createGroup(groupName, info)
@@ -13,6 +22,11 @@ function lia.admin.createGroup(groupName, info)
 
     lia.admin.groups[groupName] = info or {}
     if SERVER then lia.admin.save(true) end
+end
+
+function lia.admin.registerPrivilege(privilege)
+    if not privilege or not privilege.Name then return end
+    lia.admin.privileges[privilege.Name] = privilege
 end
 
 function lia.admin.removeGroup(groupName)

--- a/gamemode/core/libraries/thirdparty/sh_cami.lua
+++ b/gamemode/core/libraries/thirdparty/sh_cami.lua
@@ -67,6 +67,9 @@ end
 
 function CAMI.RegisterPrivilege(privilege)
     privileges[privilege.Name] = privilege
+    if lia and lia.admin and lia.admin.registerPrivilege then
+        lia.admin.registerPrivilege(privilege)
+    end
     hook.Run("CAMI.OnPrivilegeRegistered", privilege)
     return privilege
 end
@@ -75,6 +78,9 @@ function CAMI.UnregisterPrivilege(privilegeName)
     if not privileges[privilegeName] then return false end
     local privilege = privileges[privilegeName]
     privileges[privilegeName] = nil
+    if lia and lia.admin and lia.admin.privileges then
+        lia.admin.privileges[privilegeName] = nil
+    end
     hook.Run("CAMI.OnPrivilegeUnregistered", privilege)
     return true
 end


### PR DESCRIPTION
## Summary
- keep a list of registered privileges in `lia.admin`
- create default admin ranks if none exist
- track privilege registration through CAMI

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687408078ee08327a705384510074ca7