### PR TITLE
Fix mismatched variable references in stamina handling

### DIFF
--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -303,8 +303,9 @@ end
 
 if SERVER then
     function playerMeta:restoreStamina(amount)
-        local current = self:getLocalVar("stamina",  char:getMaxStamina())
-        local maxStamina = self:getChar():getMaxStamina()
+        local char = self:getChar()
+        local current = self:getLocalVar("stamina", char and char:getMaxStamina() or lia.config.get("DefaultStamina", 100))
+        local maxStamina = char and char:getMaxStamina() or lia.config.get("DefaultStamina", 100)
         local value = math.Clamp(current + amount, 0, maxStamina)
         self:setLocalVar("stamina", value)
         if value >= maxStamina * 0.5 and self:getNetVar("brth", false) then
@@ -314,8 +315,9 @@ if SERVER then
     end
 
     function playerMeta:consumeStamina(amount)
-        local current = self:getLocalVar("stamina",  char:getMaxStamina())
-        local value = math.Clamp(current - amount, 0, self:getChar():getMaxStamina())
+        local char = self:getChar()
+        local current = self:getLocalVar("stamina", char and char:getMaxStamina() or lia.config.get("DefaultStamina", 100))
+        local value = math.Clamp(current - amount, 0, char and char:getMaxStamina() or lia.config.get("DefaultStamina", 100))
         self:setLocalVar("stamina", value)
         if value == 0 and not self:getNetVar("brth", false) then
             self:setNetVar("brth", true)

--- a/modules/attributes/entities/weapons/lia_hands/shared.lua
+++ b/modules/attributes/entities/weapons/lia_hands/shared.lua
@@ -237,7 +237,8 @@ function SWEP:PrimaryAttack()
     local staminaUse = lia.config.get("PunchStamina")
     if staminaUse > 0 then
         local owner = self:GetOwner()
-        local currentStamina = owner:getLocalVar("stamina",  char:getMaxStamina())
+        local character = owner:getChar()
+        local currentStamina = owner:getLocalVar("stamina", character and character:getMaxStamina() or lia.config.get("DefaultStamina", 100))
         if currentStamina < staminaUse then return end
         if SERVER then owner:consumeStamina(staminaUse) end
     end

--- a/modules/attributes/libraries/server.lua
+++ b/modules/attributes/libraries/server.lua
@@ -53,7 +53,8 @@ function MODULE:KeyPress(client, key)
     if key == IN_JUMP and not client:isNoClipping() and client:getChar() and not client:InVehicle() and client:Alive() then
         local cost = lia.config.get("JumpStaminaCost", 25)
         client:consumeStamina(cost)
-        local stm = client:getLocalVar("stamina",  char:getMaxStamina())
+        local character = client:getChar()
+        local stm = client:getLocalVar("stamina", character and character:getMaxStamina() or lia.config.get("DefaultStamina", 100))
         if stm == 0 then
             client:setNetVar("brth", true)
             client:ConCommand("-speed")
@@ -78,7 +79,8 @@ function MODULE:PlayerStaminaLost(client)
             return
         end
 
-        local currentStamina = client:getLocalVar("stamina",  char:getMaxStamina())
+        local char = client:getChar()
+        local currentStamina = client:getLocalVar("stamina", char and char:getMaxStamina() or lia.config.get("DefaultStamina", 100))
         if currentStamina <= breathThreshold then
             client:EmitSound("player/breathe1.wav", 35, 100)
             return

--- a/modules/attributes/libraries/shared.lua
+++ b/modules/attributes/libraries/shared.lua
@@ -12,7 +12,7 @@
     offset = hook.Run("AdjustStaminaOffset", client, offset) or offset
     if CLIENT then return offset end
     local max = character:getMaxStamina()
-    local current = client:getLocalVar("stamina", char:getMaxStamina())
+    local current = client:getLocalVar("stamina", character:getMaxStamina())
     local value = math.Clamp(current + offset, 0, max)
     if current ~= value then
         client:setLocalVar("stamina", value)


### PR DESCRIPTION
## Summary
- correct variable name in shared stamina library
- fix undefined `char` references when using stamina in server library
- fix stamina checks for punching weapon
- use proper character checks in player stamina functions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687776e1cbec8327a8a997cf9e191523