### PR TITLE
Update CharList admin menu location

### DIFF
--- a/gamemode/modules/administration/submodules/permissions/commands.lua
+++ b/gamemode/modules/administration/submodules/permissions/commands.lua
@@ -86,7 +86,7 @@ lia.command.add("charlist", {
     syntax = "[string Player Or Steam ID]",
     AdminStick = {
         Name = "Open CharList",
-        Category = "characterManagement",
+        Category = "playerInformation",
         Icon = "icon16/user_gray.png"
     },
     onRun = function(client, arguments)


### PR DESCRIPTION
## Summary
- move the `charlist` admin command into the Player Information category

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687afdea490083278d1075894a89b0d5