### PR TITLE
Replace GetAll loops with iterator usage

### DIFF
--- a/documentation/docs/libraries/lia.time.md
+++ b/documentation/docs/libraries/lia.time.md
@@ -113,7 +113,7 @@ Returns the full current date/time using the `AmericanTimeStamps` config:
 -- Announce the current server date every hour
 timer.Create("ServerTimeAnnounce", 3600, 0, function()
     local text = lia.time.GetDate()
-    for _, ply in ipairs(player.GetAll()) do
+    for _, ply in player.Iterator() do
         ply:ChatPrint("Server time: " .. text)
     end
 end)

--- a/gamemode/core/derma/panels/scoreboard.lua
+++ b/gamemode/core/derma/panels/scoreboard.lua
@@ -165,7 +165,7 @@ end
 
 function PANEL:updateStaff()
     local total, duty = 0, 0
-    for _, ply in pairs(player.GetAll()) do
+    for _, ply in player.Iterator() do
         if ply:isStaff() then total = total + 1 end
         if ply:isStaffOnDuty() then duty = duty + 1 end
     end
@@ -181,7 +181,7 @@ end
 
 function PANEL:Think()
     if (self.nextUpdate or 0) > CurTime() then return end
-    for _, ply in pairs(player.GetAll()) do
+    for _, ply in player.Iterator() do
         if hook.Run("ShouldShowPlayerOnScoreboard", ply) == false then continue end
         local char = ply:getChar()
         if not char then continue end

--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -806,7 +806,7 @@ end
 concommand.Add("bots", function(ply)
     if IsValid(ply) then return end
     local maxPlayers = game.MaxPlayers()
-    local currentCount = #player.GetAll()
+    local currentCount = player.GetCount()
     local toSpawn = maxPlayers - currentCount
     if toSpawn <= 0 then return end
     timer.Remove("BotsSpawnTimer")

--- a/gamemode/core/libraries/commands.lua
+++ b/gamemode/core/libraries/commands.lua
@@ -327,7 +327,7 @@ else
             elseif fieldType == "player" then
                 ctrl = vgui.Create("DComboBox", panel)
                 ctrl:SetValue(L("selectPlayerPrompt"))
-                for _, plyObj in ipairs(player.GetAll()) do
+                for _, plyObj in player.Iterator() do
                     if IsValid(plyObj) then ctrl:AddChoice(plyObj:Name(), plyObj:SteamID()) end
                 end
             elseif fieldType == "item" then

--- a/gamemode/core/libraries/thirdparty/sh_extensions.lua
+++ b/gamemode/core/libraries/thirdparty/sh_extensions.lua
@@ -658,7 +658,7 @@ end, function(ent)
 
     SetRelationships(ent, friendliedNPCs, D_LI)
     SetRelationships(ent, hostaliziedNPCs, D_HT)
-    for _, oent in pairs(ents.GetAll()) do
+    for _, oent in ents.Iterator() do
         if oent:IsNPC() and oent ~= ent then Rbt_ProcessOtherNPC(oent) end
     end
 
@@ -687,7 +687,7 @@ end, function(ent)
 
     SetRelationships(ent, friendliedNPCs, D_HT)
     SetRelationships(ent, hostaliziedNPCs, D_LI)
-    for _, oent in pairs(ents.GetAll()) do
+    for _, oent in ents.Iterator() do
         if oent:IsNPC() and oent ~= ent then Rbt_ProcessOtherNPC(oent) end
     end
 end, "icon16/user_red.png")

--- a/modules/administration/commands.lua
+++ b/modules/administration/commands.lua
@@ -196,7 +196,7 @@ lia.command.add("blindfadeall", {
             local fadeOut = tonumber(arguments[4]) or (duration * 0.05)
             local isWhite = colorName == "white"
 
-            for _, ply in ipairs(player.GetAll()) do
+            for _, ply in player.Iterator() do
                 if not ply:isStaffOnDuty() then
                     net.Start("blindFade")
                     net.WriteBool(isWhite)

--- a/modules/teams/module.lua
+++ b/modules/teams/module.lua
@@ -15,7 +15,7 @@ if SERVER then
         local citizen = lia.faction.teams["citizen"]
         local characterID = net.ReadUInt(32)
         local IsOnline = false
-        for _, target in pairs(player.GetAll()) do
+        for _, target in player.Iterator() do
             local targetChar = target:getChar()
             if targetChar and targetChar:getID() == characterID and targetChar:getFaction() == char:getFaction() then
                 IsOnline = true


### PR DESCRIPTION
## Summary
- use `player.Iterator()` where player lists were previously retrieved with `player.GetAll()`
- use `ents.Iterator()` instead of `ents.GetAll()`
- update scoreboard and server hooks accordingly
- update the lia.time documentation example

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874c08680d883278a2bd4419eb549d9