### PR TITLE
Reset stamina to full on spawn

### DIFF
--- a/modules/attributes/libraries/server.lua
+++ b/modules/attributes/libraries/server.lua
@@ -14,7 +14,8 @@
         end
     end
 
-    client:setLocalVar("stamina", char:getData("stamina", char:getMaxStamina()))
+    -- Always start with full stamina on spawn
+    client:setLocalVar("stamina", char:getMaxStamina())
     local uniqueID = "liaStam" .. client:SteamID()
     timer.Create(uniqueID, 0.25, 0, function()
         if not IsValid(client) then
@@ -31,8 +32,7 @@ function MODULE:PlayerDisconnected(client)
 end
 
 function MODULE:CharPreSave(character)
-    local client = character:getPlayer()
-    if IsValid(client) then character:setData("stamina", client:getLocalVar("stamina", 0)) end
+    -- Stamina is not persisted; it always resets to maximum on spawn.
 end
 
 function MODULE:KeyPress(client, key)
@@ -59,7 +59,12 @@ function MODULE:KeyPress(client, key)
 end
 
 function MODULE:PlayerLoadedChar(client, character)
-    timer.Simple(0.25, function() if IsValid(client) then client:setLocalVar("stamina", character:getData("stamina", character:getMaxStamina())) end end)
+    -- Ensure players begin with maximum stamina when their character loads
+    timer.Simple(0.25, function()
+        if IsValid(client) then
+            client:setLocalVar("stamina", character:getMaxStamina())
+        end
+    end)
 end
 
 function MODULE:PlayerStaminaLost(client)


### PR DESCRIPTION
## Summary
- set local stamina to max in PostPlayerLoadout
- ensure PlayerLoadedChar restores stamina to max
- remove saving stamina when characters are saved

## Testing
- `luacheck . --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875ec7fb9848327b2c34d500570b90a