### PR TITLE
Fix charlist category

### DIFF
--- a/modules/administration/submodules/permissions/commands.lua
+++ b/modules/administration/submodules/permissions/commands.lua
@@ -84,7 +84,7 @@ lia.command.add("charlist", {
     syntax = "[string Player Or Steam ID]",
     AdminStick = {
         Name = "Open CharList",
-        Category = L("adminStickCategoryCharManagement"),
+        Category = "characterManagement",
         Icon = "icon16/user_gray.png"
     },
     onRun = function(client, arguments)


### PR DESCRIPTION
## Summary
- correct the AdminStick category for the `charlist` command

## Testing
- `luacheck modules/administration/submodules/permissions/commands.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875a79f2f648327a053548db5ea45dc