### PR TITLE
Fix admin stick freeze for bots

### DIFF
--- a/modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua
+++ b/modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua
@@ -14,7 +14,8 @@ function SWEP:SecondaryAttack()
     local target = self:GetTarget()
     if IsValid(target) and target:IsPlayer() and target ~= client then
         local action = target:IsFrozen() and "unfreeze" or "freeze"
-        if not hook.Run("RunAdminSystemCommand", action, client, target) then
+        local victim = target:IsBot() and target:Name() or target
+        if not hook.Run("RunAdminSystemCommand", action, client, victim) then
             local cmd = sam and "sam " .. action or ulx and "ulx " .. action
             if cmd then client:ConCommand(cmd .. " " .. target:SteamID()) end
         end

--- a/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/modules/administration/submodules/adminstick/libraries/client.lua
@@ -34,7 +34,8 @@ end
 
 local function RunAdminCommand(cmd, tgt, dur, reason, fallback)
     local cl = LocalPlayer()
-    if not hook.Run("RunAdminSystemCommand", cmd, cl, tgt, dur, reason) and fallback then
+    local victim = IsValid(tgt) and tgt:IsPlayer() and tgt:IsBot() and tgt:Name() or tgt
+    if not hook.Run("RunAdminSystemCommand", cmd, cl, victim, dur, reason) and fallback then
         RunConsoleCommand("say", fallback)
     end
 end


### PR DESCRIPTION
## Summary
- allow `RunAdminSystemCommand` to handle bots when freezing via right-click
- use bot names in `RunAdminCommand` so admin stick menu commands work on bots

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68765dd9e1f483278963210bd705f632