### PR TITLE
Fix stamina after lua refresh

### DIFF
--- a/modules/attributes/libraries/client.lua
+++ b/modules/attributes/libraries/client.lua
@@ -87,3 +87,11 @@ lia.bar.add(function()
     local max = char:getMaxStamina()
     return predictedStamina / max
 end, Color(200, 200, 40), nil, "stamina")
+
+function MODULE:OnReloaded()
+    local client = LocalPlayer()
+    if not IsValid(client) then return end
+    local char = client:getChar()
+    if not char then return end
+    predictedStamina = client:getLocalVar("stamina", char:getMaxStamina())
+end

--- a/modules/attributes/libraries/server.lua
+++ b/modules/attributes/libraries/server.lua
@@ -16,6 +16,7 @@
 
     client:setLocalVar("stamina", char:getMaxStamina())
     local uniqueID = "liaStam" .. client:SteamID()
+    timer.Remove(uniqueID)
     timer.Create(uniqueID, 0.25, 0, function()
         if not IsValid(client) then
             timer.Remove(uniqueID)
@@ -28,6 +29,14 @@ end
 
 function MODULE:PlayerDisconnected(client)
     timer.Remove("liaStam" .. client:SteamID())
+end
+
+function MODULE:OnReloaded()
+    for _, client in player.Iterator() do
+        if IsValid(client) and client:getChar() then
+            self:PostPlayerLoadout(client)
+        end
+    end
 end
 
 function MODULE:KeyPress(client, key)


### PR DESCRIPTION
## Summary
- ensure stamina timer is recreated when Lua is refreshed
- reset predicted stamina on the client on reload

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875fea363748327a0f2774beaaa6850