### PR TITLE
Update workshop link

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -92,7 +92,8 @@
 <h2 align="center">📦 Workshop Content</h2>
 
 <p align="center">
-  Subscribe to our essential <a href="https://steamcommunity.com/sharedfiles/filedetails/?id=2959728255">Steam Workshop collection</a> for the assets you’ll need to run Lilia optimally.
+  Subscribe to our essential <a href="https://steamcommunity.com/sharedfiles/filedetails/?id=3527535922">Steam Workshop collection</a> for the assets you’ll need to run Lilia optimally.
+  This workshop release also contains the entire gamemode so you can replace your local <code>lilia</code> folder with it for easier updates.
 </p>
 
 <h2 align="center">💬 Community Support</h2>

--- a/documentation/docs/definitions/module.md
+++ b/documentation/docs/definitions/module.md
@@ -203,7 +203,7 @@ Steam Workshop add-on IDs required by this module.
 
 ```lua
 MODULE.WorkshopContent = {
-    "2959728255", -- shared assets
+    "3527535922", -- shared assets
     "1234567890"  -- map data
 }
 ```

--- a/gamemode/modules/mainmenu/config.lua
+++ b/gamemode/modules/mainmenu/config.lua
@@ -30,7 +30,7 @@ lia.config.add("DiscordURL", "The Discord of the Server", "https://discord.gg/es
     type = "Generic"
 })
 
-lia.config.add("Workshop", "The Steam Workshop of the Server", "https://steamcommunity.com/sharedfiles/filedetails/?id=2959728255", nil, {
+lia.config.add("Workshop", "The Steam Workshop of the Server", "https://steamcommunity.com/sharedfiles/filedetails/?id=3527535922", nil, {
     desc = "The URL for the Steam Workshop page",
     category = "Main Menu",
     type = "Generic"


### PR DESCRIPTION
## Summary
- update Steam Workshop link to the new content pack
- mention that the workshop pack can fully replace the `lilia` folder

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c041c52e8832782e4583df17dc40d