### PR TITLE
Hide version when addon has none

### DIFF
--- a/gamemode/modules/f1menu/libraries/client.lua
+++ b/gamemode/modules/f1menu/libraries/client.lua
@@ -314,7 +314,9 @@ function MODULE:CreateInformationButtons(pages)
                     modulePanel.Paint = function(pnl, w, h)
                         derma.SkinHook("Paint", "Panel", pnl, w, h)
                         draw.SimpleText(moduleData.name, "liaMediumFont", 20, 10, color_white)
-                        draw.SimpleText(tostring(moduleData.version or 1.0), "liaSmallFont", w - 20, 45, color_white, TEXT_ALIGN_RIGHT, TEXT_ALIGN_TOP)
+                        if moduleData.version then
+                            draw.SimpleText(tostring(moduleData.version), "liaSmallFont", w - 20, 45, color_white, TEXT_ALIGN_RIGHT, TEXT_ALIGN_TOP)
+                        end
                         if hasDesc then draw.SimpleText(moduleData.desc, "liaSmallFont", 20, 45, color_white) end
                     end
 


### PR DESCRIPTION
## Summary
- don't display version number in modules list if addon doesn't define one

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687af8650d448327878cf10247a46761