### PR TITLE
Add OnDataPersisted hook

### DIFF
--- a/documentation/docs/hooks/gamemode_hooks.md
+++ b/documentation/docs/hooks/gamemode_hooks.md
@@ -1907,6 +1907,35 @@ end)
 
 ---
 
+### OnDataPersisted
+
+**Purpose**
+Triggered after `lia.data.set` successfully writes a key/value pair to the database.
+
+**Parameters**
+
+- `key` (`string`): Data key that was saved.
+- `value` (`any`): Value that was written.
+- `folder` (`string|nil`): Schema folder when not global.
+- `map` (`string|nil`): Map name when not global or ignored.
+
+**Realm**
+`Server`
+
+**Returns**
+- None
+
+**Example Usage**
+
+```lua
+-- Debug message whenever data is persisted.
+hook.Add("OnDataPersisted", "PrintPersist", function(k, v)
+    print("Persisted", k, v)
+end)
+```
+
+---
+
 ### PersistenceSave
 
 **Purpose**

--- a/gamemode/core/libraries/data.lua
+++ b/gamemode/core/libraries/data.lua
@@ -107,7 +107,9 @@ if SERVER then
                 _folder = folder,
                 _map = map,
                 _value = {value}
-            }, "data")
+            }, "data"):next(function()
+                hook.Run("OnDataPersisted", key, value, folder, map)
+            end)
         end)
         return "lilia/" .. (folder and folder .. "/" or "") .. (map and map .. "/" or "")
     end


### PR DESCRIPTION
## Summary
- trigger `OnDataPersisted` after data writes
- document the new hook

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875c1c3b4688327ac197e3dc91366d6