### PR TITLE
Handle map spawn JSON

### DIFF
--- a/gamemode/core/libraries/data.lua
+++ b/gamemode/core/libraries/data.lua
@@ -207,7 +207,9 @@ if SERVER then
                         local rows = res2.results or {}
                         for _, row in ipairs(rows) do
                             local decoded = util.JSONToTable(row._value or "[]")
-                            lia.data.stored[key] = decoded and decoded[1]
+                            if istable(decoded) then
+                                lia.data.stored[key] = decoded[1] or decoded
+                            end
                         end
 
                         loadNext(i + 1)


### PR DESCRIPTION
## Summary
- fix data loader to handle non-array JSON values when pulling module data

## Testing
- `apt-get update` *(fails: repository not signed)*


------
https://chatgpt.com/codex/tasks/task_e_6877d8db7e3c8327939cacc79d04b1de