### PR TITLE
Spawn players slightly above spawn point

### DIFF
--- a/modules/spawns/libraries/server.lua
+++ b/modules/spawns/libraries/server.lua
@@ -94,6 +94,7 @@ local function SpawnPlayer(client)
     end
 
     if spawnPos then
+        spawnPos = spawnPos + Vector(0, 0, 16)
         client:SetPos(spawnPos)
         print("[SpawnPlayer] final spawn position set to:", tostring(spawnPos))
     else


### PR DESCRIPTION
## Summary
- adjust spawn location so players appear slightly above the configured spawn position

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875fe667a308327bdc9626f0df6401c