### PR TITLE
Pass SteamID to RunAdminSystemCommand

### DIFF
--- a/gamemode/modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua
+++ b/gamemode/modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua
@@ -14,7 +14,7 @@ function SWEP:SecondaryAttack()
     local target = self:GetTarget()
     if IsValid(target) and target:IsPlayer() and target ~= client then
         local action = target:IsFrozen() and "unfreeze" or "freeze"
-        local victim = target:IsBot() and target:Name() or target
+        local victim = target:IsBot() and target:Name() or target:SteamID()
         hook.Run("RunAdminSystemCommand", action, client, victim)
     else
         client:notifyLocalized("cantFreezeTarget")

--- a/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
@@ -34,8 +34,8 @@ end
 
 local function RunAdminCommand(cmd, tgt, dur, reason, fallback)
     local cl = LocalPlayer()
-    local victim = IsValid(tgt) and tgt:IsPlayer() and tgt:IsBot() and tgt:Name() or tgt
-    hook.Run("RunAdminSystemCommand", action, client, victim)
+    local victim = IsValid(tgt) and tgt:IsPlayer() and (tgt:IsBot() and tgt:Name() or tgt:SteamID()) or tgt
+    hook.Run("RunAdminSystemCommand", cmd, cl, victim, dur, reason)
 end
 
 local function OpenPlayerModelUI(tgt)


### PR DESCRIPTION
## Summary
- ensure AdminStick passes the SteamID to `RunAdminSystemCommand`
- fix helper to forward command parameters properly

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aec52deb88327b34b05f43e5ecfc9