### PR TITLE
Add voice range display option

### DIFF
--- a/gamemode/core/hooks/client.lua
+++ b/gamemode/core/hooks/client.lua
@@ -466,3 +466,30 @@ concommand.Add("dev_GetEntPos", function(client) if client:isStaff() then lia.in
 concommand.Add("dev_GetEntAngles", function(client) if client:isStaff() then lia.information(math.ceil(client:getTracedEntity():GetAngles().x) .. ", " .. math.ceil(client:getTracedEntity():GetAngles().y) .. ", " .. math.ceil(client:getTracedEntity():GetAngles().z)) end end)
 concommand.Add("dev_GetRoundEntPos", function(client) if client:isStaff() then lia.information(math.ceil(client:getTracedEntity():GetPos().x) .. ", " .. math.ceil(client:getTracedEntity():GetPos().y) .. ", " .. math.ceil(client:getTracedEntity():GetPos().z)) end end)
 concommand.Add("dev_GetPos", function(client) if client:isStaff() then lia.information(math.ceil(client:GetPos().x) .. ", " .. math.ceil(client:GetPos().y) .. ", " .. math.ceil(client:GetPos().z)) end end)
+
+-- Voice range visualization ----------------------------
+local VoiceRanges = {
+    Whispering = 120,
+    Talking = 300,
+    Yelling = 600,
+}
+
+hook.Add("PostDrawOpaqueRenderables", "liaVoiceRange", function()
+    if not lia.option.get("voiceRange", false) then return end
+    local client = LocalPlayer()
+    if not (IsValid(client) and client:IsSpeaking() and client:getChar()) then return end
+    local vt = client:getNetVar("VoiceType", "Talking")
+    local radius = VoiceRanges[vt] or VoiceRanges.Talking
+    local segments = 36
+    local pos = client:GetPos() + Vector(0, 0, 2)
+    local color = Color(0, 150, 255)
+    render.SetColorMaterial()
+    for i = 0, segments - 1 do
+        local startAng = math.rad(i / segments * 360)
+        local endAng = math.rad((i + 1) / segments * 360)
+        local startPos = pos + Vector(math.cos(startAng), math.sin(startAng), 0) * radius
+        local endPos = pos + Vector(math.cos(endAng), math.sin(endAng), 0) * radius
+        render.DrawLine(startPos, endPos, color, false)
+    end
+end)
+

--- a/modules/administration/submodules/permissions/config.lua
+++ b/modules/administration/submodules/permissions/config.lua
@@ -146,3 +146,8 @@ lia.option.add("ChatShowTime", "Show Chat Timestamp", "Should chat show timestam
     category = "Chat",
     type = "Boolean"
 })
+
+lia.option.add("voiceRange", "Voice Range", "Display a circle showing your current voice range", false, nil, {
+    category = "HUD",
+    type = "Boolean"
+})


### PR DESCRIPTION
## Summary
- add `voiceRange` option
- show a 3D circle while talking to visualize voice distance

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68774cc6e3f883279064fe121dafb2fc