### PR TITLE
Fix persistence folder/map usage

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -553,8 +553,8 @@ function GM:SaveData()
         if item.liaItemID and not item.temp then data.items[#data.items + 1] = {item.liaItemID, item:GetPos()} end
     end
 
-    lia.data.set("persistance", data.entities, true)
-    lia.data.set("itemsave", data.items, true)
+    lia.data.set("persistance", data.entities)
+    lia.data.set("itemsave", data.items)
 end
 
 function GM:LoadData()
@@ -565,7 +565,7 @@ function GM:LoadData()
         return false
     end
 
-    local entities = lia.data.get("persistance", {}, true)
+    local entities = lia.data.get("persistance", {})
     for _, ent in ipairs(entities or {}) do
         if not IsEntityNearby(ent.pos, ent.class) then
             local createdEnt = ents.Create(ent.class)
@@ -582,7 +582,7 @@ function GM:LoadData()
         end
     end
 
-    local items = lia.data.get("itemsave", {}, true)
+    local items = lia.data.get("itemsave", {})
     if items then
         local idRange = {}
         local positions = {}
@@ -626,7 +626,7 @@ end
 
 function GM:OnEntityCreated(ent)
     if not IsValid(ent) or not ent:isLiliaPersistent() then return end
-    local saved = lia.data.get("persistance", {}, true) or {}
+    local saved = lia.data.get("persistance", {}) or {}
     local seen = {}
     for _, e in ipairs(saved) do
         seen[makeKey(e)] = true
@@ -641,7 +641,7 @@ function GM:OnEntityCreated(ent)
             angles = ent:GetAngles(),
         }
 
-        lia.data.set("persistance", saved, true)
+        lia.data.set("persistance", saved)
     end
 end
 

--- a/gamemode/core/libraries/data.lua
+++ b/gamemode/core/libraries/data.lua
@@ -203,7 +203,10 @@ if SERVER then
                     local tbl = tables[i]
                     if not tbl then return end
                     local key = tbl:match("^lia_data_(.+)$")
-                    lia.db.select({"_folder", "_map", "_value"}, "data_" .. key):next(function(res2)
+                    local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
+                    local map = game.GetMap()
+                    local condition = buildCondition(folder, map)
+                    lia.db.select({"_folder", "_map", "_value"}, "data_" .. key, condition):next(function(res2)
                         local rows = res2.results or {}
                         for _, row in ipairs(rows) do
                             local decoded = util.JSONToTable(row._value or "[]")


### PR DESCRIPTION
## Summary
- load data scoped to current gamemode and map
- save persistence data using folder/map instead of global

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6877dda212348327a921c8703c91cf2d