### PR TITLE
Fix webimage registration across rejoin

### DIFF
--- a/gamemode/core/libraries/webimage.lua
+++ b/gamemode/core/libraries/webimage.lua
@@ -4,6 +4,7 @@ local gamemode = engine.ActiveGamemode() or "unknown"
 local baseDir = "lilia/" .. ip .. "/" .. gamemode .. "/"
 local cache = {}
 local urlMap = {}
+local registered = lia.webimage._registered or {}
 local function ensureDir(p)
     local parts = string.Explode("/", p)
     local cur = ""
@@ -19,6 +20,8 @@ end
 
 function lia.webimage.register(n, u, cb, flags)
     if isstring(u) then urlMap[u] = n end
+    registered[n] = {url = u, flags = flags}
+    lia.webimage._registered = registered
     if cache[n] then
         if cb then cb(cache[n], true) end
         return
@@ -178,3 +181,23 @@ lia.webimage.register("notalk.png", "https://github.com/LiliaFramework/liaIcons/
 lia.webimage.register("close_button.png", "https://github.com/LiliaFramework/liaIcons/blob/main/close_button.png?raw=true")
 lia.webimage.register("close_button_pressed.png", "https://github.com/LiliaFramework/liaIcons/blob/main/close_button_pressed.png?raw=true")
 ensureDir(baseDir)
+
+hook.Add("InitPostEntity", "liaWebImageReRegister", function()
+    local newIP = string.Replace(string.Replace(game.GetIPAddress() or "unknown", ":", "_"), "%.", "_")
+    local newGamemode = engine.ActiveGamemode() or "unknown"
+    local newBase = "lilia/" .. newIP .. "/" .. newGamemode .. "/"
+    if newBase ~= baseDir then
+        ip = newIP
+        gamemode = newGamemode
+        baseDir = newBase
+        cache = {}
+        urlMap = {}
+        ensureDir(baseDir)
+        for name, data in pairs(registered) do
+            if isstring(data.url) then
+                lia.webimage.register(name, data.url, nil, data.flags)
+            end
+        end
+    end
+end)
+


### PR DESCRIPTION
## Summary
- ensure `lia.webimage.register` stores registration info
- refresh cached web images after connecting to a new server

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ab00d87788327ac09bfaed68cc938