### PR TITLE
Add item rotation and inspection hooks

### DIFF
--- a/documentation/docs/hooks/gamemode_hooks.md
+++ b/documentation/docs/hooks/gamemode_hooks.md
@@ -2163,6 +2163,123 @@ hook.Add("CanPlayerUnequipItem", "Cursed", function(ply, item)
 end)
 ```
 
+### CanPlayerRotateItem
+
+**Purpose**
+
+Called when a player attempts to rotate an inventory item. Return false to block rotating.
+
+**Parameters**
+
+- `client` (`Player`): Player rotating.
+- `item` (`table`): Item being rotated.
+
+**Realm**
+
+`Server`
+
+**Returns**
+
+- boolean: False to block rotating
+
+**Example Usage**
+
+```lua
+hook.Add("CanPlayerRotateItem", "NoRotatingArtifacts", function(ply, item)
+    if item.isArtifact then
+        return false
+    end
+end)
+```
+
+### CanPlayerInspectItem
+
+**Purpose**
+
+Checks if a player may open the item inspection panel. Return false to prevent inspection.
+
+**Parameters**
+
+- `client` (`Player`): Player inspecting.
+- `item` (`table`): Item being inspected.
+
+**Realm**
+
+`Client`
+
+**Returns**
+
+- boolean: False to block inspection
+
+**Example Usage**
+
+```lua
+hook.Add("CanPlayerInspectItem", "BlockSecretItems", function(ply, item)
+    if item.secret then
+        return false
+    end
+end)
+```
+
+### CanPlayerRequestInspectionOnItem
+
+**Purpose**
+
+Called when a player wants to show an item to someone else. Return false to cancel the request.
+
+**Parameters**
+
+- `client` (`Player`): Player requesting inspection.
+- `target` (`Player`): Target player.
+- `item` (`table`): Item being offered.
+
+**Realm**
+
+`Server`
+
+**Returns**
+
+- boolean: False to cancel the request
+
+**Example Usage**
+
+```lua
+hook.Add("CanPlayerRequestInspectionOnItem", "FriendsOnly", function(ply, target, item)
+    if not ply:isFriend(target) then
+        return false
+    end
+end)
+```
+
+### CanPlayerSeeLogCategory
+
+**Purpose**
+
+Determines if a player can view a specific log category in the admin console.
+
+**Parameters**
+
+- `client` (`Player`): Player requesting logs.
+- `category` (`string`): Category name.
+
+**Realm**
+
+`Server`
+
+**Returns**
+
+- boolean: False to hide the category
+
+**Example Usage**
+
+```lua
+hook.Add("CanPlayerSeeLogCategory", "HideChatLogs", function(ply, category)
+    if category == "chatOOC" and not ply:IsAdmin() then
+        return false
+    end
+end)
+```
+
 ---
 
 ### PostPlayerSay

--- a/gamemode/core/derma/panels/itempanel.lua
+++ b/gamemode/core/derma/panels/itempanel.lua
@@ -183,7 +183,9 @@ function PANEL:buildButtons()
     end
 
     self:addBtn(L("inspect"), function()
-        self:openInspect()
+        if hook.Run("CanPlayerInspectItem", LocalPlayer(), self.item) ~= false then
+            self:openInspect()
+        end
         self:Remove()
     end)
 

--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -174,6 +174,10 @@ function GM:CanPlayerInteractItem(client, action, item)
             return false
         end
     end
+
+    if action == "rotate" then
+        return hook.Run("CanPlayerRotateItem", client, item) ~= false
+    end
 end
 
 function GM:CanPlayerEquipItem(client, item)
@@ -224,6 +228,15 @@ function GM:CanPlayerDropItem(client, item)
         client:notifyLocalized("forbiddenActionStorage")
         return false
     end
+end
+
+function GM:CanPlayerRotateItem(_, _)
+end
+
+function GM:CanPlayerInspectItem(_, _)
+end
+
+function GM:CanPlayerRequestInspectionOnItem(_, _, _)
 end
 
 local logTypeMap = {

--- a/gamemode/core/libraries/item.lua
+++ b/gamemode/core/libraries/item.lua
@@ -114,6 +114,7 @@ local DefaultFunctions = {
             local client = item.player
             local target = client:GetEyeTraceNoCursor().Entity
             if not (IsValid(target) and target:IsPlayer() and target:Alive() and client:GetPos():DistToSqr(target:GetPos()) < 6500) then return false end
+            if hook.Run("CanPlayerRequestInspectionOnItem", client, target, item) == false then return false end
             target:binaryQuestion(client:Name() .. " wants to show you their " .. item.name .. ".", L("yes"), L("no"), false, function(choice)
                 if choice == 0 then
                     net.Start("liaItemInspect")

--- a/gamemode/core/netcalls/client.lua
+++ b/gamemode/core/netcalls/client.lua
@@ -699,6 +699,8 @@ net.Receive("liaItemInspect", function()
     local item = lia.item.new(uniqueID, 0)
     item.data = data or {}
 
+    if hook.Run("CanPlayerInspectItem", LocalPlayer(), item) == false then return end
+
     local overlay = vgui.Create("EditablePanel")
     overlay:SetSize(ScrW(), ScrH())
     overlay:MakePopup()

--- a/gamemode/modules/administration/submodules/logging/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/logging/libraries/server.lua
@@ -49,7 +49,9 @@ net.Receive("send_logs_request", function(_, client)
 
     local catList = {}
     for cat in pairs(categories) do
-        catList[#catList + 1] = cat
+        if hook.Run("CanPlayerSeeLogCategory", client, cat) ~= false then
+            catList[#catList + 1] = cat
+        end
     end
 
     local logsByCategory = {}


### PR DESCRIPTION
## Summary
- allow servers to block item rotation
- allow inspection restrictions
- allow checking when players request to inspect another item
- support per-category log visibility
- document the new hooks

## Testing
- `luacheck --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ca1d55da4832786f9f4b07d93413e