### PR TITLE
Normalize documentation headers

### DIFF
--- a/documentation/docs/installation.md
+++ b/documentation/docs/installation.md
@@ -1,4 +1,4 @@
-## Installation Tutorial
+# Installation Tutorial
 
 Lilia is a versatile roleplay framework for Garry's Mod. This tutorial guides you through installing Lilia on your server so you can create a stable roleplaying environment.
 

--- a/documentation/docs/libraries/lia.color.md
+++ b/documentation/docs/libraries/lia.color.md
@@ -102,7 +102,7 @@ surface.SetDrawColor(colors.background)
 
 ---
 
-### Color(name)
+### Color
 
 **Purpose**
 

--- a/documentation/docs/libraries/lia.notice.md
+++ b/documentation/docs/libraries/lia.notice.md
@@ -76,7 +76,7 @@ lia.notices.notifyLocalized("questFoundItem", nil, "golden_key")
 
 ---
 
-### lia.notices.notify (client)
+### lia.notices.notify
 
 **Purpose**
 
@@ -106,7 +106,7 @@ lia.notices.notify("Welcome back!")
 
 ---
 
-### lia.notices.notifyLocalized (client)
+### lia.notices.notifyLocalized
 
 **Purpose**
 

--- a/documentation/docs/libraries/lia.util.md
+++ b/documentation/docs/libraries/lia.util.md
@@ -868,7 +868,7 @@ lia.util.requestArguments("User Info",
 
 ---
 
-### lia.util.CreateTableUI (client implementation)
+### lia.util.CreateTableUI - client implementation
 
 **Purpose**
 

--- a/documentation/docs/meta/player.md
+++ b/documentation/docs/meta/player.md
@@ -1,5 +1,3 @@
----
-
 # Player Meta
 
 Lilia extends Garry's Mod players with characters, inventories, and permission checks.


### PR DESCRIPTION
## Summary
- fix `#` level on installation guide
- remove leading separator from player meta docs
- clean up library headers without arguments

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877e87353fc8327957f595bf22be011