### PR TITLE
Ensure base user groups are protected

### DIFF
--- a/documentation/docs/libraries/framework/lia.admin.md
+++ b/documentation/docs/libraries/framework/lia.admin.md
@@ -8,6 +8,8 @@ This page explains the built-in administration system.
 
 The admin library manages user groups, privileges, and bans. It automatically disables itself when the SAM or ServerGuard admin mods are detected.
 
+The base user groups `user`, `admin`, and `superadmin` are created automatically and cannot be removed.
+
 ---
 
 ### lia.admin.isDisabled
@@ -95,7 +97,7 @@ Registers a CAMI privilege for use with permission checks.
 
 **Purpose**
 
-Deletes a previously created user group.
+Deletes a previously created user group. The built-in groups `user`, `admin`, and `superadmin` are protected and cannot be removed.
 
 **Parameters**
 

--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -14,11 +14,22 @@ function lia.admin.load()
         lia.admin.privileges[name] = priv
     end
 
+    local defaults = {"user", "admin", "superadmin"}
+    local created = false
     if table.Count(lia.admin.groups) == 0 then
-        lia.admin.createGroup("admin")
-        lia.admin.createGroup("superadmin")
-        lia.admin.save(true)
+        for _, grp in ipairs(defaults) do
+            lia.admin.createGroup(grp)
+        end
+        created = true
+    else
+        for _, grp in ipairs(defaults) do
+            if not lia.admin.groups[grp] then
+                lia.admin.createGroup(grp)
+                created = true
+            end
+        end
     end
+    if created then lia.admin.save(true) end
 
     lia.bootstrap("Administration", L("adminSystemLoaded"))
 end
@@ -42,6 +53,10 @@ end
 
 function lia.admin.removeGroup(groupName)
     if lia.admin.isDisabled() then return end
+    if groupName == "user" or groupName == "admin" or groupName == "superadmin" then
+        Error("[Lilia Administration] The base usergroups cannot be removed!\n")
+        return
+    end
     if not lia.admin.groups[groupName] then
         Error("[Lilia Administration] This usergroup doesn't exist!\n")
         return
@@ -142,7 +157,14 @@ end
 hook.Add("PlayerAuthed", "lia_SetUserGroup", function(ply, steamID)
     if lia.admin.isDisabled() then return end
     local steam64 = util.SteamIDTo64(steamID)
-    lia.db.query(Format("SELECT _userGroup FROM lia_players WHERE _steamID = %s", steam64), function(data) if istable(data) and data[1] then ply:SetUserGroup(data[1]._userGroup) end end)
+    lia.db.query(Format("SELECT _userGroup FROM lia_players WHERE _steamID = %s", steam64), function(data)
+        local group = istable(data) and data[1] and data[1]._userGroup
+        if not group or group == "" then
+            group = "user"
+            lia.db.query(Format("UPDATE lia_players SET _userGroup = '%s' WHERE _steamID = %s", lia.db.escape(group), steam64))
+        end
+        ply:SetUserGroup(group)
+    end)
 end)
 
 hook.Add("OnDatabaseLoaded", "lia_LoadBans", function()

--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -420,6 +420,7 @@ if SERVER then
                     _steamName = name,
                     _firstJoin = timeStamp,
                     _lastJoin = timeStamp,
+                    _userGroup = "user",
                     _data = {},
                     _lastIP = "",
                     _lastOnline = os.time(lia.time.toNumber(timeStamp)),


### PR DESCRIPTION
## Summary
- default new players to `user` group when creating the database row
- always create `user`, `admin` and `superadmin` groups on load
- prevent removing the default groups
- document the protected default groups

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877dbdcb5ac8327a332b2dcba8d3a80