### PR TITLE
Fix workshop prompt count

### DIFF
--- a/gamemode/core/libraries/workshop.lua
+++ b/gamemode/core/libraries/workshop.lua
@@ -83,9 +83,9 @@ else
         return string.format("%.2f", bytes / (1024 * 1024 * 1024))
     end
 
-    local function showPrompt(count, have, size)
+    local function showPrompt(total, have, size)
         if IsValid(downloadFrame) then return end
-        local text = L("workshopDownloadPrompt", have, count, formatSize(size))
+        local text = L("workshopDownloadPrompt", total - have, total, formatSize(size))
         local frame = vgui.Create("DFrame")
         downloadFrame = frame
         frame:SetTitle(L("downloads"))


### PR DESCRIPTION
## Summary
- show the number of missing addons in the workshop download prompt

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_687a897fc5ac832788129f1c1b3daf5f