### PR TITLE
Fix scoreboard not blocked when interaction menu missing

### DIFF
--- a/modules/scoreboard/libraries/client.lua
+++ b/modules/scoreboard/libraries/client.lua
@@ -11,7 +11,9 @@ end
 
 function MODULE:ScoreboardShow()
     if hook.Run("CanPlayerOpenScoreboard", LocalPlayer()) == false then return false end
-    if not lia.module.list.interactionmenu:checkInteractionPossibilities() and not lia.module.list.interactionmenu.Menu then
+
+    local pim = lia.module.list and lia.module.list.interactionmenu
+    if (not pim) or (not pim:checkInteractionPossibilities() and not pim.Menu) then
         if IsValid(lia.gui.score) then
             if not lia.gui.score:IsVisible() then
                 lia.gui.score:SetVisible(true)


### PR DESCRIPTION
## Summary
- ensure scoreboard opens even if `interactionmenu` module is absent

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68774cd7de20832795ca67c56eee399f