### PR TITLE
Add websound library

### DIFF
--- a/documentation/docs/libraries/.pages
+++ b/documentation/docs/libraries/.pages
@@ -30,3 +30,4 @@ arrange:
   - lia.util.md
   - lia.workshop.md
   - lia.webimage.md
+  - lia.websound.md

--- a/documentation/docs/libraries/lia.websound.md
+++ b/documentation/docs/libraries/lia.websound.md
@@ -1,0 +1,92 @@
+# WebSound Library
+
+This page explains how remote sounds are downloaded and cached.
+
+---
+
+## Overview
+
+The web-sound library downloads remote audio files and stores them inside
+`data/lilia/sounds/<IP>/<Gamemode>/`. Each server therefore keeps its own
+collection of downloaded sounds. The library overrides `sound.PlayFile` and
+`sound.PlayURL` so HTTP(S) URLs may be passed directly—the file is downloaded,
+cached and then played. Subsequent calls using the same URL will reuse the
+previously saved file and you may also pass the cached name to
+`sound.PlayFile`.
+
+---
+
+### lia.websound.register
+
+**Purpose**
+
+Downloads a sound from the given URL and saves it in the web-sound cache. If the
+file already exists locally the callback fires immediately with the cached
+filename. On HTTP failure the callback receives `nil` and an error string.
+
+**Parameters**
+
+* `name` (*string*): Unique file name including extension.
+* `url` (*string*): HTTP address of the sound file.
+* `callback` (*function | nil*): Called as `callback(path, fromCache, err)` where
+  `path` is the local file path relative to `DATA/`, `fromCache` is `true` if
+  loaded from disk and `err` is an error string on failure.
+
+**Realm**
+
+`Client`
+
+**Returns**
+
+* *nil*: This function does not return a value.
+
+**Example**
+
+```lua
+-- Download a sound and play it when ready
+lia.websound.register("alert.mp3", "https://example.com/alert.mp3", function(path)
+    if path then
+        sound.PlayFile(path, "", function(chan) if chan then chan:Play() end end)
+    end
+end)
+```
+
+---
+
+### lia.websound.get
+
+**Purpose**
+
+Returns the file path cached with `lia.websound.register`. If the file is
+missing `nil` is returned. Both `sound.PlayFile` and `sound.PlayURL` call this
+internally when a cached name or matching URL is supplied.
+
+**Parameters**
+
+* `name` (*string*): File name used during registration.
+
+**Realm**
+
+`Client`
+
+**Returns**
+
+* *string | nil*: Local data path or `nil` if not found.
+
+**Example**
+
+```lua
+-- Retrieve a cached sound and play it
+local path = lia.websound.get("alert.mp3")
+if path then
+    sound.PlayFile(path, "", function(chan) if chan then chan:Play() end end)
+end
+
+-- Play directly from the web
+sound.PlayFile("https://example.com/alert.mp3", "", function(chan)
+    if chan then chan:Play() end
+end)
+```
+
+---
+

--- a/gamemode/core/libraries/core.lua
+++ b/gamemode/core/libraries/core.lua
@@ -123,6 +123,10 @@ local FilesToLoad = {
         realm = "client"
     },
     {
+        path = "lilia/gamemode/core/libraries/websound.lua",
+        realm = "client"
+    },
+    {
         path = "lilia/gamemode/core/libraries/networking.lua",
         realm = "shared"
     },

--- a/gamemode/core/libraries/websound.lua
+++ b/gamemode/core/libraries/websound.lua
@@ -1,0 +1,151 @@
+lia.websound = lia.websound or {}
+
+local ip = string.Replace(string.Replace(game.GetIPAddress() or "unknown", ":", "_"), "%.", "_")
+local gamemode = engine.ActiveGamemode() or "unknown"
+local baseDir = "lilia/sounds/" .. ip .. "/" .. gamemode .. "/"
+
+local cache = {}
+local urlMap = {}
+
+local function ensureDir(p)
+    local parts = string.Explode("/", p)
+    local cur = ""
+    for _, v in ipairs(parts) do
+        cur = cur == "" and v or cur .. "/" .. v
+        if not file.Exists(cur, "DATA") then
+            file.CreateDir(cur)
+        end
+    end
+end
+
+local function buildPath(p)
+    return "data/" .. p
+end
+
+function lia.websound.register(name, url, cb)
+    if isstring(url) then
+        urlMap[url] = name
+    end
+
+    if cache[name] then
+        if cb then cb(cache[name], true) end
+        return
+    end
+
+    local savePath = baseDir .. name
+
+    local function finalize(fromCache)
+        local path = buildPath(savePath)
+        cache[name] = path
+        if cb then cb(path, fromCache) end
+    end
+
+    if file.Exists(savePath, "DATA") then
+        finalize(true)
+        return
+    end
+
+    http.Fetch(url, function(body)
+        ensureDir(baseDir)
+        file.Write(savePath, body)
+        finalize(false)
+    end, function(err)
+        if cb then cb(nil, false, err) end
+    end)
+end
+
+function lia.websound.get(name)
+    local key = urlMap[name] or name
+    if cache[key] then return cache[key] end
+
+    local savePath = baseDir .. key
+    if file.Exists(savePath, "DATA") then
+        local path = buildPath(savePath)
+        cache[key] = path
+        return path
+    end
+end
+
+local origPlayFile = sound.PlayFile
+function sound.PlayFile(path, mode, cb)
+    if isstring(path) then
+        if path:find("^https?://") then
+            local name = urlMap[path]
+            if not name then
+                local ext = path:match("%.([%w]+)$") or "mp3"
+                name = util.CRC(path) .. "." .. ext
+                urlMap[path] = name
+            end
+
+            lia.websound.register(name, path, function(localPath)
+                if localPath then
+                    origPlayFile(localPath, mode or "", cb)
+                elseif cb then
+                    cb(nil, nil, "failed")
+                end
+            end)
+            return
+        else
+            local localPath = lia.websound.get(path)
+            if localPath then
+                return origPlayFile(localPath, mode or "", cb)
+            end
+        end
+    end
+    return origPlayFile(path, mode, cb)
+end
+
+local origPlayURL = sound.PlayURL
+function sound.PlayURL(url, mode, cb)
+    if isstring(url) and url:find("^https?://") then
+        local name = urlMap[url]
+        if not name then
+            local ext = url:match("%.([%w]+)$") or "mp3"
+            name = util.CRC(url) .. "." .. ext
+            urlMap[url] = name
+        end
+
+        lia.websound.register(name, url, function(localPath)
+            if localPath then
+                origPlayFile(localPath, mode or "", cb)
+            elseif cb then
+                cb(nil, nil, "failed")
+            end
+        end)
+        return
+    end
+
+    return origPlayURL(url, mode, cb)
+end
+
+concommand.Add("lia_saved_sounds", function()
+    local files = file.Find(baseDir .. "*", "DATA")
+    if not files or #files == 0 then return end
+
+    local f = vgui.Create("DFrame")
+    f:SetTitle(L("webSoundsTitle"))
+    f:SetSize(ScrW() * 0.6, ScrH() * 0.6)
+    f:Center()
+    f:MakePopup()
+
+    local scroll = vgui.Create("DScrollPanel", f)
+    scroll:Dock(FILL)
+
+    local layout = vgui.Create("DIconLayout", scroll)
+    layout:Dock(FILL)
+    layout:SetSpaceX(4)
+    layout:SetSpaceY(4)
+
+    for _, fn in ipairs(files) do
+        local btn = layout:Add("DButton")
+        btn:SetText(fn)
+        btn:SetSize(200, 20)
+        btn.DoClick = function()
+            sound.PlayFile(buildPath(baseDir .. fn), "", function(chan)
+                if chan then chan:Play() end
+            end)
+        end
+    end
+end)
+
+ensureDir(baseDir)

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -859,6 +859,7 @@ LANGUAGE = {
     webImagesTitle = "Web Images",
     webImageTesterTitle = "WebImage Tester",
     loadImage = "Load Image",
+    webSoundsTitle = "Web Sounds",
     dermaPreviewTitle = "Derma Controls Preview",
     dframe = "DFrame",
     dbutton = "DButton",


### PR DESCRIPTION
## Summary
- add `lia.websound` client library to cache and play audio from the web
- include the library in core's loader
- document websound and update docs ordering
- add English string for "Web Sounds"

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6874b43eac6483279985fdb0258f128e