### PR TITLE
Remove close button image references

### DIFF
--- a/gamemode/core/derma/skin.lua
+++ b/gamemode/core/derma/skin.lua
@@ -1,7 +1,5 @@
 ﻿local surface = surface
 local Color = Color
-local MAT_CLOSE = Material("close_button_pressed.png", "noclamp smooth")
-local MAT_CLOSE_IDLE = Material("close_button.png", "noclamp smooth")
 local function drawAltBg(panel, w, h)
     lia.util.drawBlur(panel, 10)
     surface.SetDrawColor(45, 45, 45, 200)
@@ -93,10 +91,8 @@ function SKIN:PaintButton(panel)
 end
 
 function SKIN:PaintWindowCloseButton(panel, w, h)
-    surface.SetDrawColor(255, 255, 255, 255)
-    local mat = panel.Depressed and MAT_CLOSE or MAT_CLOSE_IDLE
-    surface.SetMaterial(mat)
-    surface.DrawTexturedRect(0, 0, w, h)
+    local base = derma.GetDefaultSkin()
+    base.PaintWindowCloseButton(base, panel, w, h)
 end
 
 function SKIN:PaintWindowMinimizeButton(panel, w, h)
@@ -450,10 +446,8 @@ end
 
 function SKIN:PaintWindowCloseButton(panel, w, h)
     paintButtonBase(panel, w, h)
-    surface.SetDrawColor(255, 255, 255, 255)
-    local mat = panel.Depressed and MAT_CLOSE or MAT_CLOSE_IDLE
-    surface.SetMaterial(mat)
-    surface.DrawTexturedRect(0, 0, w, h)
+    local base = derma.GetDefaultSkin()
+    base.PaintWindowCloseButton(base, panel, w, h)
 end
 
 function SKIN:PaintButton(panel)

--- a/gamemode/core/libraries/webimage.lua
+++ b/gamemode/core/libraries/webimage.lua
@@ -196,6 +196,4 @@ lia.webimage.register("normaltalk.png", "https://github.com/LiliaFramework/liaIc
 lia.webimage.register("yelltalk.png", "https://github.com/LiliaFramework/liaIcons/blob/main/yelltalk.png?raw=true")
 lia.webimage.register("whispertalk.png", "https://github.com/LiliaFramework/liaIcons/blob/main/whispertalk.png?raw=true")
 lia.webimage.register("notalk.png", "https://github.com/LiliaFramework/liaIcons/blob/main/notalk.png?raw=true")
-lia.webimage.register("close_button.png", "https://github.com/LiliaFramework/liaIcons/blob/main/close_button.png?raw=true")
-lia.webimage.register("close_button_pressed.png", "https://github.com/LiliaFramework/liaIcons/blob/main/close_button_pressed.png?raw=true")
 ensureDir(baseDir)


### PR DESCRIPTION
## Summary
- remove `close_button.png` and `close_button_pressed.png` materials from the skin
- stop registering the close button images via `webimage`

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_687af99e51088327955c25d4efac8094