### PR TITLE
Ensure logs include SteamID and char ID

### DIFF
--- a/documentation/docs/libraries/lia.logger.md
+++ b/documentation/docs/libraries/lia.logger.md
@@ -6,7 +6,9 @@ This page documents logging utilities.
 
 ## Overview
 
-The logger library writes structured log entries to files, to the console, and to the `lia_logs` SQL table (gamemode, category, text, character ID, SteamID). Built-in log types live in `modules/administration/submodules/logging/logs.lua`; custom types can be added with `lia.log.addType`.
+The logger library writes structured log entries to the console and to the `lia_logs` SQL table (gamemode, category, text, character ID, SteamID). Built-in log types live in `modules/administration/submodules/logging/logs.lua`; custom types can be added with `lia.log.addType`.
+
+Each database row stores the timestamp, SteamID, and (if relevant) character ID so that every entry can be associated with a specific player.
 
 ---
 
@@ -48,7 +50,7 @@ Registers a log type by supplying a generator function and a category.
 
 * `logType` (*string*): Unique identifier.
 * `func` (*function*): Builds the log string (`func(client, ...) → string`).
-* `category` (*string*): Folder/category name used for log files.
+* `category` (*string*): Category name used to organise logs.
 
 **Realm**
 
@@ -107,7 +109,7 @@ print(cat .. ": " .. text)
 
 **Purpose**
 
-Creates a log entry, fires `OnServerLog`, prints to console, writes to file, and inserts into `lia_logs`.
+Creates a log entry, fires `OnServerLog`, prints to console, and inserts into `lia_logs`.
 
 **Parameters**
 

--- a/gamemode/core/libraries/logger.lua
+++ b/gamemode/core/libraries/logger.lua
@@ -53,7 +53,6 @@ if SERVER then
     end
 
     function lia.log.loadTables()
-        file.CreateDir("lilia/logs/" .. engine.ActiveGamemode())
         lia.db.waitForTablesToLoad():next(function()
             createLogsTable()
             checkLegacyLogs()
@@ -82,12 +81,7 @@ if SERVER then
         if not isstring(logString) then return end
         hook.Run("OnServerLog", client, logType, logString, category)
         lia.printLog(category, logString)
-        local logsDir = "lilia/logs/" .. engine.ActiveGamemode()
-        if not file.Exists(logsDir, "DATA") then file.CreateDir(logsDir) end
-        local filenameCategory = string.lower(string.gsub(category, "%s+", "_"))
-        local logFilePath = logsDir .. "/" .. filenameCategory .. ".txt"
         local timestamp = os.date("%Y-%m-%d %H:%M:%S")
-        file.Append(logFilePath, "[" .. timestamp .. "]\t" .. logString .. "\r\n")
         local charID
         local steamID
         if IsValid(client) then


### PR DESCRIPTION
## Summary
- remove file logging so only DB is used
- update docs to describe the DB-only logging behaviour

## Testing
- `luacheck . --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877e81ee53c8327aa9e7cfebdb01d61