### PR TITLE
Add web sound support for EmitSound

### DIFF
--- a/documentation/docs/libraries/lia.websound.md
+++ b/documentation/docs/libraries/lia.websound.md
@@ -10,8 +10,9 @@ The web-sound library downloads remote audio files and stores them inside
 `data/lilia/sounds/<IP>/<Gamemode>/`. Each server therefore keeps its own
 collection of downloaded sounds. The library overrides `sound.PlayFile` and
 `sound.PlayURL` so HTTP(S) URLs may be passed directly—the file is downloaded,
-cached and then played. Subsequent calls using the same URL will reuse the
-previously saved file and you may also pass the cached name to
+cached and then played. `Entity:EmitSound` is also hooked so web addresses can
+be used anywhere a sound path is expected. Subsequent calls using the same URL
+will reuse the previously saved file and you may also pass the cached name to
 `sound.PlayFile`.
 
 ---
@@ -86,6 +87,10 @@ end
 sound.PlayFile("https://example.com/alert.mp3", "", function(chan)
     if chan then chan:Play() end
 end)
+
+-- Emit a web sound from an entity
+local ply = LocalPlayer()
+ply:EmitSound("https://example.com/alert.mp3")
 ```
 
 ---

--- a/gamemode/core/libraries/websound.lua
+++ b/gamemode/core/libraries/websound.lua
@@ -152,3 +152,42 @@ concommand.Add("lia_saved_sounds", function()
 end)
 
 ensureDir(baseDir)
+
+hook.Add("EntityEmitSound", "liaWebSound", function(data)
+    local soundName = data.OriginalSoundName or data.SoundName
+    if not isstring(soundName) then return end
+
+    local function play(path)
+        sound.PlayFile(path, "3d", function(chan)
+            if not chan then return end
+
+            local ent = data.Entity
+            if IsValid(ent) and chan.FollowEntity then
+                chan:FollowEntity(ent)
+            elseif data.Pos then
+                chan:SetPos(data.Pos)
+            end
+
+            if data.Volume then
+                chan:SetVolume(math.Clamp(data.Volume, 0, 1))
+            end
+
+            if data.Pitch and chan.SetPlaybackRate then
+                chan:SetPlaybackRate(data.Pitch / 100)
+            end
+
+            chan:Play()
+        end)
+    end
+
+    if soundName:find("^https?://") then
+        play(soundName)
+        return true
+    end
+
+    local localPath = lia.websound.get(soundName)
+    if localPath then
+        play(localPath)
+        return true
+    end
+end)


### PR DESCRIPTION
## Summary
- play HTTP sounds with `Entity:EmitSound`
- document EmitSound support in the WebSound library

## Testing
- `luacheck gamemode/core/libraries/websound.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687600aee74c8327b6b70b82bf9019e0