### PR TITLE
Fix scoreboard showing with interaction menu

### DIFF
--- a/modules/scoreboard/libraries/client.lua
+++ b/modules/scoreboard/libraries/client.lua
@@ -11,7 +11,7 @@ end
 
 function MODULE:ScoreboardShow()
     if hook.Run("CanPlayerOpenScoreboard", LocalPlayer()) == false then return false end
-    if not lia.module.list.interactionmenu:checkInteractionPossibilities() then
+    if not lia.module.list.interactionmenu:checkInteractionPossibilities() and not lia.module.list.interactionmenu.Menu then
         if IsValid(lia.gui.score) then
             if not lia.gui.score:IsVisible() then
                 lia.gui.score:SetVisible(true)
@@ -24,6 +24,10 @@ function MODULE:ScoreboardShow()
 
     gui.EnableScreenClicker(true)
     return true
+end
+
+function MODULE:InteractionMenuOpened()
+    self:ScoreboardHide()
 end
 
 function MODULE:OnReloaded()


### PR DESCRIPTION
## Summary
- ensure scoreboard doesn't appear alongside the interaction menu
- hide scoreboard when the interaction menu opens

## Testing
- `git show --stat`


------
https://chatgpt.com/codex/tasks/task_e_68765a789fd48327bc819d4ff084937f