### PR TITLE
Add oil pump system

### DIFF
--- a/gamemode/items/oil/high_quality_oil.txt
+++ b/gamemode/items/oil/high_quality_oil.txt
@@ -1,0 +1,5 @@
+ITEM.name = "High-Quality Oil"
+ITEM.desc = "A drum of refined high-grade oil."
+ITEM.model = "models/props_c17/oildrum001.mdl"
+ITEM.width = 1
+ITEM.height = 1

--- a/gamemode/items/oil/low_quality_oil.txt
+++ b/gamemode/items/oil/low_quality_oil.txt
@@ -1,0 +1,5 @@
+ITEM.name = "Low-Quality Oil"
+ITEM.desc = "A drum of low-grade oil."
+ITEM.model = "models/props_c17/oildrum001.mdl"
+ITEM.width = 1
+ITEM.height = 1

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -1119,5 +1119,8 @@ Reload: Drop]],
     urlName = "Generic Item",
     urlDesc = "Generic Description",
     weaponsName = "Weapon",
+    oilPumpReady = "Oil Ready",
+    oilPumpNext = "Ready in %s",
+    oilPumping = "Pumping oil...",
     weaponsDesc = "A Weapon.",
 }

--- a/modules/oil/config.lua
+++ b/modules/oil/config.lua
@@ -1,0 +1,24 @@
+
+lia.config.add("OilPumpCooldown", "Oil Pump Cooldown", 60, nil, {
+    desc = "Time in seconds before the pump can be used again.",
+    category = "Economy",
+    type = "Int",
+    min = 1,
+    max = 3600
+})
+
+lia.config.add("OilPumpYield", "Oil Pump Yield", 1, nil, {
+    desc = "Amount of low-quality oil granted per pump.",
+    category = "Economy",
+    type = "Int",
+    min = 1,
+    max = 10
+})
+
+lia.config.add("OilPumpActionTime", "Oil Pump Action Time", 5, nil, {
+    desc = "Time spent pumping oil.",
+    category = "Economy",
+    type = "Float",
+    min = 0,
+    max = 60
+})

--- a/modules/oil/entities/entities/lia_oilpump/cl_init.lua
+++ b/modules/oil/entities/entities/lia_oilpump/cl_init.lua
@@ -1,0 +1,19 @@
+include("shared.lua")
+
+local vectorMeta = FindMetaTable("Vector")
+local toScreen = vectorMeta.ToScreen
+
+function ENT:onDrawEntityInfo(alpha)
+    local pos = toScreen(self:LocalToWorld(self:OBBCenter()))
+    local x, y = pos.x, pos.y
+    local color = lia.config.get("Color")
+    color.a = 255
+    local text
+    if self:isReady() then
+        text = L("oilPumpReady", "Oil Ready")
+    else
+        local timeLeft = math.ceil(self:getNetVar("ready", 0) - CurTime())
+        text = L("oilPumpNext", "Ready in %s", timeLeft)
+    end
+    lia.util.drawText(text, x, y, color, 1, 1, nil, alpha * 0.65)
+end

--- a/modules/oil/entities/entities/lia_oilpump/init.lua
+++ b/modules/oil/entities/entities/lia_oilpump/init.lua
@@ -1,0 +1,35 @@
+AddCSLuaFile()
+include("shared.lua")
+
+function ENT:Initialize()
+    self:SetModel("models/props_c17/oildrum001.mdl")
+    self:SetSolid(SOLID_VPHYSICS)
+    self:PhysicsInit(SOLID_VPHYSICS)
+    self:SetUseType(SIMPLE_USE)
+    local phys = self:GetPhysicsObject()
+    if IsValid(phys) then
+        phys:EnableMotion(false)
+    end
+    self:setNetVar("ready", CurTime())
+end
+
+function ENT:Use(client)
+    if not self:isReady() or self.pumping then return end
+    local char = client:getChar()
+    if not char then return end
+    self.pumping = true
+    local actionTime = lia.config.get("OilPumpActionTime", 5)
+    client:setAction(L("oilPumping", "Pumping oil"), actionTime, function()
+        if not IsValid(self) or not IsValid(client) then return end
+        local amount = lia.config.get("OilPumpYield", 1)
+        for _ = 1, amount do
+            char:getInv():add("low_quality_oil")
+        end
+        self:setNetVar("ready", CurTime() + lia.config.get("OilPumpCooldown", 60))
+        self.pumping = false
+    end)
+    client:doStaredAction(self, function() end, actionTime, function()
+        self.pumping = false
+        if IsValid(client) then client:setAction() end
+    end)
+end

--- a/modules/oil/entities/entities/lia_oilpump/shared.lua
+++ b/modules/oil/entities/entities/lia_oilpump/shared.lua
@@ -1,0 +1,9 @@
+ENT.Type = "anim"
+ENT.PrintName = "Oil Pump"
+ENT.Category = "Lilia"
+ENT.Spawnable = true
+ENT.DrawEntityInfo = true
+
+function ENT:isReady()
+    return CurTime() >= self:getNetVar("ready", 0)
+end

--- a/modules/oil/module.lua
+++ b/modules/oil/module.lua
@@ -1,0 +1,24 @@
+MODULE.name = "Oil System"
+MODULE.author = "Samael"
+MODULE.discord = "@liliaplayer"
+MODULE.desc = "Adds oil pumping and items."
+MODULE.version = "1.0"
+
+MODULE.Dependencies = {
+    {
+        File = "entities/entities/lia_oilpump/shared.lua",
+        Realm = "shared"
+    },
+    {
+        File = "entities/entities/lia_oilpump/cl_init.lua",
+        Realm = "client"
+    },
+    {
+        File = "entities/entities/lia_oilpump/init.lua",
+        Realm = "server"
+    },
+    {
+        File = "config.lua",
+        Realm = "shared"
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable oil pump module
- create oil pump entity with action timer and reward
- draw pump status text on client
- add oil items
- document pump strings in English locale

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68740e9990a0832795012c7fbdfeb4d9