### PR TITLE
Add command to wipe webimages

### DIFF
--- a/documentation/docs/libraries/lia.webimage.md
+++ b/documentation/docs/libraries/lia.webimage.md
@@ -99,3 +99,8 @@ local byURL = Material("https://example.com/logo.png")
 ```
 
 ---
+
+### Clearing the Cache
+
+Use the `lia_wipewebimages` console command on the client to delete all cached web
+images from disk. New requests will download the images again.

--- a/gamemode/core/libraries/webimage.lua
+++ b/gamemode/core/libraries/webimage.lua
@@ -134,6 +134,19 @@ concommand.Add("lia_saved_images", function()
     end
 end)
 
+concommand.Add("lia_wipewebimages", function()
+    local files = file.Find(baseDir .. "*", "DATA")
+    if files then
+        for _, fn in ipairs(files) do
+            file.Delete(baseDir .. fn)
+        end
+    end
+    cache = {}
+    urlMap = {}
+    lia.information(L("webImagesCleared"))
+    ensureDir(baseDir)
+end)
+
 concommand.Add("test_webimage_menu", function()
     local frame = vgui.Create("DFrame")
     frame:SetTitle(L("webImageTesterTitle"))

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -907,6 +907,7 @@ LANGUAGE = {
     webImagesTitle = "Web Images",
     webImageTesterTitle = "WebImage Tester",
     loadImage = "Load Image",
+    webImagesCleared = "Web image cache cleared.",
     webSoundsTitle = "Web Sounds",
     dermaPreviewTitle = "Derma Controls Preview",
     dframe = "DFrame",


### PR DESCRIPTION
## Summary
- add `lia_wipewebimages` command
- add English translation for cleared webimage cache
- document the new command

## Testing
- `git show --stat`


------
https://chatgpt.com/codex/tasks/task_e_687ab156c1148327984d49db1da7991f