### PR TITLE
Fix F1 attributes section when empty

### DIFF
--- a/modules/attributes/libraries/client.lua
+++ b/modules/attributes/libraries/client.lua
@@ -61,6 +61,7 @@ function MODULE:LoadCharInformation()
     if not IsValid(client) then return end
     local char = client:getChar()
     if not char then return end
+    if table.IsEmpty(lia.attribs.list) then return end
     hook.Run("AddSection", L("attributes"), Color(0, 0, 0), 2, 1)
     local attrs = {}
     for id, attr in pairs(lia.attribs.list) do


### PR DESCRIPTION
## Summary
- stop displaying the Attributes section in the F1 menu when no attributes are registered

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875e197ffac8327bd107b303b272d12