### PR TITLE
Fix adminstick freeze bots

### DIFF
--- a/modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua
+++ b/modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua
@@ -14,9 +14,13 @@ function SWEP:SecondaryAttack()
     local target = self:GetTarget()
     if IsValid(target) and target:IsPlayer() and target ~= client then
         local action = target:IsFrozen() and "unfreeze" or "freeze"
-        if not hook.Run("RunAdminSystemCommand", action, client, target) then
+        local identifier = target:IsBot() and target:Name() or target
+        if not hook.Run("RunAdminSystemCommand", action, client, identifier) then
             local cmd = sam and "sam " .. action or ulx and "ulx " .. action
-            if cmd then client:ConCommand(cmd .. " " .. target:SteamID()) end
+            if cmd then
+                local id = target:IsBot() and target:Name() or target:SteamID()
+                client:ConCommand(cmd .. " " .. id)
+            end
         end
     else
         client:notifyLocalized("cantFreezeTarget")


### PR DESCRIPTION
## Summary
- handle bots in adminstick secondary attack so freeze works
- revert default dispatch logic

## Testing
- `luac -p modules/administration/libraries/client.lua` *(fails: command not found)*
- `luac -p modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_687659a8161483279b2acb48fbb04250