### PR TITLE
Fix last online display in roster & management

### DIFF
--- a/modules/teams/commands.lua
+++ b/modules/teams/commands.lua
@@ -84,12 +84,15 @@ lia.command.add("roster", {
                     local last = tonumber(v._lastOnline)
                     if not isnumber(last) then last = os.time(lia.time.toNumber(v._lastJoinTime)) end
                     local lastDiff = os.time() - last
+                    local timeSince = lia.time.TimeSince(last)
+                    local timeStripped = timeSince:match("^(.-)%sago$") or timeSince
+                    local lastOnlineText = string.format("%s (%s) ago", timeStripped, formatDHM(lastDiff))
                     table.insert(characters, {
                         id = v._id,
                         name = v._name,
                         faction = v._faction,
                         steamID = v._steamID,
-                        lastOnline = formatDHM(lastDiff),
+                        lastOnline = lastOnlineText,
                         hoursPlayed = formatDHM(tonumber(v._totalOnlineTime) or 0)
                     })
                 end
@@ -146,12 +149,15 @@ lia.command.add("factionmanagement", {
                     local last = tonumber(v._lastOnline)
                     if not isnumber(last) then last = os.time(lia.time.toNumber(v._lastJoinTime)) end
                     local lastDiff = os.time() - last
+                    local timeSince = lia.time.TimeSince(last)
+                    local timeStripped = timeSince:match("^(.-)%sago$") or timeSince
+                    local lastOnlineText = string.format("%s (%s) ago", timeStripped, formatDHM(lastDiff))
                     table.insert(characters, {
                         id = v._id,
                         name = v._name,
                         faction = v._faction,
                         steamID = v._steamID,
-                        lastOnline = formatDHM(lastDiff),
+                        lastOnline = lastOnlineText,
                         hoursPlayed = formatDHM(tonumber(v._totalOnlineTime) or 0)
                     })
                 end


### PR DESCRIPTION
## Summary
- include human-readable relative time next to DHM in roster and faction management

## Testing
- `lua` interpreter not available

------
https://chatgpt.com/codex/tasks/task_e_6877dea0feb88327964b60f21f5888b4