### PR TITLE
Remove deprecated refresh parameter

### DIFF
--- a/documentation/docs/libraries/lia.data.md
+++ b/documentation/docs/libraries/lia.data.md
@@ -88,14 +88,6 @@ Retrieves the stored value for the specified key from the cache.
 
 * `default` (*any*): Default value to return if no data is found.
 
-* `global` (*boolean*): Legacy parameter, currently ignored.
-
-* `ignoreMap` (*boolean*): Legacy parameter, currently ignored.
-
-* `refresh` (*boolean*): When `true`, bypasses the cached value and simply
-
-  returns the default. This behavior is kept for legacy compatibility.
-
 **Realm**
 
 `Shared`
@@ -108,7 +100,7 @@ Retrieves the stored value for the specified key from the cache.
 
 ```lua
 hook.Add("PlayerSpawn", "UseSavedSpawn", function(ply)
-    local pos = lia.data.get("spawn_pos", vector_origin, true)
+    local pos = lia.data.get("spawn_pos", vector_origin)
     if pos then
         ply:SetPos(pos)
     end

--- a/documentation/docs/libraries/lia.time.md
+++ b/documentation/docs/libraries/lia.time.md
@@ -38,7 +38,7 @@ Returns a human-readable string describing how long ago a given time occurred (e
 -- Greet joining players with the time since they last logged in
 hook.Add("PlayerInitialSpawn", "welcomeLastSeen", function(ply)
     local key  = "lastLogin_" .. ply:SteamID64()
-    local last = lia.data.get(key, nil, true)
+    local last = lia.data.get(key, nil)
 
     if last then
         ply:ChatPrint(("Welcome back! You last joined %s."):format(lia.time.TimeSince(last)))

--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -9,7 +9,7 @@ end
 
 function lia.admin.load()
     if lia.admin.isDisabled() then return end
-    lia.admin.groups = lia.data.get("admin_groups", {}, true, true)
+    lia.admin.groups = lia.data.get("admin_groups", {})
     for name, priv in pairs(CAMI.GetPrivileges() or {}) do
         lia.admin.privileges[name] = priv
     end

--- a/gamemode/core/libraries/config.lua
+++ b/gamemode/core/libraries/config.lua
@@ -74,7 +74,7 @@ function lia.config.load()
                 local rows = res.results or {}
                 local existing = {}
                 if #rows == 0 then
-                    local legacy = lia.data.get("config", nil, false, true)
+                    local legacy = lia.data.get("config", nil)
                     if legacy then
                         for k, v in pairs(legacy) do
                             lia.config.stored[k] = lia.config.stored[k] or {}
@@ -162,7 +162,7 @@ if SERVER then
         if lia.config.isConverting then return end
         lia.config.isConverting = true
         lia.bootstrap("Database", L("convertConfigToDatabase"))
-        data = data or lia.data.get("config", nil, false, true) or {}
+        data = data or lia.data.get("config", nil) or {}
         local entryCount = table.Count(data)
         local schema = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
         local queries = {"DELETE FROM lia_config WHERE _schema = " .. lia.db.convertDataType(schema)}
@@ -184,7 +184,7 @@ if SERVER then
 end
 
 local function countLegacyConfigEntries()
-    local data = lia.data.get("config", nil, false, true) or {}
+    local data = lia.data.get("config", nil) or {}
     local total = istable(data) and table.Count(data) or 0
     return total, total
 end

--- a/gamemode/core/libraries/data.lua
+++ b/gamemode/core/libraries/data.lua
@@ -287,49 +287,47 @@ if SERVER then
     end)
 end
 
-function lia.data.get(key, default, _, _, refresh)
-    if not refresh then
-        local stored = lia.data.stored[key]
-        PrintTable(stored, 1)
-        if stored ~= nil then
-            print("[lia.data.get] key:", key, "type(stored):", type(stored))
-            if isstring(stored) then
-                print("[lia.data.get] raw string stored:", stored)
-                local decoded = util.JSONToTable(stored)
-                if decoded then print("[lia.data.get] json decoded type:", type(decoded)) end
-                local depth = 0
-                while isstring(decoded) and depth < 5 do
-                    depth = depth + 1
-                    print("[lia.data.get] nested json string depth:", depth, "value:", decoded)
-                    decoded = util.JSONToTable(decoded)
-                    if decoded then print("[lia.data.get] nested decode type:", type(decoded)) end
-                end
-
-                if not decoded then
-                    local ok, ponDecoded = pcall(pon.decode, stored)
-                    if ok and ponDecoded then
-                        decoded = ponDecoded
-                        print("[lia.data.get] pon decoded type:", type(decoded))
-                    else
-                        print("[lia.data.get] pon decode failed")
-                    end
-                end
-
-                if istable(decoded) then
-                    stored = decoded[1] or decoded
-                    print("[lia.data.get] final table stored type:", type(stored))
-                elseif decoded ~= nil then
-                    stored = decoded
-                    print("[lia.data.get] final non-table stored type:", type(stored))
-                end
-
-                lia.data.stored[key] = stored
+function lia.data.get(key, default)
+    local stored = lia.data.stored[key]
+    PrintTable(stored, 1)
+    if stored ~= nil then
+        print("[lia.data.get] key:", key, "type(stored):", type(stored))
+        if isstring(stored) then
+            print("[lia.data.get] raw string stored:", stored)
+            local decoded = util.JSONToTable(stored)
+            if decoded then print("[lia.data.get] json decoded type:", type(decoded)) end
+            local depth = 0
+            while isstring(decoded) and depth < 5 do
+                depth = depth + 1
+                print("[lia.data.get] nested json string depth:", depth, "value:", decoded)
+                decoded = util.JSONToTable(decoded)
+                if decoded then print("[lia.data.get] nested decode type:", type(decoded)) end
             end
 
-            local final = lia.data.decode(stored)
-            print("[lia.data.get] returning type:", type(final))
-            return final
+            if not decoded then
+                local ok, ponDecoded = pcall(pon.decode, stored)
+                if ok and ponDecoded then
+                    decoded = ponDecoded
+                    print("[lia.data.get] pon decoded type:", type(decoded))
+                else
+                    print("[lia.data.get] pon decode failed")
+                end
+            end
+
+            if istable(decoded) then
+                stored = decoded[1] or decoded
+                print("[lia.data.get] final table stored type:", type(stored))
+            elseif decoded ~= nil then
+                stored = decoded
+                print("[lia.data.get] final non-table stored type:", type(stored))
+            end
+
+            lia.data.stored[key] = stored
         end
+
+        local final = lia.data.decode(stored)
+        print("[lia.data.get] returning type:", type(final))
+        return final
     end
 
     print("[lia.data.get] key:", key, "using default")

--- a/gamemode/core/libraries/modularity.lua
+++ b/gamemode/core/libraries/modularity.lua
@@ -130,8 +130,8 @@ function lia.module.load(uniqueID, path, isSingleFile, variable, skipSubmodules)
         lia.data.set(idKey, v, g, m)
     end
 
-    function MODULE:getData(d, g, m, r)
-        return lia.data.get(idKey, d, g, m, r) or {}
+    function MODULE:getData(d)
+        return lia.data.get(idKey, d) or {}
     end
 
     for k, f in pairs(MODULE) do

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -41,7 +41,7 @@ lia.command.add("managesitrooms", {
     onRun = function(client)
         if not client:hasPrivilege("Manage SitRooms") then return end
         local mapName = game.GetMap()
-        local sitrooms = lia.data.get("sitrooms", {}, true, true)
+        local sitrooms = lia.data.get("sitrooms", {})
         local rooms = sitrooms[mapName] or {}
         net.Start("managesitrooms")
         net.WriteTable(rooms)
@@ -61,7 +61,7 @@ lia.command.add("addsitroom", {
             end
 
             local mapName = game.GetMap()
-            local sitrooms = lia.data.get("sitrooms", {}, true, true)
+            local sitrooms = lia.data.get("sitrooms", {})
             sitrooms[mapName] = sitrooms[mapName] or {}
             sitrooms[mapName][name] = client:GetPos()
             lia.data.set("sitrooms", sitrooms, true, true)
@@ -90,7 +90,7 @@ lia.command.add("sendtositroom", {
         end
 
         local mapName = game.GetMap()
-        local sitrooms = lia.data.get("sitrooms", {}, true, true)
+        local sitrooms = lia.data.get("sitrooms", {})
         local rooms = sitrooms[mapName] or {}
         local names = {}
         for name in pairs(rooms) do

--- a/gamemode/modules/administration/libraries/shared.lua
+++ b/gamemode/modules/administration/libraries/shared.lua
@@ -15,7 +15,7 @@ properties.Add("TogglePropBlacklist", {
     Receive = function(_, _, ply)
         if not ply:hasPrivilege("Staff Permissions - Manage Prop Blacklist") then return end
         local model = net.ReadString()
-        local list = lia.data.get("blacklist", {}, true, true)
+        local list = lia.data.get("blacklist", {})
         if table.HasValue(list, model) then
             table.RemoveByValue(list, model)
             lia.data.set("blacklist", list, true, true)

--- a/gamemode/modules/administration/netcalls/server.lua
+++ b/gamemode/modules/administration/netcalls/server.lua
@@ -28,7 +28,7 @@ net.Receive("lia_managesitrooms_action", function(_, client)
     local action = net.ReadUInt(2)
     local name = net.ReadString()
     local mapName = game.GetMap()
-    local sitrooms = lia.data.get("sitrooms", {}, true, true)
+    local sitrooms = lia.data.get("sitrooms", {})
     sitrooms[mapName] = sitrooms[mapName] or {}
     local rooms = sitrooms[mapName]
     if action == 1 then

--- a/gamemode/modules/administration/submodules/logging/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/logging/libraries/server.lua
@@ -181,13 +181,13 @@ function MODULE:OnPlayerObserve(client, state)
 end
 
 function MODULE:TicketSystemClaim(admin, requester)
-    local caseclaims = lia.data.get("caseclaims", {}, true)
+    local caseclaims = lia.data.get("caseclaims", {})
     local info = caseclaims[admin:SteamID64()]
     lia.log.add(admin, "ticketClaimed", requester:Name(), info and info.claims or 0)
 end
 
 function MODULE:TicketSystemClose(admin, requester)
-    local caseclaims = lia.data.get("caseclaims", {}, true)
+    local caseclaims = lia.data.get("caseclaims", {})
     local info = caseclaims[admin:SteamID64()]
     lia.log.add(admin, "ticketClosed", requester:Name(), info and info.claims or 0)
 end

--- a/gamemode/modules/administration/submodules/permissions/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/server.lua
@@ -7,7 +7,7 @@ local restrictedProperties = {
 }
 
 function GM:PlayerSpawnProp(client, model)
-    local list = lia.data.get("blacklist", {}, true, true)
+    local list = lia.data.get("blacklist", {})
     if table.HasValue(list, model) and not client:hasPrivilege("Spawn Permissions - Can Spawn Blacklisted Props") then
         lia.log.add(client, "spawnDenied", "prop", model)
         client:notifyLocalized("blacklistedProp")
@@ -92,7 +92,7 @@ end
 
 function GM:PlayerSpawnVehicle(client, model)
     if not client:hasPrivilege("Spawn Permissions - No Car Spawn Delay") then client.NextVehicleSpawn = SysTime() + lia.config.get("PlayerSpawnVehicleDelay", 30) end
-    local list = lia.data.get("carBlacklist", {}, true, true)
+    local list = lia.data.get("carBlacklist", {})
     if model and table.HasValue(list, model) and not client:hasPrivilege("Spawn Permissions - Can Spawn Blacklisted Cars") then
         lia.log.add(client, "spawnDenied", "vehicle", model)
         client:notifyLocalized("blacklistedVehicle")

--- a/gamemode/modules/administration/submodules/permissions/libraries/shared.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/shared.lua
@@ -71,7 +71,7 @@ properties.Add("ToggleCarBlacklist", {
     Receive = function(_, _, ply)
         if not ply:hasPrivilege("Staff Permissions - Manage Car Blacklist") then return end
         local model = net.ReadString()
-        local list = lia.data.get("carBlacklist", {}, true, true)
+        local list = lia.data.get("carBlacklist", {})
         if table.HasValue(list, model) then
             table.RemoveByValue(list, model)
             lia.data.set("carBlacklist", list, true, true)

--- a/gamemode/modules/administration/submodules/tickets/commands.lua
+++ b/gamemode/modules/administration/submodules/tickets/commands.lua
@@ -23,7 +23,7 @@
         end
 
         local steamID = target:SteamID64()
-        local caseclaims = lia.data.get("caseclaims", {}, true)
+        local caseclaims = lia.data.get("caseclaims", {})
         local claim = caseclaims[steamID]
         if not claim then
             client:ChatPrint(L("noClaimsFound"))
@@ -88,7 +88,7 @@ lia.command.add("viewallclaims", {
     privilege = "View Claims",
     desc = "viewAllClaimsDesc",
     onRun = function(client)
-        local caseclaims = lia.data.get("caseclaims", {}, true)
+        local caseclaims = lia.data.get("caseclaims", {})
         if not next(caseclaims) then
             client:ChatPrint(L("noClaimsRecorded"))
             return
@@ -153,7 +153,7 @@ lia.command.add("viewclaims", {
     privilege = "View Claims",
     desc = "viewClaimsDesc",
     onRun = function(client)
-        local caseclaims = lia.data.get("caseclaims", {}, true)
+        local caseclaims = lia.data.get("caseclaims", {})
         if not next(caseclaims) then
             client:ChatPrint(L("noClaimsData"))
             return

--- a/gamemode/modules/administration/submodules/tickets/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/tickets/libraries/server.lua
@@ -1,5 +1,5 @@
 ﻿function MODULE:TicketSystemClaim(admin, requester)
-    local caseclaims = lia.data.get("caseclaims", {}, true)
+    local caseclaims = lia.data.get("caseclaims", {})
     if caseclaims[admin:SteamID()] then
         caseclaims[admin:SteamID64()] = caseclaims[admin:SteamID()]
         caseclaims[admin:SteamID()] = nil

--- a/gamemode/modules/administration/submodules/tickets/netcalls/server.lua
+++ b/gamemode/modules/administration/submodules/tickets/netcalls/server.lua
@@ -1,6 +1,6 @@
 ﻿net.Receive("ViewClaims", function(_, client)
     local sid = net.ReadString()
-    local caseclaims = lia.data.get("caseclaims", {}, true)
+    local caseclaims = lia.data.get("caseclaims", {})
     net.Start("ViewClaims")
     net.WriteTable(caseclaims)
     net.WriteString(sid)


### PR DESCRIPTION
## Summary
- drop the unused `refresh` argument from `lia.data.get`
- update modules to call `lia.data.get` with just key and default
- clean up documentation for `lia.data.get`
- update example in `lia.time` docs

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_687ba163a34c8327b200e8f58e48e29e