### PR TITLE
Add persistence hooks

### DIFF
--- a/documentation/docs/hooks/gamemode_hooks.md
+++ b/documentation/docs/hooks/gamemode_hooks.md
@@ -2000,6 +2000,90 @@ end)
 
 ---
 
+### GetEntitySaveData
+
+**Purpose**
+Allows adding custom data to each persisted entity during `SaveData`.
+
+**Parameters**
+
+- `entity` (`Entity`): Entity being persisted.
+
+**Realm**
+`Server`
+
+**Returns**
+- `table|nil`: Extra data to store with the entity.
+
+**Example Usage**
+
+```lua
+-- Store door color so it can be restored later.
+hook.Add("GetEntitySaveData", "DoorTint", function(ent)
+    if ent:GetClass() == "prop_door_rotating" then
+        return { color = ent:GetColor() }
+    end
+end)
+```
+
+---
+
+### OnEntityPersisted
+
+**Purpose**
+Runs when an entity is added to the persistence table.
+
+**Parameters**
+
+- `entity` (`Entity`): Entity that was saved.
+- `data` (`table`): Persistence data for that entity.
+
+**Realm**
+`Server`
+
+**Returns**
+- None
+
+**Example Usage**
+
+```lua
+-- Log each entity that is persisted.
+hook.Add("OnEntityPersisted", "PrintEntity", function(ent, data)
+    print("Persisted", ent, "with", table.Count(data or {}) .. " fields")
+end)
+```
+
+---
+
+### OnEntityLoaded
+
+**Purpose**
+Called for each entity spawned from saved persistence data.
+
+**Parameters**
+
+- `entity` (`Entity`): The newly created entity.
+- `data` (`table|nil`): Extra data stored for the entity.
+
+**Realm**
+`Server`
+
+**Returns**
+- None
+
+**Example Usage**
+
+```lua
+-- Restore door color from saved data.
+hook.Add("OnEntityLoaded", "RestoreTint", function(ent, data)
+    if IsValid(ent) and data and data.color then
+        ent:SetColor(data.color)
+    end
+end)
+```
+
+---
+
 ### LoadData
 
 **Purpose**

--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -530,12 +530,18 @@ function GM:SaveData()
             local key = makeKey(ent)
             if not seen[key] then
                 seen[key] = true
-                data.entities[#data.entities + 1] = {
+                local entData = {
                     pos = ent:GetPos(),
                     class = ent:GetClass(),
                     model = ent:GetModel(),
-                    angles = ent:GetAngles(),
+                    angles = ent:GetAngles()
                 }
+
+                local extra = hook.Run("GetEntitySaveData", ent)
+                if extra ~= nil then entData.data = extra end
+
+                data.entities[#data.entities + 1] = entData
+                hook.Run("OnEntityPersisted", ent, entData)
             end
         end
     end
@@ -587,6 +593,8 @@ function GM:LoadData()
                 if ent.model then createdEnt:SetModel(ent.model) end
                 createdEnt:Spawn()
                 createdEnt:Activate()
+
+                hook.Run("OnEntityLoaded", createdEnt, ent.data)
             end
         else
             lia.error(L("entityCreationAborted", ent.class, ent.pos.x, ent.pos.y, ent.pos.z))


### PR DESCRIPTION
## Summary
- allow modules to add data for each persisted entity
- fire hooks when entities are persisted and loaded
- document new hooks

## Testing
- `luacheck --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875c4c35c908327aed473dcf7896c80