### PR TITLE
Add class scoreboardHidden flag

### DIFF
--- a/documentation/docs/definitions/class.md
+++ b/documentation/docs/definitions/class.md
@@ -37,6 +37,7 @@ The global `CLASS` table defines per-class settings such as display name, lore, 
 | `bloodcolor` | `number` | `0` | Blood color enumeration constant. |
 | `bodyGroups` | `table` | `{}` | List of {id, value} pairs applied on spawn. |
 | `logo` | `string` | `""` | Material path for the class logo. |
+| `scoreboardHidden` | `boolean` | `false` | Hide class headers and logos in the scoreboard. |
 | `skin` | `number` | `0` | Player model skin index. |
 | `subMaterials` | `table` | `{}` | Sub-material overrides for the model. |
 | `model` | `string` | `""` | Model path or list of paths used by this class. |
@@ -526,6 +527,24 @@ CLASS.logo = "materials/example/eng_logo.png"
 
 ---
 
+#### `scoreboardHidden`
+
+**Type:**
+
+`boolean`
+
+**Description:**
+
+If `true`, this class will not display a header or logo on the scoreboard.
+
+**Example Usage:**
+
+```lua
+CLASS.scoreboardHidden = true
+```
+
+---
+
 #### `skin`
 
 **Type:**
@@ -681,6 +700,7 @@ CLASS.walkSpeedMultiplier = true
 CLASS.jumpPower = 200
 CLASS.jumpPowerMultiplier = false
 CLASS.logo = "materials/example/eng_logo.png"
+CLASS.scoreboardHidden = true
 CLASS.skin = 0
 CLASS.subMaterials = {
     "models/example/custom_cloth", -- sub-material 0

--- a/gamemode/core/derma/panels/scoreboard.lua
+++ b/gamemode/core/derma/panels/scoreboard.lua
@@ -127,6 +127,13 @@ function PANEL:Init()
         if lia.config.get("ClassHeaders", true) then
             for clsID, clsData in pairs(lia.class.list) do
                 if clsData.faction ~= facID then continue end
+                if clsData.scoreboardHidden then
+                    local lst = facCont:Add("DListLayout")
+                    lst:Dock(TOP)
+                    facCont.classLists[clsID] = lst
+                    continue
+                end
+
                 local cat = facCont:Add("DCollapsibleCategory")
                 cat:SetLabel("")
                 cat:SetExpanded(true)
@@ -288,7 +295,7 @@ function PANEL:addPlayer(ply, parent)
     function slot:layout()
         self.ping:SizeToContents()
         local pingW, totalW = self.ping:GetWide(), self:GetWide()
-        local hasLogo = lia.config.get("ClassLogo", false) and self.classLogo:GetMaterial()
+        local hasLogo = lia.config.get("ClassLogo", false) and self.classLogo:GetMaterial() and not self.hideLogo
         local extra = hasLogo and logoSize + logoOffset or 0
         local availW = totalW - (iconSize + margin * 2) - extra - pingW - margin
         self.name:SetPos(iconSize + margin * 2, 2)
@@ -371,15 +378,18 @@ function PANEL:addPlayer(ply, parent)
         end
 
         local clsData = lia.class.list[char:getClass()]
-        local logoMat = lia.config.get("ClassLogo", false) and clsData and clsData.logo or nil
-        if logoMat then
+        local showLogo = lia.config.get("ClassLogo", false) and clsData and not clsData.scoreboardHidden and clsData.logo and clsData.logo ~= ""
+        if showLogo then
+            local logoMat = clsData.logo
             if self.lastClassLogo ~= logoMat then
                 self.classLogo:SetMaterial(Material(logoMat))
                 self.lastClassLogo = logoMat
             end
+            self.hideLogo = false
         else
             self.classLogo:SetMaterial(nil)
             self.lastClassLogo = nil
+            self.hideLogo = true
         end
 
         slot:layout()


### PR DESCRIPTION
## Summary
- add `scoreboardHidden` to class docs
- implement class scoreboardHidden support in scoreboard panel

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6874cda620408327b5fd532df8409d55