### PR TITLE
Fix item icon update on rotation

### DIFF
--- a/gamemode/core/derma/panels/item.lua
+++ b/gamemode/core/derma/panels/item.lua
@@ -1,4 +1,4 @@
-﻿local PANEL = {}
+local PANEL = {}
 local renderedIcons = {}
 local function renderNewIcon(panel, itemTable)
     if itemTable.iconCam and (not renderedIcons[string.lower(itemTable.model)] or itemTable.forceRender) then
@@ -11,6 +11,7 @@ local function renderNewIcon(panel, itemTable)
 
         renderedIcons[string.lower(itemTable.model)] = true
         panel.Icon:RebuildSpawnIconEx(iconCam)
+        itemTable.forceRender = nil
     end
 end
 

--- a/gamemode/modules/inventory/derma/cl_grid_inventory_item.lua
+++ b/gamemode/modules/inventory/derma/cl_grid_inventory_item.lua
@@ -1,4 +1,4 @@
-﻿local PANEL = {}
+local PANEL = {}
 local renderedIcons = {}
 local function renderNewIcon(panel, itemTable)
     if itemTable.iconCam and (not renderedIcons[string.lower(itemTable.model)] or itemTable.forceRender) then
@@ -11,6 +11,7 @@ local function renderNewIcon(panel, itemTable)
 
         renderedIcons[string.lower(itemTable.model)] = true
         panel.Icon:RebuildSpawnIconEx(iconCam)
+        itemTable.forceRender = nil
     end
 end
 

--- a/gamemode/modules/inventory/derma/cl_grid_inventory_panel.lua
+++ b/gamemode/modules/inventory/derma/cl_grid_inventory_panel.lua
@@ -1,4 +1,4 @@
-﻿local InvSlotMat = Material("invslotfree.png", "smooth noclamp")
+local InvSlotMat = Material("invslotfree.png", "smooth noclamp")
 local PANEL = {}
 function PANEL:Init()
     self:SetPaintBackground(false)
@@ -163,7 +163,8 @@ function PANEL:InventoryItemRemoved()
     self:populateItems()
 end
 
-function PANEL:InventoryItemDataChanged()
+function PANEL:InventoryItemDataChanged(item, key)
+    if key == "rotated" then item.forceRender = true end
     self:populateItems()
 end
 


### PR DESCRIPTION
## Summary
- regenerate item spawn icon when item rotates
- request icon refresh on rotation data change

## Testing
- `No tests present`


------
https://chatgpt.com/codex/tasks/task_e_687c0ca918748327b6d7c389f9243ab6