### PR TITLE
Fix empty bars when always visible

### DIFF
--- a/documentation/docs/libraries/framework/lia.bars.md
+++ b/documentation/docs/libraries/framework/lia.bars.md
@@ -6,7 +6,7 @@ This page describes the API for status bars displayed on the HUD.
 
 ## Overview
 
-The bars library manages health, stamina, and other progress bars shown on the player's HUD. It lets you register custom bar callbacks, draws them every frame, and provides helpers for temporary action bars. Bars automatically fade out after a few seconds unless kept visible. The `BarsAlwaysVisible` configuration option can override this behaviour, and the hooks `ShouldHideBars` and `ShouldBarDraw` allow modules to control when bars are rendered.
+The bars library manages health, stamina, and other progress bars shown on the player's HUD. It lets you register custom bar callbacks, draws them every frame, and provides helpers for temporary action bars. Bars automatically fade out after a few seconds unless kept visible. The `BarsAlwaysVisible` configuration option overrides this behaviour, keeping bars visible whenever they have a value above zero. The hooks `ShouldHideBars` and `ShouldBarDraw` allow modules to control when bars are rendered.
 
 Default health, armor, and stamina bars are registered automatically when the client loads.
 

--- a/gamemode/core/libraries/bars.lua
+++ b/gamemode/core/libraries/bars.lua
@@ -110,7 +110,7 @@ function lia.bar.drawAll()
             bar.lifeTime = now + 5
         end
 
-        if always or bar.lifeTime >= now or bar.visible or hook.Run("ShouldBarDraw", bar) then
+        if (always and value > 0) or bar.lifeTime >= now or bar.visible or hook.Run("ShouldBarDraw", bar) then
             lia.bar.drawBar(x, y, w, h, value, 1, bar.color)
             y = y + h + 2
         end


### PR DESCRIPTION
## Summary
- hide empty bars when `BarsAlwaysVisible` option is enabled
- document that bars remain visible only while their value is above zero

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877955f083483278fdb99006257cd4f