### PR TITLE
Set storage icons to white

### DIFF
--- a/gamemode/modules/inventory/submodules/storage/entities/entities/lia_storage/cl_init.lua
+++ b/gamemode/modules/inventory/submodules/storage/entities/entities/lia_storage/cl_init.lua
@@ -7,7 +7,7 @@ function ENT:onDrawEntityInfo(alpha)
     y = y - 20
     local mat = locked and "locked.png" or "unlocked.png"
     local ty = 32
-    lia.util.drawTexture(mat, ColorAlpha(locked and Color(242, 38, 19) or Color(135, 211, 124), alpha), x - 16, y - 16, 32, 32)
+    lia.util.drawTexture(mat, ColorAlpha(color_white, alpha), x - 16, y - 16, 32, 32)
     y = y + ty * .9
     local def = self:getStorageInfo()
     if def then


### PR DESCRIPTION
## Summary
- show locked/unlocked storage icons in white

## Testing
- `luac -p gamemode/modules/inventory/submodules/storage/entities/entities/lia_storage/cl_init.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687af71942c08327b3bab7649ae98d65