### PR TITLE
Allow re-registering web resources

### DIFF
--- a/documentation/docs/libraries/lia.webimage.md
+++ b/documentation/docs/libraries/lia.webimage.md
@@ -18,7 +18,7 @@ The web-image library downloads remote images and caches them as materials. Cach
 
 **Purpose**
 
-Downloads an image from the given URL and saves it inside the web-image cache. If the file already exists locally the callback fires immediately with the cached `Material`. On HTTP failure the callback receives `nil` and an error string.
+Downloads an image from the given URL and saves it inside the web-image cache. If the file already exists it will be replaced with the new download. Should the request fail the previous cached file is used and passed to the callback.
 
 **Parameters**
 

--- a/documentation/docs/libraries/lia.websound.md
+++ b/documentation/docs/libraries/lia.websound.md
@@ -28,11 +28,7 @@ will reuse the previously saved file and you may also pass the cached name to
 
 **Purpose**
 
-Downloads a sound from the given URL and saves it in the web-sound cache. If the
-
-file already exists locally the callback fires immediately with the cached
-
-filename. On HTTP failure the callback receives `nil` and an error string.
+Downloads a sound from the given URL and saves it in the web-sound cache. Any existing file with the same name is overwritten by the new download. If the request fails the old cached file is used and passed to the callback.
 
 **Parameters**
 

--- a/gamemode/core/libraries/webimage.lua
+++ b/gamemode/core/libraries/webimage.lua
@@ -26,10 +26,7 @@ function lia.webimage.register(n, u, cb, flags)
     }
 
     lia.webimage._registered = registered
-    if cache[n] then
-        if cb then cb(cache[n], true) end
-        return
-    end
+    cache[n] = nil
 
     local savePath = baseDir .. n
     local function finalize(fromCache)
@@ -39,16 +36,17 @@ function lia.webimage.register(n, u, cb, flags)
         if not fromCache then hook.Run("WebImageDownloaded", n, "data/" .. savePath) end
     end
 
-    if file.Exists(savePath, "DATA") then
-        finalize(true)
-        return
-    end
-
     http.Fetch(u, function(b)
         ensureDir(baseDir)
         file.Write(savePath, b)
         finalize(false)
-    end, function(e) if cb then cb(nil, false, e) end end)
+    end, function(e)
+        if file.Exists(savePath, "DATA") then
+            finalize(true)
+        elseif cb then
+            cb(nil, false, e)
+        end
+    end)
 end
 
 function lia.webimage.get(n, flags)

--- a/gamemode/core/libraries/websound.lua
+++ b/gamemode/core/libraries/websound.lua
@@ -19,10 +19,7 @@ end
 
 function lia.websound.register(name, url, cb)
     if isstring(url) then urlMap[url] = name end
-    if cache[name] then
-        if cb then cb(cache[name], true) end
-        return
-    end
+    cache[name] = nil
 
     local savePath = baseDir .. name
     local function finalize(fromCache)
@@ -32,16 +29,17 @@ function lia.websound.register(name, url, cb)
         if not fromCache then hook.Run("WebSoundDownloaded", name, path) end
     end
 
-    if file.Exists(savePath, "DATA") then
-        finalize(true)
-        return
-    end
-
     http.Fetch(url, function(body)
         ensureDir(baseDir)
         file.Write(savePath, body)
         finalize(false)
-    end, function(err) if cb then cb(nil, false, err) end end)
+    end, function(err)
+        if file.Exists(savePath, "DATA") then
+            finalize(true)
+        elseif cb then
+            cb(nil, false, err)
+        end
+    end)
 end
 
 function lia.websound.get(name)


### PR DESCRIPTION
## Summary
- overwrite saved data when registering web images or sounds again
- document that register will replace existing cached files

## Testing
- `luacheck gamemode` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_687afd7ab8d08327a6259d365fe5a6e3