### PR TITLE
Implement last online tracking

### DIFF
--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -408,7 +408,8 @@ if SERVER then
                 self.lastJoin = data[1]._lastJoin or timeStamp
                 self.liaData = util.JSONToTable(data[1]._data)
                 self.totalOnlineTime = self:getLiliaData("totalOnlineTime", 0)
-                self.lastOnline = self:getLiliaData("lastOnline", self.lastJoin)
+                local default = os.time(lia.time.toNumber(self.lastJoin))
+                self.lastOnline = self:getLiliaData("lastOnline", default)
                 if callback then callback(self.liaData) end
             else
                 lia.db.insertTable({
@@ -428,11 +429,12 @@ if SERVER then
         if self:IsBot() then return end
         local name = self:steamName()
         local steamID64 = self:SteamID64()
-        local timeStamp = os.date("%Y-%m-%d %H:%M:%S", os.time())
+        local currentTime = os.time()
+        local timeStamp = os.date("%Y-%m-%d %H:%M:%S", currentTime)
         local stored = self:getLiliaData("totalOnlineTime", 0)
         local session = RealTime() - (self.liaJoinTime or RealTime())
         self:setLiliaData("totalOnlineTime", stored + session, true)
-        self:setLiliaData("lastOnline", timeStamp, true)
+        self:setLiliaData("lastOnline", currentTime, true)
         lia.db.updateTable({
             _steamName = name,
             _lastJoin = timeStamp,
@@ -627,7 +629,12 @@ if SERVER then
     end
 
     function playerMeta:getLastOnline()
-        return self:getLiliaData("lastOnline", self.lastJoin)
+        local last = self:getLiliaData("lastOnline", os.time())
+        return lia.time.TimeSince(last)
+    end
+
+    function playerMeta:getLastOnlineTime()
+        return self:getLiliaData("lastOnline", os.time())
     end
 
     function playerMeta:createRagdoll(freeze, isDead)
@@ -823,7 +830,12 @@ else
     end
 
     function playerMeta:getLastOnline()
-        return self:getLiliaData("lastOnline", lia.lastJoin)
+        local last = self:getLiliaData("lastOnline", os.time())
+        return lia.time.TimeSince(last)
+    end
+
+    function playerMeta:getLastOnlineTime()
+        return self:getLiliaData("lastOnline", os.time())
     end
 
     function playerMeta:setWaypoint(name, vector, onReach)

--- a/modules/teams/commands.lua
+++ b/modules/teams/commands.lua
@@ -82,7 +82,11 @@ lia.command.add("roster", {
             if data then
                 for k, v in ipairs(data) do
                     local pdata = util.JSONToTable(v._data or "{}")
-                    local lastDiff = os.time() - os.time(lia.time.toNumber(v._lastJoinTime))
+                    local last = pdata.lastOnline
+                    if not isnumber(last) then
+                        last = os.time(lia.time.toNumber(v._lastJoinTime))
+                    end
+                    local lastDiff = os.time() - last
                     table.insert(characters, {
                         id = v._id,
                         name = v._name,
@@ -142,7 +146,11 @@ lia.command.add("factionmanagement", {
             if data then
                 for k, v in ipairs(data) do
                     local pdata = util.JSONToTable(v._data or "{}")
-                    local lastDiff = os.time() - os.time(lia.time.toNumber(v._lastJoinTime))
+                    local last = pdata.lastOnline
+                    if not isnumber(last) then
+                        last = os.time(lia.time.toNumber(v._lastJoinTime))
+                    end
+                    local lastDiff = os.time() - last
                     table.insert(characters, {
                         id = v._id,
                         name = v._name,


### PR DESCRIPTION
## Summary
- track lastOnline using Unix time
- expose `getLastOnlineTime`
- make `getLastOnline` return time since lastOnline
- show lastOnline correctly in faction roster

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875a7d27350832795b5029a18ab57ff