### PR TITLE
Fix attribute panel appearing with no attributes

### DIFF
--- a/modules/attributes/libraries/client.lua
+++ b/modules/attributes/libraries/client.lua
@@ -2,7 +2,9 @@
 local stmBlurAmount = 0
 local stmBlurAlpha = 0
 function MODULE:ConfigureCharacterCreationSteps(panel)
-    panel:addStep(vgui.Create("liaCharacterAttribs"), 98)
+    if table.Count(lia.attribs.list) > 0 then
+        panel:addStep(vgui.Create("liaCharacterAttribs"), 98)
+    end
 end
 
 function MODULE:PlayerBindPress(client, bind, pressed)


### PR DESCRIPTION
## Summary
- add check for existing attributes in ConfigureCharacterCreationSteps so attribute selector only shows when attributes exist

## Testing
- `luajit` not available; no tests run

------
https://chatgpt.com/codex/tasks/task_e_687514fbb86883279421ba13e2be97e3