### PR TITLE
Add UI open/close hooks

### DIFF
--- a/documentation/docs/hooks/gamemode_hooks.md
+++ b/documentation/docs/hooks/gamemode_hooks.md
@@ -573,6 +573,310 @@ end)
 
 ---
 
+### ScoreboardOpened
+
+**Purpose**
+Triggered when the scoreboard becomes visible on the client.
+
+**Parameters**
+
+- `panel` (`Panel`): Scoreboard panel instance.
+
+**Realm**
+`Client`
+
+**Returns**
+- None
+
+**Example Usage**
+
+```lua
+hook.Add("ScoreboardOpened", "PlaySound", function(pnl)
+    surface.PlaySound("buttons/button15.wav")
+end)
+```
+
+---
+
+### ScoreboardClosed
+
+**Purpose**
+Called after the scoreboard is hidden or removed.
+
+**Parameters**
+
+- `panel` (`Panel`): Scoreboard panel instance.
+
+**Realm**
+`Client`
+
+**Returns**
+- None
+
+**Example Usage**
+
+```lua
+hook.Add("ScoreboardClosed", "LogClose", function(pnl)
+    print("Closed scoreboard")
+end)
+```
+
+---
+
+### F1MenuOpened
+
+**Purpose**
+Runs when the F1 main menu panel initializes.
+
+**Parameters**
+
+- `panel` (`Panel`): Menu panel.
+
+**Realm**
+`Client`
+
+**Returns**
+- None
+
+**Example Usage**
+
+```lua
+hook.Add("F1MenuOpened", "Notify", function(menu)
+    print("F1 menu opened")
+end)
+```
+
+---
+
+### F1MenuClosed
+
+**Purpose**
+Fires when the F1 main menu panel is removed.
+
+**Parameters**
+
+- None
+
+**Realm**
+`Client`
+
+**Returns**
+- None
+
+**Example Usage**
+
+```lua
+hook.Add("F1MenuClosed", "MenuGone", function()
+    print("F1 menu closed")
+end)
+```
+
+---
+
+### CharacterMenuOpened
+
+**Purpose**
+Called when the character selection menu is created.
+
+**Parameters**
+
+- `panel` (`Panel`): Character menu panel.
+
+**Realm**
+`Client`
+
+**Returns**
+- None
+
+**Example Usage**
+
+```lua
+hook.Add("CharacterMenuOpened", "PlayMusic", function(panel)
+    surface.PlaySound("music/hl2_song17.mp3")
+end)
+```
+
+---
+
+### CharacterMenuClosed
+
+**Purpose**
+Fired when the character menu panel is removed.
+
+**Parameters**
+
+- None
+
+**Realm**
+`Client`
+
+**Returns**
+- None
+
+**Example Usage**
+
+```lua
+hook.Add("CharacterMenuClosed", "StopMusic", function()
+    print("Character menu closed")
+end)
+```
+
+---
+
+### ItemPanelOpened
+
+**Purpose**
+Triggered when an item detail panel is created.
+
+**Parameters**
+
+- `panel` (`Panel`): Item panel instance.
+- `entity` (`Entity`): Item entity represented.
+
+**Realm**
+`Client`
+
+**Returns**
+- None
+
+**Example Usage**
+
+```lua
+hook.Add("ItemPanelOpened", "Inspect", function(pnl, ent)
+    print("Viewing item", ent)
+end)
+```
+
+---
+
+### ItemPanelClosed
+
+**Purpose**
+Runs after an item panel is removed.
+
+**Parameters**
+
+- `panel` (`Panel`): Item panel instance.
+- `entity` (`Entity`): Item entity represented.
+
+**Realm**
+`Client`
+
+**Returns**
+- None
+
+**Example Usage**
+
+```lua
+hook.Add("ItemPanelClosed", "LogClose", function(pnl, ent)
+    print("Closed item panel for", ent)
+end)
+```
+
+---
+
+### InventoryOpened
+
+**Purpose**
+Called when an inventory panel is created.
+
+**Parameters**
+
+- `panel` (`Panel`): Inventory panel.
+- `inventory` (`table`): Inventory shown.
+
+**Realm**
+`Client`
+
+**Returns**
+- None
+
+**Example Usage**
+
+```lua
+hook.Add("InventoryOpened", "Flash", function(pnl, inv)
+    print("Opened inventory", inv:getID())
+end)
+```
+
+---
+
+### InventoryClosed
+
+**Purpose**
+Fired when an inventory panel is removed.
+
+**Parameters**
+
+- `panel` (`Panel`): Inventory panel.
+- `inventory` (`table`): Inventory shown.
+
+**Realm**
+`Client`
+
+**Returns**
+- None
+
+**Example Usage**
+
+```lua
+hook.Add("InventoryClosed", "StopFlash", function(pnl, inv)
+    print("Closed inventory", inv:getID())
+end)
+```
+
+---
+
+### InteractionMenuOpened
+
+**Purpose**
+Called when the interaction menu pops up.
+
+**Parameters**
+
+- `frame` (`Panel`): Interaction menu frame.
+
+**Realm**
+`Client`
+
+**Returns**
+- None
+
+**Example Usage**
+
+```lua
+hook.Add("InteractionMenuOpened", "Notify", function(frame)
+    print("Opened interaction menu")
+end)
+```
+
+---
+
+### InteractionMenuClosed
+
+**Purpose**
+Runs when the interaction menu frame is removed.
+
+**Parameters**
+
+- None
+
+**Realm**
+`Client`
+
+**Returns**
+- None
+
+**Example Usage**
+
+```lua
+hook.Add("InteractionMenuClosed", "Notify", function()
+    print("Interaction menu closed")
+end)
+```
+
+---
+
 ### ChatTextChanged
 
 **Purpose**

--- a/gamemode/core/derma/f1menu/cl_menu.lua
+++ b/gamemode/core/derma/f1menu/cl_menu.lua
@@ -2,6 +2,7 @@
 function PANEL:Init()
     lia.module.list["f1menu"].CharacterInformation = {}
     lia.gui.menu = self
+    hook.Run("F1MenuOpened", self)
     self:SetSize(ScrW(), ScrH())
     self:SetAlpha(0)
     self:AlphaTo(255, 0.25, 0)
@@ -177,6 +178,10 @@ function PANEL:remove()
         self:AlphaTo(0, 0.25, 0, function() self:Remove() end)
         self.closing = true
     end
+end
+
+function PANEL:OnRemove()
+    hook.Run("F1MenuClosed")
 end
 
 function PANEL:OnKeyCodePressed(key)

--- a/gamemode/core/derma/mainmenu/character.lua
+++ b/gamemode/core/derma/mainmenu/character.lua
@@ -8,6 +8,7 @@ function PANEL:Init()
     if IsValid(lia.gui.loading) then lia.gui.loading:Remove() end
     if IsValid(lia.gui.character) then lia.gui.character:Remove() end
     lia.gui.character = self
+    hook.Run("CharacterMenuOpened", self)
     if not render.oldDrawBeam then
         render.oldDrawBeam = render.DrawBeam
         render.DrawBeam = function(startPos, endPos, width, textureStart, textureEnd, color)
@@ -666,6 +667,7 @@ function PANEL:warningSound()
 end
 
 function PANEL:OnRemove()
+    hook.Run("CharacterMenuClosed")
     hook.Remove("PrePlayerDraw", "liaMainMenuPrePlayerDraw")
     hook.Remove("CalcView", "liaMainMenuCalcView")
     hook.Remove("PostDrawOpaqueRenderables", "liaMainMenuPostDrawOpaqueRenderables")

--- a/gamemode/core/derma/panels/itempanel.lua
+++ b/gamemode/core/derma/panels/itempanel.lua
@@ -211,6 +211,7 @@ function PANEL:SetEntity(ent)
     self.nameLabel:SizeToContentsY()
     self.header:SetTall(self.nameLabel:GetTall())
     self:buildButtons()
+    hook.Run("ItemPanelOpened", self, ent)
 end
 
 function PANEL:Think()
@@ -223,6 +224,7 @@ function PANEL:OnRemove()
         self.item.entity = nil
     end
 
+    hook.Run("ItemPanelClosed", self, self.ent)
     lia.gui.itemPanel = nil
 end
 

--- a/gamemode/core/derma/panels/scoreboard.lua
+++ b/gamemode/core/derma/panels/scoreboard.lua
@@ -35,6 +35,7 @@ end
 function PANEL:Init()
     if IsValid(lia.gui.score) then lia.gui.score:Remove() end
     lia.gui.score = self
+    hook.Run("ScoreboardOpened", self)
     local w, h = ScrW() * lia.config.get("sbWidth", 0.35), ScrH() * lia.config.get("sbHeight", 0.65)
     self:SetSize(w, h)
     self:Center()
@@ -437,6 +438,7 @@ function PANEL:Paint(w, h)
 end
 
 function PANEL:OnRemove()
+    hook.Run("ScoreboardClosed", self)
     CloseDermaMenus()
 end
 

--- a/gamemode/core/libraries/inventory.lua
+++ b/gamemode/core/libraries/inventory.lua
@@ -135,6 +135,12 @@ else
         local globalName = "inv" .. inventory.id
         if IsValid(lia.gui[globalName]) then lia.gui[globalName]:Remove() end
         local panel = hook.Run("CreateInventoryPanel", inventory, parent)
+        hook.Run("InventoryOpened", panel, inventory)
+        local oldOnRemove = panel.OnRemove
+        function panel:OnRemove()
+            if oldOnRemove then oldOnRemove(self) end
+            hook.Run("InventoryClosed", self, inventory)
+        end
         lia.gui[globalName] = panel
         return panel
     end

--- a/modules/interactionmenu/libraries/client.lua
+++ b/modules/interactionmenu/libraries/client.lua
@@ -53,6 +53,12 @@ local function openMenu(options, isInteraction, titleText, closeKey, netMsg)
     frame:MakePopup()
     frame:SetTitle("")
     frame:ShowCloseButton(false)
+    hook.Run("InteractionMenuOpened", frame)
+    local oldOnRemove = frame.OnRemove
+    function frame:OnRemove()
+        if oldOnRemove then oldOnRemove(self) end
+        hook.Run("InteractionMenuClosed")
+    end
     frame:SetAlpha(0)
     frame:AlphaTo(255, fadeSpeed)
     function frame:Paint(w, h)

--- a/modules/scoreboard/libraries/client.lua
+++ b/modules/scoreboard/libraries/client.lua
@@ -1,5 +1,5 @@
 function MODULE:ScoreboardHide()
-    if IsValid(lia.gui.score) then
+    if IsValid(lia.gui.score) and lia.gui.score:IsVisible() then
         lia.gui.score:SetVisible(false)
         CloseDermaMenus()
         hook.Run("ScoreboardClosed", lia.gui.score)
@@ -15,8 +15,10 @@ function MODULE:ScoreboardShow()
     end
     local pimEnabled = lia.module.list.interactionmenu:checkInteractionPossibilities()
     if IsValid(lia.gui.score) then
-        lia.gui.score:SetVisible(true)
-        hook.Run("ScoreboardOpened", lia.gui.score)
+        if not lia.gui.score:IsVisible() then
+            lia.gui.score:SetVisible(true)
+            hook.Run("ScoreboardOpened", lia.gui.score)
+        end
     elseif not pimEnabled then
         vgui.Create("liaScoreboard")
     end

--- a/modules/scoreboard/libraries/client.lua
+++ b/modules/scoreboard/libraries/client.lua
@@ -1,7 +1,8 @@
-﻿function MODULE:ScoreboardHide()
+function MODULE:ScoreboardHide()
     if IsValid(lia.gui.score) then
         lia.gui.score:SetVisible(false)
         CloseDermaMenus()
+        hook.Run("ScoreboardClosed", lia.gui.score)
     end
 
     gui.EnableScreenClicker(false)
@@ -15,6 +16,7 @@ function MODULE:ScoreboardShow()
     local pimEnabled = lia.module.list.interactionmenu:checkInteractionPossibilities()
     if IsValid(lia.gui.score) then
         lia.gui.score:SetVisible(true)
+        hook.Run("ScoreboardOpened", lia.gui.score)
     elseif not pimEnabled then
         vgui.Create("liaScoreboard")
     end


### PR DESCRIPTION
## Summary
- fire scoreboard hooks only from the panel itself
- send menu events for the character screen
- trigger hooks when the item panel opens or closes
- add scoreboard open/close calls in ScoreboardShow and ScoreboardHide

## Testing
- `luacheck modules/scoreboard/libraries/client.lua gamemode/core/derma/f1menu/cl_menu.lua modules/interactionmenu/libraries/client.lua gamemode/core/libraries/inventory.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875a8266bb083278f01a94db475847b