### PR TITLE
Fix global spawn persistence by storing per map

### DIFF
--- a/modules/spawns/libraries/server.lua
+++ b/modules/spawns/libraries/server.lua
@@ -9,7 +9,8 @@ local function encodeVector(vec)
 end
 
 function MODULE:LoadData()
-    local data = self:getData(nil, true) or {}
+    local data = self:getData() or {}
+    if not next(data) then data = self:getData(nil, true) or {} end
     self.spawns = {}
     self.globalSpawns = {}
     print("[MODULE] LoadData: fetched data")
@@ -62,7 +63,7 @@ function MODULE:SaveData()
     self:setData({
         factions = factions,
         global = global
-    }, true)
+    })
 
     print("[MODULE] SaveData: data saved successfully")
 end


### PR DESCRIPTION
## Summary
- ensure spawn data is saved per map
- gracefully fall back to legacy global data when loading

## Testing
- `luacheck modules/spawns/libraries/server.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68765ee8630083278e427a54e3214d67