### PR TITLE
Update list UIs to use util table helper

### DIFF
--- a/gamemode/core/libraries/util.lua
+++ b/gamemode/core/libraries/util.lua
@@ -736,5 +736,7 @@ else
 
             menu:Open()
         end
+
+        return frame, listView
     end
 end

--- a/modules/teams/module.lua
+++ b/modules/teams/module.lua
@@ -42,46 +42,58 @@ else
         local characterData = net.ReadTable()
         local character = LocalPlayer():getChar()
         local isLeader = LocalPlayer():IsSuperAdmin() or character:getData("factionOwner") or character:getData("factionAdmin") or character:hasFlags("V")
-        local isValidViewer = isLeader
-        if not isValidViewer then return end
+        if not isLeader then return end
+
         if IsValid(characterPanel) then characterPanel:Remove() end
-        characterPanel = vgui.Create("DFrame")
-        characterPanel:SetSize(400, 300)
-        characterPanel:Center()
-        characterPanel:SetTitle("Character Information")
-        characterPanel:MakePopup()
-        local list = vgui.Create("DListView", characterPanel)
-        list:Dock(FILL)
-        list:SetMultiSelect(false)
-        list:AddColumn("ID")
-        list:AddColumn("Name")
-        list:AddColumn("Last Online")
-        list:AddColumn("Hours Played")
+
+        local rows = {}
         for _, data in ipairs(characterData) do
             if data.faction == factionID and data.id ~= character:getID() then
-                local line = list:AddLine(data.id, data.name, data.lastOnline, data.hoursPlayed)
-                line.steamID = data.steamID
+                table.insert(rows, data)
             end
         end
 
-        list.OnRowRightClick = function(parent, lineIndex, line)
-            local menu = DermaMenu()
-            if isLeader then
+        local columns = {
+            {name = "ID", field = "id"},
+            {name = "Name", field = "name"},
+            {name = "Last Online", field = "lastOnline"},
+            {name = "Hours Played", field = "hoursPlayed"}
+        }
+
+        local frame, list = lia.util.CreateTableUI("Character Information", columns, rows, {
+            {name = "Kick", net = "KickCharacter"}
+        })
+
+        if IsValid(list) then
+            list.OnRowRightClick = function(_, _, line)
+                if not IsValid(line) or not line.rowData then return end
+                local rowData = line.rowData
+                local menu = DermaMenu()
                 menu:AddOption("Kick", function()
                     Derma_Query("Are you sure you want to kick this player?", "Confirm", "Yes", function()
                         net.Start("KickCharacter")
-                        net.WriteInt(tonumber(line:GetValue(1)), 32)
+                        net.WriteInt(tonumber(rowData.id), 32)
                         net.SendToServer()
-                        characterPanel:Remove()
+                        if IsValid(frame) then frame:Remove() end
                     end, "No")
                 end)
+
+                menu:AddOption("View Character List", function()
+                    LocalPlayer():ConCommand("say /charlist " .. rowData.steamID)
+                end)
+
+                menu:AddOption(L("copyRow"), function()
+                    local rowString = ""
+                    for key, value in pairs(rowData) do
+                        value = tostring(value or L("na"))
+                        rowString = rowString .. key:gsub("^%l", string.upper) .. ": " .. value .. " | "
+                    end
+                    rowString = rowString:sub(1, -4)
+                    SetClipboardText(rowString)
+                end)
+
+                menu:Open()
             end
-
-            menu:AddOption("View Character List", function()
-                LocalPlayer():ConCommand("say /charlist " .. line.steamID)
-            end)
-
-            menu:Open()
         end
     end)
 end


### PR DESCRIPTION
## Summary
- return the frame and list from `lia.util.CreateTableUI`
- use `lia.util.CreateTableUI` for faction roster/faction management
- use `lia.util.CreateTableUI` for the character list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875b1f1f4188327b9f71d3c2d265f8d