### PR TITLE
Fix nil variable crash when adding database fields

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -593,6 +593,8 @@ function lia.db.addDatabaseFields()
     }
 
     local ignore = function() end
+    if not istable(lia.char.vars) then return end
+
     for _, v in pairs(lia.char.vars) do
         if v.field and typeMap[v.fieldType] then
             lia.db.fieldExists("lia_characters", v.field):next(function(exists)


### PR DESCRIPTION
## Summary
- prevent `lia.db.addDatabaseFields` from iterating over `lia.char.vars` when it's nil

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687babe8823c83278c269ed3fdc2b3b0