### PR TITLE
Stop logging OnLoadout/OnSave item calls

### DIFF
--- a/gamemode/modules/administration/submodules/logging/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/logging/libraries/server.lua
@@ -216,6 +216,9 @@ function MODULE:OnItemAdded(owner, item)
 end
 
 function MODULE:ItemFunctionCalled(item, action, client)
+    if not action then return end
+    local lowered = string.lower(action)
+    if lowered == "onloadout" or lowered == "onsave" then return end
     if IsValid(client) then lia.log.add(client, "itemFunction", action, item:getName()) end
 end
 


### PR DESCRIPTION
## Summary
- avoid logging `OnLoadout` and `OnSave` item function calls

## Testing
- `luacheck gamemode/modules/administration/submodules/logging/libraries/server.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b0269eedc8327904b13f9dd0a1ac3