### PR TITLE
Fix CreateTableUI width

### DIFF
--- a/gamemode/core/libraries/util.lua
+++ b/gamemode/core/libraries/util.lua
@@ -586,7 +586,7 @@ else
     end
 
     function lia.util.CreateTableUI(title, columns, data, options, charID)
-        local frameWidth, frameHeight = ScrH() * 0.8, ScrH() * 0.8
+        local frameWidth, frameHeight = ScrW() * 0.8, ScrH() * 0.8
         local frame = vgui.Create("DFrame")
         frame:SetTitle(title or L("tableListTitle"))
         frame:SetSize(frameWidth, frameHeight)


### PR DESCRIPTION
## Summary
- make CreateTableUI frame use screen width when calculating 80% size

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877deb3ae5c8327a5c64b0ea1c74fe7