### PR TITLE
Fix stamina blur persistence

### DIFF
--- a/modules/attributes/libraries/server.lua
+++ b/modules/attributes/libraries/server.lua
@@ -60,7 +60,9 @@ function MODULE:PlayerStaminaLost(client)
     if client:getNetVar("brth", false) then return end
     client:setNetVar("brth", true)
     client:EmitSound("player/breathe1.wav", 35, 100)
-    local breathThreshold = character:getMaxStamina() * 0.25
+    local character = client:getChar()
+    local maxStamina = character and character:getMaxStamina() or lia.config.get("DefaultStamina", 100)
+    local breathThreshold = maxStamina * 0.25
     timer.Create("liaStamBreathCheck" .. client:SteamID64(), 1, 0, function()
         if not IsValid(client) then
             timer.Remove("liaStamBreathCheck" .. client:SteamID64())


### PR DESCRIPTION
## Summary
- ensure `PlayerStaminaLost` uses the player's character when calculating the breathing threshold

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875f88c287c8327aaa323f4ca01056c