### PR TITLE
Fix chatbox panel nil error on Lua reload

### DIFF
--- a/modules/chatbox/libraries/client.lua
+++ b/modules/chatbox/libraries/client.lua
@@ -17,6 +17,9 @@ end
 function MODULE:PlayerBindPress(_, bind, pressed)
     bind = bind:lower()
     if bind:find("messagemode") and pressed then
+        if not IsValid(self.panel) then
+            self:createChat()
+        end
         if not self.panel.active then self.panel:setActive(true) end
         return true
     end
@@ -61,6 +64,6 @@ end
 concommand.Add("fixchatplz", function()
     if IsValid(MODULE.panel) then
         MODULE.panel:Remove()
-        MODULE:createChat()
     end
+    MODULE:createChat()
 end)


### PR DESCRIPTION
## Summary
- ensure `self.panel` exists when toggling chatbox
- recreate the chat panel whenever `fixchatplz` is run

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68760696acd083279aa175cdedaa891b