### PR TITLE
Fix stamina calculation variable

### DIFF
--- a/modules/attributes/libraries/shared.lua
+++ b/modules/attributes/libraries/shared.lua
@@ -1,6 +1,6 @@
-﻿function MODULE:CalcStaminaChange(client)
-    local character = client:getChar()
-    if not character or client:isNoClipping() then return 1 end
+function MODULE:CalcStaminaChange(client)
+    local char = client:getChar()
+    if not char or client:isNoClipping() then return 1 end
     local walkSpeed = lia.config.get("WalkSpeed", client:GetWalkSpeed())
     local offset
     if client:KeyDown(IN_SPEED) and client:GetVelocity():LengthSqr() >= walkSpeed * walkSpeed then
@@ -11,8 +11,8 @@
 
     offset = hook.Run("AdjustStaminaOffset", client, offset) or offset
     if CLIENT then return offset end
-    local max = character:getMaxStamina()
-    local current = client:getLocalVar("stamina", character:getMaxStamina())
+    local max = char:getMaxStamina()
+    local current = client:getLocalVar("stamina", char:getMaxStamina())
     local value = math.Clamp(current + offset, 0, max)
     if current ~= value then
         client:setLocalVar("stamina", value)


### PR DESCRIPTION
## Summary
- sanitize attributes library without BOM
- fix CalcStaminaChange to use `char` variable consistently

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68777f0cf5548327b468ad2914dc855d