### PR TITLE
Fix vendor data loading

### DIFF
--- a/gamemode/modules/inventory/submodules/storage/libraries/server.lua
+++ b/gamemode/modules/inventory/submodules/storage/libraries/server.lua
@@ -20,6 +20,11 @@
     end
 }
 
+local encodeVector = lia.data.encodeVector
+local encodeAngle = lia.data.encodeAngle
+local decodeVector = lia.data.decodeVector
+local decodeAngle = lia.data.decodeAngle
+
 function MODULE:PlayerSpawnedProp(client, model, entity)
     local data = self.StorageDefinitions[model:lower()]
     if not data then return end
@@ -64,7 +69,15 @@ function MODULE:SaveData()
             continue
         end
 
-        if entity:getInv() then data[#data + 1] = {entity:GetPos(), entity:GetAngles(), entity:getNetVar("id"), entity:GetModel():lower(), entity.password} end
+        if entity:getInv() then
+            data[#data + 1] = {
+                encodeVector(entity:GetPos()),
+                encodeAngle(entity:GetAngles()),
+                entity:getNetVar("id"),
+                entity:GetModel():lower(),
+                entity.password
+            }
+        end
     end
 
     self:setData(data)
@@ -79,6 +92,8 @@ function MODULE:LoadData()
     if not data then return end
     for _, info in ipairs(data) do
         local position, angles, invID, model, password = unpack(info)
+        position = decodeVector(position)
+        angles = decodeAngle(angles)
         local storageDef = self.StorageDefinitions[model]
         if not storageDef then continue end
         local storage = ents.Create("lia_storage")

--- a/gamemode/modules/inventory/submodules/vendor/libraries/server.lua
+++ b/gamemode/modules/inventory/submodules/vendor/libraries/server.lua
@@ -1,10 +1,15 @@
-﻿function MODULE:SaveData()
+local encodeVector = lia.data.encodeVector
+local encodeAngle = lia.data.encodeAngle
+local decodeVector = lia.data.decodeVector
+local decodeAngle = lia.data.decodeAngle
+
+function MODULE:SaveData()
     local data = {}
     for _, v in ipairs(ents.FindByClass("lia_vendor")) do
         data[#data + 1] = {
             name = v:getNetVar("name"),
-            pos = v:GetPos(),
-            angles = v:GetAngles(),
+            pos = encodeVector(v:GetPos()),
+            angles = encodeAngle(v:GetAngles()),
             model = v:GetModel(),
             items = v.items,
             factions = v.factions,
@@ -23,8 +28,8 @@ end
 function MODULE:LoadData()
     for _, v in ipairs(self:getData() or {}) do
         local entity = ents.Create("lia_vendor")
-        entity:SetPos(v.pos)
-        entity:SetAngles(v.angles)
+        entity:SetPos(decodeVector(v.pos))
+        entity:SetAngles(decodeAngle(v.angles))
         entity:Spawn()
         entity:SetModel(v.model)
         entity:setNetVar("name", v.name)

--- a/gamemode/modules/spawns/libraries/server.lua
+++ b/gamemode/modules/spawns/libraries/server.lua
@@ -1,13 +1,7 @@
 local MODULE = MODULE
 MODULE.spawns = MODULE.spawns or {}
-local function decodeVector(tbl)
-    if istable(tbl) and tbl[1] and tbl[2] and tbl[3] then return Vector(tbl[1], tbl[2], tbl[3]) end
-    return tbl
-end
-
-local function encodeVector(vec)
-    return {vec.x, vec.y, vec.z}
-end
+local decodeVector = lia.data.decodeVector
+local encodeVector = lia.data.encodeVector
 
 function MODULE:LoadData(attempt)
     attempt = attempt or 1


### PR DESCRIPTION
## Summary
- ensure vendor data saves vectors and angles in a portable format
- decode previously stored string values when loading vendors
- apply vector/angle decoding across all stored data
- handle persistence and storage modules with universal helpers

## Testing
- `luacheck gamemode/core/libraries/data.lua gamemode/modules/inventory/submodules/vendor/libraries/server.lua gamemode/modules/inventory/submodules/storage/libraries/server.lua gamemode/modules/spawns/libraries/server.lua gamemode/core/hooks/server.lua > /tmp/luacheck.log && tail -n 20 /tmp/luacheck.log` *(fails: command not found)*
- `sudo apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687b0461461c8327ab533d4c4e790617