### PR TITLE
Add multi-button request API

### DIFF
--- a/documentation/docs/meta/player.md
+++ b/documentation/docs/meta/player.md
@@ -1970,6 +1970,37 @@ player:binaryQuestion("Proceed?", "Yes", "No", false, print)
 
 ---
 
+### requestButtons
+
+**Purpose**
+
+Prompts the player with multiple buttons that each trigger a server callback.
+
+**Parameters**
+
+* `title` (`string`): Window title.
+
+* `buttons` (`table`): Array where each element contains button text and a callback.
+
+**Realm**
+
+`Server`
+
+**Returns**
+
+* `nil`: This function does not return a value.
+
+**Example Usage**
+
+```lua
+player:requestButtons("Select one", {
+    {"A", function(client) print("Chose A") end},
+    {"B", function(client) print("Chose B") end}
+})
+```
+
+---
+
 ### getPlayTime (Server)
 
 **Purpose**

--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -628,6 +628,25 @@ if SERVER then
         self.binaryQuestionCallback = callback
     end
 
+    function playerMeta:requestButtons(title, buttons)
+        self.buttonRequests = self.buttonRequests or {}
+        local labels = {}
+        local callbacks = {}
+        for i, data in ipairs(buttons) do
+            labels[i] = data.text or data[1] or ""
+            callbacks[i] = data.callback or data[2]
+        end
+        local id = table.insert(self.buttonRequests, callbacks)
+        net.Start("ButtonRequest")
+        net.WriteUInt(id, 32)
+        net.WriteString(title or "")
+        net.WriteUInt(#labels, 8)
+        for _, lbl in ipairs(labels) do
+            net.WriteString(lbl)
+        end
+        net.Send(self)
+    end
+
     function playerMeta:getPlayTime()
         local diff = os.time(lia.time.toNumber(self.lastJoin)) - os.time(lia.time.toNumber(self.firstJoin))
         return diff + RealTime() - (self.liaJoinTime or RealTime())

--- a/gamemode/core/netcalls/client.lua
+++ b/gamemode/core/netcalls/client.lua
@@ -600,6 +600,34 @@ net.Receive("BinaryQuestionRequest", function()
     end)
 end)
 
+net.Receive("ButtonRequest", function()
+    local id = net.ReadUInt(32)
+    local title = L(net.ReadString())
+    local count = net.ReadUInt(8)
+    local options = {}
+    for i = 1, count do
+        options[i] = L(net.ReadString())
+    end
+    local frame = vgui.Create("DFrame")
+    frame:SetTitle(title)
+    frame:SetSize(300, 60 + count * 30)
+    frame:Center()
+    frame:MakePopup()
+    for i, text in ipairs(options) do
+        local btn = frame:Add("DButton")
+        btn:Dock(TOP)
+        btn:DockMargin(10, 5, 10, 0)
+        btn:SetText(text)
+        btn.DoClick = function()
+            net.Start("ButtonRequest")
+            net.WriteUInt(id, 32)
+            net.WriteUInt(i, 8)
+            net.SendToServer()
+            frame:Close()
+        end
+    end
+end)
+
 net.Receive("AnimationStatus", function()
     local ply = net.ReadEntity()
     local active = net.ReadBool()

--- a/gamemode/core/netcalls/server.lua
+++ b/gamemode/core/netcalls/server.lua
@@ -41,6 +41,16 @@ net.Receive("BinaryQuestionRequest", function(_, client)
     end
 end)
 
+net.Receive("ButtonRequest", function(_, client)
+    local id = net.ReadUInt(32)
+    local choice = net.ReadUInt(8)
+    local data = client.buttonRequests and client.buttonRequests[id]
+    if data and data[choice] then
+        data[choice](client)
+        client.buttonRequests[id] = nil
+    end
+end)
+
 net.Receive("liaTransferItem", function(_, client)
     local itemID = net.ReadUInt(32)
     local x = net.ReadUInt(32)


### PR DESCRIPTION
## Summary
- implement `playerMeta:requestButtons` for prompting with multiple buttons
- handle new `ButtonRequest` net message server-side
- add client UI for `ButtonRequest`
- document `requestButtons` usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877e2dddc508327b1759bf8bc66f073