### PR TITLE
Add CanPlayerOpenScoreboard hook

### DIFF
--- a/documentation/docs/hooks/gamemode_hooks.md
+++ b/documentation/docs/hooks/gamemode_hooks.md
@@ -400,6 +400,34 @@ end)
 
 ---
 
+### CanPlayerOpenScoreboard
+
+**Purpose**
+Checks if the local player may open the scoreboard. Return false to prevent it from showing.
+
+**Parameters**
+
+- `player` (`Player`): Local player.
+
+**Realm**
+`Client`
+
+**Returns**
+- boolean: False to disallow opening.
+
+**Example**
+
+```lua
+-- Only allow the scoreboard while alive.
+hook.Add("CanPlayerOpenScoreboard", "AliveOnly", function(ply)
+    if not ply:Alive() then
+        return false
+    end
+end)
+```
+
+---
+
 ### ShowPlayerOptions
 
 **Purpose**

--- a/modules/scoreboard/libraries/client.lua
+++ b/modules/scoreboard/libraries/client.lua
@@ -9,6 +9,9 @@
 end
 
 function MODULE:ScoreboardShow()
+    if hook.Run("CanPlayerOpenScoreboard", LocalPlayer()) == false then
+        return false
+    end
     local pimEnabled = lia.module.list.interactionmenu:checkInteractionPossibilities()
     if IsValid(lia.gui.score) then
         lia.gui.score:SetVisible(true)


### PR DESCRIPTION
## Summary
- add a new `CanPlayerOpenScoreboard` hook
- document the new hook in gamemode hooks docs

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874b24c84c88327a69e791bc8790bf0