### PR TITLE
Document liaQuick panel

### DIFF
--- a/documentation/docs/definitions/panels.md
+++ b/documentation/docs/definitions/panels.md
@@ -60,6 +60,7 @@ Panels provide the building blocks for Lilia's user interface. Most derive from 
 | `liaSmallButton` | `DButton` | Compact button for tight layouts. |
 | `liaMiniButton` | `DButton` | Very small button variant. |
 | `liaNoBGButton` | `DButton` | Text-only button with no background. |
+| `liaQuick` | `EditablePanel` | Quick settings panel showing options flagged with `isQuick`. |
 
 ---
 
@@ -628,6 +629,24 @@ Tiny button using `liaMiniFont` for dense interfaces.
 **Description:**
 
 Text-only button that still shows the underline animation.
+
+---
+
+### `liaQuick`
+
+**Base Panel:**
+
+`EditablePanel`
+
+**Description:**
+
+Quick settings menu that lists options flagged with `isQuick`.
+
+**Example Usage:**
+
+```lua
+vgui.Create("liaQuick")
+```
 
 ---
 

--- a/documentation/docs/libraries/framework/lia.option.md
+++ b/documentation/docs/libraries/framework/lia.option.md
@@ -27,6 +27,7 @@ Options are kept inside `lia.option.stored`; each entry contains:
 * `visible` (*boolean | function | nil*) – Whether the option appears in the config UI.
 
 * `shouldNetwork` (*boolean | nil*) – When `true`, the server fires `liaOptionReceived` upon change.
+* `isQuick` (*boolean | nil*) – Display this option inside the quick settings panel.
 
 Whenever `lia.option.set` updates a value, the `liaOptionChanged` hook is fired on both realms.
 
@@ -50,7 +51,7 @@ Registers a configurable option that can be networked.
 
 * `callback` (*function | nil*): Runs on change. Optional.
 
-* `data` (*table*): Extra option data.
+* `data` (*table*): Extra option data. Set `isQuick = true` to also list this option in the quick settings panel.
 
 **Realm**
 

--- a/gamemode/core/libraries/option.lua
+++ b/gamemode/core/libraries/option.lua
@@ -23,7 +23,8 @@ function lia.option.add(key, name, desc, default, callback, data)
         callback = callback,
         type = optionType,
         visible = data.visible,
-        shouldNetwork = data.shouldNetwork
+        shouldNetwork = data.shouldNetwork,
+        isQuick = data.isQuick
     }
 end
 


### PR DESCRIPTION
## Summary
- clarify that `isQuick` belongs inside the option's data table
- add `liaQuick` panel to the panel definitions reference

## Testing
- `luac -p gamemode/core/libraries/option.lua` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6877643f0670832791420613d8acee1c