### PR TITLE
Add item failure logs

### DIFF
--- a/modules/administration/submodules/logging/libraries/server.lua
+++ b/modules/administration/submodules/logging/libraries/server.lua
@@ -73,7 +73,7 @@ function MODULE:OnCharDelete(client, id)
     lia.log.add(client, "charDelete", id)
 end
 
-function MODULE:OnPlayerInteractItem(client, action, item)
+function MODULE:OnPlayerInteractItem(client, action, item, result)
     if isentity(item) then
         if IsValid(item) then
             local itemID = item.liaItemID
@@ -88,6 +88,10 @@ function MODULE:OnPlayerInteractItem(client, action, item)
     action = string.lower(action)
     if not item then return end
     local name = item.name
+    if result == false then
+        lia.log.add(client, "itemInteractionFailed", action, name)
+        return
+    end
     if action == "use" then
         lia.log.add(client, "use", name)
     elseif action == "drop" then
@@ -195,4 +199,34 @@ end
 function MODULE:WarningRemoved(admin, target, warning, index)
     local warns = target:getLiliaData("warns") or {}
     lia.log.add(admin, "warningRemoved", target, warning, #warns, index)
+end
+
+function MODULE:ItemTransfered(context)
+    local client = context.client
+    local item = context.item
+    if not (IsValid(client) and item) then return end
+    local fromID = context.from and context.from:getID() or 0
+    local toID = context.to and context.to:getID() or 0
+    lia.log.add(client, "itemTransfer", item:getName(), fromID, toID)
+end
+
+function MODULE:OnItemAdded(owner, item)
+    lia.log.add(owner, "itemAdded", item:getName())
+end
+
+function MODULE:OnItemCreated(item)
+    lia.log.add(nil, "itemCreated", item:getName())
+end
+
+function MODULE:OnItemSpawned(entity)
+    local item = entity.getItemTable and entity:getItemTable()
+    if item then lia.log.add(nil, "itemSpawned", item:getName()) end
+end
+
+function MODULE:ItemFunctionCalled(item, action, client)
+    if IsValid(client) then lia.log.add(client, "itemFunction", action, item:getName()) end
+end
+
+function MODULE:ItemDraggedOutOfInventory(client, item)
+    lia.log.add(client, "itemDraggedOut", item:getName())
 end

--- a/modules/administration/submodules/logging/logs.lua
+++ b/modules/administration/submodules/logging/logs.lua
@@ -122,6 +122,12 @@
         func = function(client, item) return string.format("Player '%s' dropped item '%s'.", client:Name(), item) end,
         category = "Items"
     },
+    ["itemInteractionFailed"] = {
+        func = function(client, action, itemName)
+            return string.format("Player '%s' failed to %s item '%s'.", client:Name(), action, itemName)
+        end,
+        category = "Items"
+    },
     ["itemInteraction"] = {
         func = function(client, action, item) return string.format("Player '%s' %s item '%s'.", client:Name(), action, item.name) end,
         category = "Items"
@@ -134,9 +140,72 @@
         func = function(client, item) return string.format("Player '%s' unequipped item '%s'.", client:Name(), item) end,
         category = "Items"
     },
+    ["itemTransfer"] = {
+        func = function(client, itemName, fromID, toID)
+            return string.format("Player '%s' moved item '%s' from inventory %s to %s.", client:Name(), itemName, tostring(fromID), tostring(toID))
+        end,
+        category = "Items"
+    },
+    ["itemTransferFailed"] = {
+        func = function(client, itemName, fromID, toID)
+            return string.format("Player '%s' failed to move item '%s' from inventory %s to %s.", client:Name(), itemName, tostring(fromID), tostring(toID))
+        end,
+        category = "Items"
+    },
+    ["itemCombine"] = {
+        func = function(client, itemName, targetName)
+            return string.format("Player '%s' combined item '%s' with '%s'.", client:Name(), itemName, targetName)
+        end,
+        category = "Items"
+    },
+    ["itemFunction"] = {
+        func = function(client, action, itemName)
+            return string.format("Player '%s' called item function '%s' on '%s'.", client:Name(), action, itemName)
+        end,
+        category = "Items"
+    },
+    ["itemAdded"] = {
+        func = function(client, itemName)
+            local ownerName = IsValid(client) and client:Name() or L("unknown")
+            return string.format("Item '%s' added to %s's inventory.", itemName, ownerName)
+        end,
+        category = "Items"
+    },
+    ["itemCreated"] = {
+        func = function(_, itemName) return string.format("Item '%s' instance created.", itemName) end,
+        category = "Items"
+    },
+    ["itemSpawned"] = {
+        func = function(_, itemName) return string.format("Item '%s' spawned in the world.", itemName) end,
+        category = "Items"
+    },
+    ["itemDraggedOut"] = {
+        func = function(client, itemName)
+            return string.format("Player '%s' dragged item '%s' out of an inventory.", client:Name(), itemName)
+        end,
+        category = "Items"
+    },
     ["toolgunUse"] = {
         func = function(client, tool) return string.format("Player '%s' used toolgun: '%s'.", client:Name(), tool) end,
         category = "Tools"
+    },
+    ["permissionDenied"] = {
+        func = function(client, action)
+            return string.format("Player '%s' was denied permission to %s.", client:Name(), action)
+        end,
+        category = "Permissions"
+    },
+    ["spawnDenied"] = {
+        func = function(client, objectType, model)
+            return string.format("Player '%s' was denied from spawning %s '%s'.", client:Name(), objectType, tostring(model))
+        end,
+        category = "Permissions"
+    },
+    ["toolDenied"] = {
+        func = function(client, tool)
+            return string.format("Player '%s' was denied tool '%s'.", client:Name(), tool)
+        end,
+        category = "Permissions"
     },
     ["observeToggle"] = {
         func = function(client, state) return string.format("Player '%s' toggled observe mode %s.", client:Name(), state) end,

--- a/modules/administration/submodules/permissions/libraries/server.lua
+++ b/modules/administration/submodules/permissions/libraries/server.lua
@@ -9,29 +9,36 @@ local restrictedProperties = {
 function GM:PlayerSpawnProp(client, model)
     local list = lia.data.get("blacklist", {}, true, true)
     if table.HasValue(list, model) and not client:hasPrivilege("Spawn Permissions - Can Spawn Blacklisted Props") then
+        lia.log.add(client, "spawnDenied", "prop", model)
         client:notifyLocalized("blacklistedProp")
         return false
     end
 
     local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn Props") or client:getChar():hasFlags("e")
-    if not canSpawn then client:notifyLocalized("noSpawnPropsPerm") end
+    if not canSpawn then
+        lia.log.add(client, "spawnDenied", "prop", model)
+        client:notifyLocalized("noSpawnPropsPerm")
+    end
     return canSpawn
 end
 
 function GM:CanProperty(client, property, entity)
     if restrictedProperties[property] then
+        lia.log.add(client, "permissionDenied", "use property " .. property)
         client:notifyLocalized("disabledFeature")
         return false
     end
 
     if entity:IsWorld() and IsValid(entity) then
         if client:hasPrivilege("Staff Permissions - Can Property World Entities") then return true end
+        lia.log.add(client, "permissionDenied", "modify world property " .. property)
         client:notifyLocalized("noModifyWorldEntities")
         return false
     end
 
     if entity:GetCreator() == client and (property == "remover" or property == "collision") then return true end
     if client:IsSuperAdmin() or client:hasPrivilege("Staff Permissions - Access Property " .. property:gsub("^%l", string.upper)) and client:isStaffOnDuty() then return true end
+    lia.log.add(client, "permissionDenied", "modify property " .. property)
     client:notifyLocalized("noModifyProperty")
     return false
 end
@@ -43,6 +50,7 @@ end
 function GM:PhysgunPickup(client, entity)
     if (client:hasPrivilege("Staff Permissions - Physgun Pickup") or client:isStaffOnDuty()) and entity.NoPhysgun then
         if not client:hasPrivilege("Staff Permissions - Physgun Pickup on Restricted Entities") then
+            lia.log.add(client, "permissionDenied", "physgun restricted entity")
             client:notifyLocalized("noPickupRestricted")
             return false
         end
@@ -54,18 +62,21 @@ function GM:PhysgunPickup(client, entity)
     if client:hasPrivilege("Staff Permissions - Physgun Pickup") then
         if entity:IsVehicle() then
             if not client:hasPrivilege("Staff Permissions - Physgun Pickup on Vehicles") then
+                lia.log.add(client, "permissionDenied", "physgun vehicle")
                 client:notifyLocalized("noPickupVehicles")
                 return false
             end
             return true
         elseif entity:IsPlayer() then
             if entity:hasPrivilege("Staff Permissions - Can't be Grabbed with PhysGun") or not client:hasPrivilege("Staff Permissions - Can Grab Players") then
+                lia.log.add(client, "permissionDenied", "physgun player")
                 client:notifyLocalized("noPickupPlayer")
                 return false
             end
             return true
         elseif entity:IsWorld() or entity:CreatedByMap() then
             if not client:hasPrivilege("Staff Permissions - Can Grab World Props") then
+                lia.log.add(client, "permissionDenied", "physgun world prop")
                 client:notifyLocalized("noPickupWorld")
                 return false
             end
@@ -74,6 +85,7 @@ function GM:PhysgunPickup(client, entity)
         return true
     end
 
+    lia.log.add(client, "permissionDenied", "physgun entity")
     client:notifyLocalized("noPickupEntity")
     return false
 end
@@ -82,17 +94,22 @@ function GM:PlayerSpawnVehicle(client, model)
     if not client:hasPrivilege("Spawn Permissions - No Car Spawn Delay") then client.NextVehicleSpawn = SysTime() + lia.config.get("PlayerSpawnVehicleDelay", 30) end
     local list = lia.data.get("carBlacklist", {}, true, true)
     if model and table.HasValue(list, model) and not client:hasPrivilege("Spawn Permissions - Can Spawn Blacklisted Cars") then
+        lia.log.add(client, "spawnDenied", "vehicle", model)
         client:notifyLocalized("blacklistedVehicle")
         return false
     end
 
     local canSpawn = client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn Cars") or client:getChar():hasFlags("C")
-    if not canSpawn then client:notifyLocalized("noSpawnVehicles") end
+    if not canSpawn then
+        lia.log.add(client, "spawnDenied", "vehicle", model)
+        client:notifyLocalized("noSpawnVehicles")
+    end
     return canSpawn
 end
 
 function GM:PlayerNoClip(ply, enabled)
     if not (ply:isStaffOnDuty() or ply:hasPrivilege("Staff Permissions - No Clip Outside Staff Character")) then
+        lia.log.add(ply, "permissionDenied", "noclip")
         ply:notifyLocalized("noNoclip")
         return false
     end
@@ -106,43 +123,64 @@ end
 
 function GM:PlayerSpawnEffect(client)
     local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn Effects") or client:getChar():hasFlags("L")
-    if not canSpawn then client:notifyLocalized("noSpawnEffects") end
+    if not canSpawn then
+        lia.log.add(client, "spawnDenied", "effect")
+        client:notifyLocalized("noSpawnEffects")
+    end
     return canSpawn
 end
 
 function GM:PlayerSpawnNPC(client)
     local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn NPCs") or client:getChar():hasFlags("n")
-    if not canSpawn then client:notifyLocalized("noSpawnNPCs") end
+    if not canSpawn then
+        lia.log.add(client, "spawnDenied", "npc")
+        client:notifyLocalized("noSpawnNPCs")
+    end
     return canSpawn
 end
 
 function GM:PlayerSpawnRagdoll(client)
     local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn Ragdolls") or client:getChar():hasFlags("r")
-    if not canSpawn then client:notifyLocalized("noSpawnRagdolls") end
+    if not canSpawn then
+        lia.log.add(client, "spawnDenied", "ragdoll")
+        client:notifyLocalized("noSpawnRagdolls")
+    end
     return canSpawn
 end
 
 function GM:PlayerSpawnSENT(client)
     local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn SENTs") or client:getChar():hasFlags("E")
-    if not canSpawn then client:notifyLocalized("noSpawnSents") end
+    if not canSpawn then
+        lia.log.add(client, "spawnDenied", "sent")
+        client:notifyLocalized("noSpawnSents")
+    end
     return canSpawn
 end
 
 function GM:PlayerSpawnSWEP(client)
     local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn SWEPs") or client:getChar():hasFlags("z")
-    if not canSpawn then client:notifyLocalized("noSpawnSweps") end
+    if not canSpawn then
+        lia.log.add(client, "spawnDenied", "swep", tostring(swep))
+        client:notifyLocalized("noSpawnSweps")
+    end
     return canSpawn
 end
 
 function GM:PlayerGiveSWEP(client)
     local canGive = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn SWEPs") or client:getChar():hasFlags("W")
-    if not canGive then client:notifyLocalized("noGiveSweps") end
+    if not canGive then
+        lia.log.add(client, "permissionDenied", "give swep")
+        client:notifyLocalized("noGiveSweps")
+    end
     return canGive
 end
 
 function GM:OnPhysgunReload(_, client)
     local canReload = client:hasPrivilege("Staff Permissions - Can Physgun Reload")
-    if not canReload then client:notifyLocalized("noPhysgunReload") end
+    if not canReload then
+        lia.log.add(client, "permissionDenied", "physgun reload")
+        client:notifyLocalized("noPhysgunReload")
+    end
     return canReload
 end
 
@@ -172,6 +210,7 @@ function GM:CanTool(client, _, tool)
     end
 
     if DisallowedTools[tool] and not client:IsSuperAdmin() then
+        lia.log.add(client, "toolDenied", tool)
         client:notifyLocalized("toolNotAllowed", tool)
         return false
     end
@@ -185,6 +224,7 @@ function GM:CanTool(client, _, tool)
         if not isSuperAdmin then table.insert(reasons, "SuperAdmin") end
         if not isStaffOrFlagged then table.insert(reasons, "On-duty staff or flag 't'") end
         if not hasPriv then table.insert(reasons, "Privilege '" .. privilege .. "'") end
+        lia.log.add(client, "toolDenied", tool)
         client:notifyLocalized("toolNoPermission", tool, table.concat(reasons, ", "))
         return false
     end
@@ -195,12 +235,14 @@ function GM:CanTool(client, _, tool)
         if tool == "remover" then
             if entity.NoRemover then
                 if not client:hasPrivilege("Staff Permissions - Can Remove Blocked Entities") then
+                    lia.log.add(client, "permissionDenied", "remove blocked entity")
                     client:notifyLocalized("noRemoveBlockedEntities")
                     return false
                 end
                 return true
             elseif entity:IsWorld() then
                 if not client:hasPrivilege("Staff Permissions - Can Remove World Entities") then
+                    lia.log.add(client, "permissionDenied", "remove world entity")
                     client:notifyLocalized("noRemoveWorldEntities")
                     return false
                 end
@@ -210,16 +252,19 @@ function GM:CanTool(client, _, tool)
         end
 
         if (tool == "permaall" or tool == "blacklistandremove") and hook.Run("CanPersistEntity", entity) ~= false and (string.StartWith(entClass, "lia_") or entity:isLiliaPersistent() or entity:CreatedByMap()) then
+            lia.log.add(client, "toolDenied", tool)
             client:notifyLocalized("toolCantUseEntity", tool)
             return false
         end
 
         if (tool == "duplicator" or tool == "blacklistandremove") and entity.NoDuplicate then
+            lia.log.add(client, "toolDenied", tool)
             client:notifyLocalized("cannotDuplicateEntity", tool)
             return false
         end
 
         if tool == "weld" and entClass == "sent_ball" then
+            lia.log.add(client, "toolDenied", tool)
             client:notifyLocalized("cannotWeldBall")
             return false
         end

--- a/modules/inventory/libraries/server.lua
+++ b/modules/inventory/libraries/server.lua
@@ -41,6 +41,7 @@ end
 function MODULE:ItemCombine(client, item, target)
     if target.onCombine and target:call("onCombine", client, nil, item) then return end
     if item.onCombineTo and item and item:call("onCombineTo", client, nil, target) then return end
+    lia.log.add(client, "itemCombine", item:getName(), target:getName())
 end
 
 function MODULE:ItemDraggedOutOfInventory(client, item)
@@ -106,6 +107,10 @@ function MODULE:HandleItemTransferRequest(client, itemID, x, y, invID)
         if err then
             print(err)
             debug.Trace()
+        end
+
+        if IsValid(client) then
+            lia.log.add(client, "itemTransferFailed", item:getName(), oldInventory:getID(), newInventory and newInventory:getID() or 0)
         end
 
         if IsValid(client) then client:notifyLocalized("itemOnGround") end

--- a/modules/inventory/submodules/storage/netcalls/server.lua
+++ b/modules/inventory/submodules/storage/netcalls/server.lua
@@ -69,10 +69,16 @@ net.Receive("liaStorageTransfer", function(_, client)
         return res
     end):catch(function(err)
         client.storageTransaction = nil
+        if IsValid(client) then
+            lia.log.add(client, "itemTransferFailed", item:getName(), fromInv:getID(), toInv:getID())
+        end
         if IsValid(client) then client:notifyLocalized(err) end
         return fromInv:add(item)
     end):catch(function()
         client.storageTransaction = nil
+        if IsValid(client) then
+            lia.log.add(client, "itemTransferFailed", item:getName(), fromInv:getID(), toInv:getID())
+        end
         item:spawn(failItemDropPos)
         if IsValid(client) then client:notifyLocalized("itemOnGround") end
     end)

--- a/modules/inventory/submodules/vendor/entities/entities/lia_vendor/init.lua
+++ b/modules/inventory/submodules/vendor/entities/entities/lia_vendor/init.lua
@@ -111,7 +111,7 @@ function ENT:removeReceiver(client, requestedByPlayer)
     if requestedByPlayer then return end
     net.Start("VendorExit")
     net.Send(client)
-    lia.log.add(activator, "vendorExit", self:getNetVar("name"))
+    lia.log.add(client, "vendorExit", self:getNetVar("name"))
 end
 
 local ALLOWED_MODES = {

--- a/modules/protection/libraries/server.lua
+++ b/modules/protection/libraries/server.lua
@@ -3,9 +3,15 @@ function MODULE:CanPlayerSwitchChar(client, character)
     if not client:isStaffOnDuty() then
         local damageCooldown = lia.config.get("OnDamageCharacterSwitchCooldownTimer", 15)
         local switchCooldown = lia.config.get("CharacterSwitchCooldownTimer", 5)
-        if damageCooldown > 0 and client.LastDamaged and client.LastDamaged > CurTime() - damageCooldown then return false, L("tookDamageSwitchCooldown") end
+        if damageCooldown > 0 and client.LastDamaged and client.LastDamaged > CurTime() - damageCooldown then
+            lia.log.add(client, "permissionDenied", "switch character (recent damage)")
+            return false, L("tookDamageSwitchCooldown")
+        end
         local loginTime = character:getData("loginTime", 0)
-        if switchCooldown > 0 and loginTime + switchCooldown > os.time() then return false, L("switchCooldown") end
+        if switchCooldown > 0 and loginTime + switchCooldown > os.time() then
+            lia.log.add(client, "permissionDenied", "switch character (cooldown)")
+            return false, L("switchCooldown")
+        end
     end
     return true
 end


### PR DESCRIPTION
## Summary
- log failed item interactions
- log failed transfers and transactions between inventories
- report item failures when transfers leave items on the ground
- log item spawning, creation, inventory additions and function calls
- add logs for denied spawns, tool use and other permission failures
- track character switch cooldown denials in protection module

## Testing
- ❌ `luacheck .` (failed: command not found)


------
https://chatgpt.com/codex/tasks/task_e_6877d9763a1883278337d380748d6cab