### PR TITLE
Fix admin load hook and documentation

### DIFF
--- a/documentation/docs/hooks/gamemode_hooks.md
+++ b/documentation/docs/hooks/gamemode_hooks.md
@@ -2318,6 +2318,31 @@ end)
 
 ---
 
+### ShouldLiliaAdminLoad
+
+**Purpose**
+Determines whether Lilia's built-in administration system should initialize. Compatibility modules can return `false` to prevent the default admin library from loading.
+
+**Parameters**
+
+- None
+
+**Realm**
+`Shared`
+
+**Returns**
+- `boolean`|`nil`: Return `false` to stop the admin system from loading.
+
+**Example Usage**
+```lua
+-- Disable Lilia admin when SAM is installed
+hook.Add("ShouldLiliaAdminLoad", "liaSam", function()
+    return false
+end)
+```
+
+---
+
 ### InventoryDataChanged
 
 **Purpose**

--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -3,8 +3,11 @@ lia.admin.bans = lia.admin.bans or {}
 lia.admin.groups = lia.admin.groups or {}
 lia.admin.banList = lia.admin.banList or {}
 lia.admin.privileges = lia.admin.privileges or {}
+---Determines whether the built-in admin library should be disabled.
+-- Hooks may return `false` to stop Lilia's admin system from loading.
+-- @return boolean True if the admin library is disabled.
 function lia.admin.isDisabled()
-    return hook.Run("ShouldLiliaAdminLoad") ~= false
+    return hook.Run("ShouldLiliaAdminLoad") == false
 end
 
 function lia.admin.load()


### PR DESCRIPTION
## Summary
- make `ShouldLiliaAdminLoad` default to loading unless hooks return `false`
- document `ShouldLiliaAdminLoad` hook in gamemode hooks documentation

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875228051e883279fdaa6038bdd467b