### PR TITLE
Document missing hooks

### DIFF
--- a/documentation/docs/hooks/gamemode_hooks.md
+++ b/documentation/docs/hooks/gamemode_hooks.md
@@ -2343,6 +2343,42 @@ end)
 
 ---
 
+### RunAdminSystemCommand
+
+**Purpose**
+
+Allows external admin mods to intercept and handle admin actions. Returning
+`true` prevents the default command behaviour.
+
+**Parameters**
+
+- `cmd` (`string`): Action identifier such as `kick` or `ban`.
+- `executor` (`Player`|`nil`): Player running the command, if any.
+- `target` (`Player`|`string`): Target player or SteamID.
+- `duration` (`number`|`nil`): Optional duration for timed actions.
+- `reason` (`string`|`nil`): Optional reason text.
+
+**Realm**
+
+`Shared`
+
+**Returns**
+
+- `boolean?`: Return `true` if the command was handled.
+
+**Example Usage**
+
+```lua
+hook.Add("RunAdminSystemCommand", "liaSam", function(cmd, exec, victim, dur, reason)
+    if SAM and SAM.Commands[cmd] then
+        SAM.Commands[cmd](exec, victim, dur, reason)
+        return true
+    end
+end)
+```
+
+---
+
 ### InventoryDataChanged
 
 **Purpose**
@@ -6280,6 +6316,36 @@ hook.Add("OnMySQLOOConnected", "PrepareDatabaseStatements", function()
         { MYSQLOO_NUMBER, MYSQLOO_NUMBER, MYSQLOO_STRING }
     )
     print("Prepared MySQLOO statements.")
+end)
+```
+
+### OnDatabaseLoaded
+
+**Purpose**
+
+Triggered once all required database tables have been created and initial data has been loaded. Use this hook to run custom queries or additional setup after Lilia prepares its schema.
+
+**Parameters**
+
+- None
+
+**Realm**
+
+`Server`
+
+**Returns**
+
+- None
+
+**Example Usage**
+
+```lua
+hook.Add("OnDatabaseLoaded", "lia_LoadBans", function()
+    lia.db.query("SELECT * FROM lia_bans", function(data)
+        if istable(data) then
+            print("Loaded", #data, "bans from the database")
+        end
+    end)
 end)
 ```
 

--- a/documentation/docs/libraries/lia.logger.md
+++ b/documentation/docs/libraries/lia.logger.md
@@ -31,7 +31,7 @@ Initialises the logging system and converts any legacy text logs.
 **Example Usage**
 
 ```lua
-hook.Add("LiliaDatabaseInitialized", nil, function()
+hook.Add("DatabaseConnected", "LoadLogs", function()
     lia.log.loadTables()
 end)
 ```


### PR DESCRIPTION
## Summary
- add `OnDatabaseLoaded` description to gamemode hooks
- document `RunAdminSystemCommand`
- update logger example to use `DatabaseConnected`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68759b1c49488327a02d157cf94f9b00