### PR TITLE
Add DB columns for player session info

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -421,6 +421,7 @@ function GM:PlayerInitialSpawn(client)
         if not IsValid(client) then return end
         local address = client:IPAddress()
         client:setLiliaData("lastIP", address)
+        lia.db.updateTable({ _lastIP = address }, nil, "players", "_steamID = " .. client:SteamID64())
         net.Start("liaDataSync")
         net.WriteTable(data)
         net.WriteType(client.firstJoin)

--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -299,6 +299,9 @@ function lia.db.loadTables()
         lia.db.fieldExists("lia_players", "_firstJoin"):next(function(exists) if not exists then lia.db.query("ALTER TABLE lia_players ADD COLUMN _firstJoin DATETIME"):catch(ignore) end end)
         lia.db.fieldExists("lia_players", "_lastJoin"):next(function(exists) if not exists then lia.db.query("ALTER TABLE lia_players ADD COLUMN _lastJoin DATETIME"):catch(ignore) end end)
         lia.db.fieldExists("lia_players", "_userGroup"):next(function(exists) if not exists then lia.db.query("ALTER TABLE lia_players ADD COLUMN _userGroup VARCHAR(32)"):catch(ignore) end end)
+        lia.db.fieldExists("lia_players", "_lastIP"):next(function(exists) if not exists then lia.db.query("ALTER TABLE lia_players ADD COLUMN _lastIP VARCHAR(64)"):catch(ignore) end end)
+        lia.db.fieldExists("lia_players", "_lastOnline"):next(function(exists) if not exists then lia.db.query("ALTER TABLE lia_players ADD COLUMN _lastOnline INTEGER"):catch(ignore) end end)
+        lia.db.fieldExists("lia_players", "_totalOnlineTime"):next(function(exists) if not exists then lia.db.query("ALTER TABLE lia_players ADD COLUMN _totalOnlineTime FLOAT"):catch(ignore) end end)
         lia.db.fieldExists("lia_items", "_quantity"):next(function(exists) if not exists then lia.db.query("ALTER TABLE lia_items ADD COLUMN _quantity INTEGER"):catch(ignore) end end)
         lia.db.addDatabaseFields()
         lia.db.tablesLoaded = true
@@ -314,7 +317,10 @@ function lia.db.loadTables()
                 _lastJoin datetime,
                 _userGroup varchar,
                 _data varchar,
-                _intro binary
+                _intro binary,
+                _lastIP varchar,
+                _lastOnline integer,
+                _totalOnlineTime float
             );
 
             CREATE TABLE IF NOT EXISTS lia_characters (
@@ -393,6 +399,9 @@ function lia.db.loadTables()
                 `_userGroup` VARCHAR(32) NULL DEFAULT NULL COLLATE 'utf8mb4_general_ci',
                 `_data` VARCHAR(255) NOT NULL COLLATE 'utf8mb4_general_ci',
                 `_intro` BINARY(1) NULL DEFAULT 0,
+                `_lastIP` VARCHAR(64) NULL DEFAULT NULL COLLATE 'utf8mb4_general_ci',
+                `_lastOnline` INT(32) NULL DEFAULT 0,
+                `_totalOnlineTime` FLOAT NULL DEFAULT 0,
                 PRIMARY KEY (`_steamID`)
             );
 

--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -400,7 +400,7 @@ if SERVER then
         local name = self:steamName()
         local steamID64 = self:SteamID64()
         local timeStamp = os.date("%Y-%m-%d %H:%M:%S", os.time())
-        lia.db.query("SELECT _data, _firstJoin, _lastJoin FROM lia_players WHERE _steamID = " .. steamID64, function(data)
+        lia.db.query("SELECT _data, _firstJoin, _lastJoin, _lastIP, _lastOnline, _totalOnlineTime FROM lia_players WHERE _steamID = " .. steamID64, function(data)
             if IsValid(self) and data and data[1] and data[1]._data then
                 lia.db.updateTable({
                     _lastJoin = timeStamp,
@@ -409,9 +409,10 @@ if SERVER then
                 self.firstJoin = data[1]._firstJoin or timeStamp
                 self.lastJoin = data[1]._lastJoin or timeStamp
                 self.liaData = util.JSONToTable(data[1]._data)
-                self.totalOnlineTime = self:getLiliaData("totalOnlineTime", 0)
+                self.totalOnlineTime = tonumber(data[1]._totalOnlineTime) or self:getLiliaData("totalOnlineTime", 0)
                 local default = os.time(lia.time.toNumber(self.lastJoin))
-                self.lastOnline = self:getLiliaData("lastOnline", default)
+                self.lastOnline = tonumber(data[1]._lastOnline) or self:getLiliaData("lastOnline", default)
+                self.lastIP = data[1]._lastIP or self:getLiliaData("lastIP")
                 if callback then callback(self.liaData) end
             else
                 lia.db.insertTable({
@@ -419,7 +420,10 @@ if SERVER then
                     _steamName = name,
                     _firstJoin = timeStamp,
                     _lastJoin = timeStamp,
-                    _data = {}
+                    _data = {},
+                    _lastIP = "",
+                    _lastOnline = os.time(lia.time.toNumber(timeStamp)),
+                    _totalOnlineTime = 0
                 }, nil, "players")
 
                 if callback then callback({}) end
@@ -440,7 +444,10 @@ if SERVER then
         lia.db.updateTable({
             _steamName = name,
             _lastJoin = timeStamp,
-            _data = self.liaData
+            _data = self.liaData,
+            _lastIP = self:getLiliaData("lastIP", ""),
+            _lastOnline = currentTime,
+            _totalOnlineTime = stored + session
         }, nil, "players", "_steamID = " .. steamID64)
     end
 

--- a/modules/teams/commands.lua
+++ b/modules/teams/commands.lua
@@ -57,7 +57,7 @@ lia.command.add("roster", {
 
         local isLeader = client:IsSuperAdmin() or character:getData("factionOwner") or character:getData("factionAdmin") or character:hasFlags("V")
         if not isLeader then return end
-        local fields = "lia_characters._name, lia_characters._faction, lia_characters._id, lia_characters._steamID, lia_characters._lastJoinTime, lia_players._data"
+        local fields = "lia_characters._name, lia_characters._faction, lia_characters._id, lia_characters._steamID, lia_characters._lastJoinTime, lia_players._totalOnlineTime, lia_players._lastOnline"
         if not character then
             client:notify("Character data not found for client:", client)
             return
@@ -81,8 +81,7 @@ lia.command.add("roster", {
             local characters = {}
             if data then
                 for _, v in ipairs(data) do
-                    local pdata = util.JSONToTable(v._data or "{}")
-                    local last = pdata.lastOnline
+                    local last = tonumber(v._lastOnline)
                     if not isnumber(last) then last = os.time(lia.time.toNumber(v._lastJoinTime)) end
                     local lastDiff = os.time() - last
                     table.insert(characters, {
@@ -91,7 +90,7 @@ lia.command.add("roster", {
                         faction = v._faction,
                         steamID = v._steamID,
                         lastOnline = formatDHM(lastDiff),
-                        hoursPlayed = formatDHM(pdata.totalOnlineTime or 0)
+                        hoursPlayed = formatDHM(tonumber(v._totalOnlineTime) or 0)
                     })
                 end
             else
@@ -112,7 +111,7 @@ lia.command.add("factionmanagement", {
     desc = "factionManagementDesc",
     syntax = "[faction Faction]",
     onRun = function(client, arguments)
-        local fields = "lia_characters._name, lia_characters._faction, lia_characters._id, lia_characters._steamID, lia_characters._lastJoinTime, lia_players._data"
+        local fields = "lia_characters._name, lia_characters._faction, lia_characters._id, lia_characters._steamID, lia_characters._lastJoinTime, lia_players._totalOnlineTime, lia_players._lastOnline"
         local faction
         local arg = table.concat(arguments, " ")
         if arg ~= "" then
@@ -144,8 +143,7 @@ lia.command.add("factionmanagement", {
             local characters = {}
             if data then
                 for _, v in ipairs(data) do
-                    local pdata = util.JSONToTable(v._data or "{}")
-                    local last = pdata.lastOnline
+                    local last = tonumber(v._lastOnline)
                     if not isnumber(last) then last = os.time(lia.time.toNumber(v._lastJoinTime)) end
                     local lastDiff = os.time() - last
                     table.insert(characters, {
@@ -154,7 +152,7 @@ lia.command.add("factionmanagement", {
                         faction = v._faction,
                         steamID = v._steamID,
                         lastOnline = formatDHM(lastDiff),
-                        hoursPlayed = formatDHM(pdata.totalOnlineTime or 0)
+                        hoursPlayed = formatDHM(tonumber(v._totalOnlineTime) or 0)
                     })
                 end
             else


### PR DESCRIPTION
## Summary
- expand player table with columns for last IP, last online, and total time
- save and load these fields through player meta functions
- sync last IP on spawn
- use new columns in faction commands

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877da1867dc83278b5ad94a2e9f7a73