### PR TITLE
Fix charlist command error when run on bots

### DIFF
--- a/gamemode/modules/administration/submodules/permissions/commands.lua
+++ b/gamemode/modules/administration/submodules/permissions/commands.lua
@@ -101,7 +101,7 @@ lia.command.add("charlist", {
 
         local steam64 = target:SteamID64()
         lia.db.query("SELECT * FROM lia_characters WHERE _steamID = " .. lia.db.convertDataType(steam64), function(data)
-            if #data == 0 then
+            if not data or #data == 0 then
                 client:notify("No characters found for this player.")
                 return
             end


### PR DESCRIPTION
## Summary
- handle nil results from database queries for charlist command

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687afa825280832792bf56cc84bfec94