### PR TITLE
Increase flag checkbox size

### DIFF
--- a/gamemode/core/libraries/flags.lua
+++ b/gamemode/core/libraries/flags.lua
@@ -79,7 +79,8 @@ hook.Add("CreateInformationButtons", "liaInformationFlags", function(pages)
                         derma.SkinHook("Paint", "Panel", pnl, w, h)
                         draw.SimpleText(L("flagLabel", flagName), "liaMediumFont", 20, 10, color_white, TEXT_ALIGN_LEFT, TEXT_ALIGN_TOP)
                         local icon = hasFlag and "checkbox.png" or "unchecked.png"
-                        lia.util.drawTexture(icon, color_white, w - 42, h * 0.5 - 16, 32, 32)
+                        local iconSize = 64
+                        lia.util.drawTexture(icon, color_white, w - iconSize - 10, h * 0.5 - iconSize * 0.5, iconSize, iconSize)
                         if hasDesc then draw.SimpleText(flagData.desc, "liaSmallFont", 20, 45, color_white, TEXT_ALIGN_LEFT, TEXT_ALIGN_TOP) end
                     end
                 end


### PR DESCRIPTION
## Summary
- bump the checkbox icon size in the flags menu for improved readability

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687afca837188327b85c83708d20a6b9