### PR TITLE
Add command to wipe web sound cache

### DIFF
--- a/documentation/docs/libraries/lia.websound.md
+++ b/documentation/docs/libraries/lia.websound.md
@@ -109,3 +109,14 @@ ply:EmitSound("https://example.com/alert.mp3")
 ```
 
 ---
+
+### Clearing the Cache
+
+To remove all downloaded web sounds on the client use the following console
+command:
+
+```
+lia_wipe_sounds
+```
+
+Any sounds played afterwards will be downloaded again as needed.

--- a/gamemode/core/libraries/websound.lua
+++ b/gamemode/core/libraries/websound.lua
@@ -126,6 +126,17 @@ concommand.Add("lia_saved_sounds", function()
     end
 end)
 
+concommand.Add("lia_wipe_sounds", function()
+    local files = file.Find(baseDir .. "*", "DATA")
+    for _, fn in ipairs(files) do
+        file.Delete(baseDir .. fn)
+    end
+
+    cache = {}
+    urlMap = {}
+    MsgC(Color(83, 143, 239), "[Lilia] ", Color(0, 255, 0), "[WebSound]", Color(255, 255, 255), " " .. L("webSoundCacheCleared") .. "\n")
+end)
+
 ensureDir(baseDir)
 hook.Add("EntityEmitSound", "liaWebSound", function(data)
     local soundName = data.OriginalSoundName or data.SoundName

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -908,6 +908,7 @@ LANGUAGE = {
     webImageTesterTitle = "WebImage Tester",
     loadImage = "Load Image",
     webSoundsTitle = "Web Sounds",
+    webSoundCacheCleared = "Web sound cache cleared.",
     dermaPreviewTitle = "Derma Controls Preview",
     dframe = "DFrame",
     dbutton = "DButton",


### PR DESCRIPTION
## Summary
- add `lia_wipe_sounds` console command to delete downloaded web sounds
- add English localization string for wiping message
- document how to wipe the web sound cache

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ab2334df883279ce94ec56786cd34