### PR TITLE
Fix missing blank lines in docs

### DIFF
--- a/documentation/docs/definitions/attribute.md
+++ b/documentation/docs/definitions/attribute.md
@@ -25,6 +25,7 @@ Each attribute is registered on the global `ATTRIBUTE` table. You can customize:
 | `startingMax`  | `number`  | `30`    | Maximum base value at character creation, before any startup bonus points are applied. |
 | `noStartBonus` | `boolean` | `false` | If `true`, players cannot allocate any of the creation startup bonus points to this attribute. |
 | `maxValue`     | `number`  | `30`    | Absolute upper limit an attribute can ever reach. |
+
 ---
 
 ## Field Details

--- a/documentation/docs/definitions/bars.md
+++ b/documentation/docs/definitions/bars.md
@@ -20,5 +20,6 @@ Each bar represents a progress value such as health, armor, or stamina. The bar 
 | `identifier` | `string` \| `nil` | Unique identifier, if provided. |
 | `visible` | `boolean` \| `nil` | Set to `true` to force the bar to remain visible. |
 | `lifeTime` | `number` | Internal timer used for fading; managed automatically. |
+
 ---
 

--- a/documentation/docs/definitions/class.md
+++ b/documentation/docs/definitions/class.md
@@ -47,6 +47,7 @@ The global `CLASS` table defines per-class settings such as display name, lore, 
 | `commands` | `table` | `{}` | Command names members may always use. |
 | `canInviteToFaction` | `boolean` | `false` | Allows members of this class to invite players to their faction. |
 | `canInviteToClass` | `boolean` | `false` | Allows members of this class to invite others to their class. |
+
 ---
 
 ## Field Details

--- a/documentation/docs/definitions/command.md
+++ b/documentation/docs/definitions/command.md
@@ -34,6 +34,7 @@ The command name itself is the first argument to `lia.command.add` and is stored
 | `desc` | `string` | `""` | Short description shown in command lists and menus. |
 | `AdminStick` | `table` | `nil` | Defines how the command appears in admin utilities. |
 | `onRun(client, args)` | `function(client, table)` | **required** | Function executed when the command is invoked. |
+
 ---
 
 ## Field Details

--- a/documentation/docs/definitions/faction.md
+++ b/documentation/docs/definitions/faction.md
@@ -48,6 +48,7 @@ Each faction in the game is defined by a set of fields on the global `FACTION` t
 | `isGloballyRecognized` | `boolean` | `false` | Everyone automatically recognizes this faction.
 | `scoreboardHidden` | `boolean` | `false` | Hide members from the scoreboard. |
 | `commands` | `table` | `{}` | Command names members may always use. |
+
 ---
 
 ## Field Details

--- a/documentation/docs/definitions/items.md
+++ b/documentation/docs/definitions/items.md
@@ -69,6 +69,7 @@ The global `ITEM` table defines per-item settings such as sounds, inventory dime
 | `url` | `string` | `""` | Web address opened when using the item. |
 | `weaponCategory` | `string` | `""` | Slot category for the weapon. |
 | `width` | `number` | `1` | Width in inventory grid. |
+
 ---
 
 ## Field Details

--- a/documentation/docs/definitions/module.md
+++ b/documentation/docs/definitions/module.md
@@ -32,6 +32,7 @@ A `MODULE` table defines a self-contained add-on for the Lilia framework. Each f
 | `ModuleLoaded` | `function` | `nil` | Callback run after module finishes loading. |
 | `Public` | `boolean` | `false` | Participates in public version checks. |
 | `Private` | `boolean` | `false` | Uses private version checking. |
+
 ---
 
 ## Field Details

--- a/documentation/docs/definitions/panels.md
+++ b/documentation/docs/definitions/panels.md
@@ -61,6 +61,7 @@ Panels provide the building blocks for Lilia's user interface. Most derive from 
 | `liaMiniButton` | `DButton` | Very small button variant. |
 | `liaNoBGButton` | `DButton` | Text-only button with no background. |
 | `liaQuick` | `EditablePanel` | Quick settings panel showing options flagged with `isQuick`. |
+
 ---
 
 ## Panel Details

--- a/documentation/docs/libraries/lia.flags.md
+++ b/documentation/docs/libraries/lia.flags.md
@@ -91,5 +91,6 @@ The base gamemode registers the following permission flags. Additional flags can
 | `n`  | Spawn NPCs                     |
 | `Z`  | Invite players to your faction |
 | `P`  | Use PAC3 features              |
+
 ---
 


### PR DESCRIPTION
## Summary
- ensure tables have trailing blank line so docs are uniformly double-spaced

## Testing
- `python3` script checks for consecutive non-empty lines

------
https://chatgpt.com/codex/tasks/task_e_687a7fff64388327bb4a21d3e52b4646