### PR TITLE
Fix command syntax

### DIFF
--- a/gamemode/core/libraries/compatibility/sam.lua
+++ b/gamemode/core/libraries/compatibility/sam.lua
@@ -199,7 +199,7 @@ lia.command.add("playtime", {
 lia.command.add("plygetplaytime", {
     adminOnly = true,
     privilege = "View Playtime",
-    syntax = "[player Char Name]",
+    syntax = "[player Name]",
     AdminStick = {
         Name = "adminStickGetPlayTimeName",
         Category = "moderationTools",

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -75,7 +75,7 @@ lia.command.add("sendtositroom", {
     adminOnly = true,
     privilege = "Manage SitRooms",
     desc = "sendToSitRoomDesc",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     AdminStick = {
         Name = "sendToSitRoom",
         Category = "moderationTools",
@@ -121,7 +121,7 @@ lia.command.add("returnsitroom", {
     adminOnly = true,
     privilege = "Manage SitRooms",
     desc = "returnFromSitroomDesc",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     AdminStick = {
         Name = "returnFromSitroom",
         Category = "moderationTools",
@@ -153,7 +153,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Kick Player",
         desc = "plyKickDesc",
-        syntax = "<string name> [string reason]",
+        syntax = "[player Name] [string Reason optional]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then
@@ -168,7 +168,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Ban Player",
         desc = "plyBanDesc",
-        syntax = "<string name> [number duration] [string reason]",
+        syntax = "[player Name] [number Duration optional] [string Reason optional]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then
@@ -183,7 +183,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Kill Player",
         desc = "plyKillDesc",
-        syntax = "<string name>",
+        syntax = "[player Name]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then
@@ -198,7 +198,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Set Player Group",
         desc = "plySetGroupDesc",
-        syntax = "<string name> <string group>",
+        syntax = "[player Name] [string Group]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) and lia.admin.groups[arguments[2]] then
@@ -215,7 +215,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Unban Player",
         desc = "plyUnbanDesc",
-        syntax = "<string steamid>",
+        syntax = "[string SteamID]",
         onRun = function(client, arguments)
             local steamid = arguments[1]
             if steamid and steamid ~= "" then
@@ -230,7 +230,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Freeze Player",
         desc = "plyFreezeDesc",
-        syntax = "<string name> [number duration]",
+        syntax = "[player Name] [number Duration optional]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then
@@ -246,7 +246,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Unfreeze Player",
         desc = "plyUnfreezeDesc",
-        syntax = "<string name>",
+        syntax = "[player Name]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then
@@ -260,7 +260,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Slay Player",
         desc = "plySlayDesc",
-        syntax = "<string name>",
+        syntax = "[player Name]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then
@@ -274,7 +274,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Respawn Player",
         desc = "plyRespawnDesc",
-        syntax = "<string name>",
+        syntax = "[player Name]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then
@@ -288,7 +288,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Blind Player",
         desc = "plyBlindDesc",
-        syntax = "<string name> [number time]",
+        syntax = "[player Name] [number Time optional]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then
@@ -315,7 +315,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Unblind Player",
         desc = "plyUnblindDesc",
-        syntax = "<string name>",
+        syntax = "[player Name]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then
@@ -331,7 +331,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Blind Fade Player",
         desc = "plyBlindFadeDesc",
-        syntax = "<string name> <number time> [string color] [number fadein] [number fadeout]",
+        syntax = "[player Name] [number Time optional] [string Color optional] [number FadeIn optional] [number FadeOut optional]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then
@@ -356,7 +356,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Blind Fade All",
         desc = "blindFadeAllDesc",
-        syntax = "<number time> [string color] [number fadein] [number fadeout]",
+        syntax = "[number Time optional] [string Color optional] [number FadeIn optional] [number FadeOut optional]",
         onRun = function(_, arguments)
             local duration = tonumber(arguments[1]) or 0
             local colorName = (arguments[2] or "black"):lower()
@@ -380,7 +380,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Gag Player",
         desc = "plyGagDesc",
-        syntax = "<string name>",
+        syntax = "[player Name]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then
@@ -395,7 +395,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Ungag Player",
         desc = "plyUngagDesc",
-        syntax = "<string name>",
+        syntax = "[player Name]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then
@@ -410,7 +410,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Mute Player",
         desc = "plyMuteDesc",
-        syntax = "<string name>",
+        syntax = "[player Name]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) and target:getChar() then
@@ -425,7 +425,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Unmute Player",
         desc = "plyUnmuteDesc",
-        syntax = "<string name>",
+        syntax = "[player Name]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) and target:getChar() then
@@ -441,7 +441,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Bring Player",
         desc = "plyBringDesc",
-        syntax = "<string name>",
+        syntax = "[player Name]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then
@@ -456,7 +456,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Goto Player",
         desc = "plyGotoDesc",
-        syntax = "<string name>",
+        syntax = "[player Name]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then
@@ -471,7 +471,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Return Player",
         desc = "plyReturnDesc",
-        syntax = "<string name>",
+        syntax = "[player Name optional]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             target = IsValid(target) and target or client
@@ -488,7 +488,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Jail Player",
         desc = "plyJailDesc",
-        syntax = "<string name> [number duration]",
+        syntax = "[player Name]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then
@@ -503,7 +503,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Unjail Player",
         desc = "plyUnjailDesc",
-        syntax = "<string name>",
+        syntax = "[player Name]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then
@@ -518,7 +518,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Cloak Player",
         desc = "plyCloakDesc",
-        syntax = "<string name>",
+        syntax = "[player Name]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then
@@ -532,7 +532,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Uncloak Player",
         desc = "plyUncloakDesc",
-        syntax = "<string name>",
+        syntax = "[player Name]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then
@@ -546,7 +546,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "God Player",
         desc = "plyGodDesc",
-        syntax = "<string name>",
+        syntax = "[player Name]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then
@@ -560,7 +560,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Ungod Player",
         desc = "plyUngodDesc",
-        syntax = "<string name>",
+        syntax = "[player Name]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then
@@ -574,7 +574,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Ignite Player",
         desc = "plyIgniteDesc",
-        syntax = "<string name> [number duration]",
+        syntax = "[player Name] [number Duration optional]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then
@@ -589,7 +589,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Extinguish Player",
         desc = "plyExtinguishDesc",
-        syntax = "<string name>",
+        syntax = "[player Name]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then
@@ -603,7 +603,7 @@ if not lia.admin.isDisabled() then
         adminOnly = true,
         privilege = "Strip Player",
         desc = "plyStripDesc",
-        syntax = "<string name>",
+        syntax = "[player Name]",
         onRun = function(client, arguments)
             local target = lia.command.findPlayer(client, arguments[1])
             if IsValid(target) then

--- a/gamemode/modules/administration/submodules/permissions/commands.lua
+++ b/gamemode/modules/administration/submodules/permissions/commands.lua
@@ -2,7 +2,7 @@
     adminOnly = true,
     privilege = "Toggle Permakill",
     desc = "togglePermakillDesc",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     AdminStick = {
         Name = "adminStickTogglePermakillName",
         Category = "characterManagement",
@@ -196,7 +196,7 @@ lia.command.add("playsound", {
     superAdminOnly = true,
     privilege = "Play Sounds",
     desc = "playSoundDesc",
-    syntax = "[player Player Name] [string Sound]",
+    syntax = "[player Name] [string Sound]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local sound = arguments[2]
@@ -247,7 +247,7 @@ lia.command.add("forcefallover", {
     adminOnly = true,
     privilege = "Force Fallover",
     desc = "forceFalloverDesc",
-    syntax = "[player Player Name] [number Time optional]",
+    syntax = "[player Name] [number Time optional]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -291,7 +291,7 @@ lia.command.add("forcegetup", {
     adminOnly = true,
     privilege = "Force GetUp",
     desc = "forceGetUpDesc",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -417,7 +417,7 @@ lia.command.add("checkinventory", {
     adminOnly = true,
     privilege = "Check Inventories",
     desc = "checkInventoryDesc",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     AdminStick = {
         Name = "adminStickCheckInventoryName",
         Category = "characterManagement",
@@ -451,7 +451,7 @@ lia.command.add("flaggive", {
     adminOnly = true,
     privilege = "Manage Flags",
     desc = "flagGiveDesc",
-    syntax = "[player Player Name] [string Flags]",
+    syntax = "[player Name] [string Flags]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -485,7 +485,7 @@ lia.command.add("flaggiveall", {
     adminOnly = true,
     privilege = "Manage Flags",
     desc = "giveAllFlagsDesc",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     AdminStick = {
         Name = "adminStickGiveAllFlagsName",
         Category = "characterManagement",
@@ -513,7 +513,7 @@ lia.command.add("flagtakeall", {
     adminOnly = true,
     privilege = "Manage Flags",
     desc = "takeAllFlagsDesc",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     AdminStick = {
         Name = "adminStickTakeAllFlagsName",
         Category = "characterManagement",
@@ -546,7 +546,7 @@ lia.command.add("flagtake", {
     adminOnly = true,
     privilege = "Manage Flags",
     desc = "flagTakeDesc",
-    syntax = "[player Player Name] [string Flags]",
+    syntax = "[player Name] [string Flags]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -736,7 +736,7 @@ lia.command.add("clearinv", {
     superAdminOnly = true,
     privilege = "Manage Characters",
     desc = "clearInvDesc",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     AdminStick = {
         Name = "adminStickClearInventoryName",
         Category = "characterManagement",
@@ -759,7 +759,7 @@ lia.command.add("charkick", {
     adminOnly = true,
     privilege = "Kick Characters",
     desc = "kickCharDesc",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     AdminStick = {
         Name = "adminStickKickCharacterName",
         Category = "characterManagement",
@@ -791,7 +791,7 @@ lia.command.add("freezeallprops", {
     superAdminOnly = true,
     privilege = "Manage Characters",
     desc = "freezeAllPropsDesc",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -869,7 +869,7 @@ lia.command.add("checkmoney", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = "checkMoneyDesc",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     AdminStick = {
         Name = "adminStickCheckMoneyName",
         Category = "characterManagement",
@@ -892,7 +892,7 @@ lia.command.add("listbodygroups", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = "listBodygroupsDesc",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -937,7 +937,7 @@ lia.command.add("charsetspeed", {
     adminOnly = true,
     privilege = "Manage Character Stats",
     desc = "setSpeedDesc",
-    syntax = "[player Player Name] [number Speed optional]",
+    syntax = "[player Name] [number Speed optional]",
     AdminStick = {
         Name = "adminStickSetCharSpeedName",
         Category = "characterManagement",
@@ -960,7 +960,7 @@ lia.command.add("charsetmodel", {
     adminOnly = true,
     privilege = "Manage Character Information",
     desc = "setModelDesc",
-    syntax = "[player Player Name] [string Model optional]",
+    syntax = "[player Name] [string Model optional]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -980,7 +980,7 @@ lia.command.add("chargiveitem", {
     superAdminOnly = true,
     privilege = "Manage Items",
     desc = "giveItemDesc",
-    syntax = "[player Player Name] [item Item Name]",
+    syntax = "[player Name] [item Item Name]",
     AdminStick = {
         Name = "adminStickGiveItemName",
         Category = "characterManagement",
@@ -1029,7 +1029,7 @@ lia.command.add("charsetdesc", {
     adminOnly = true,
     privilege = "Manage Character Information",
     desc = "setDescDesc",
-    syntax = "[player Player Name] [string Description optional]",
+    syntax = "[player Name] [string Description optional]",
     AdminStick = {
         Name = "adminStickSetCharDescName",
         Category = "characterManagement",
@@ -1059,7 +1059,7 @@ lia.command.add("charsetname", {
     adminOnly = true,
     privilege = "Manage Character Information",
     desc = "setNameDesc",
-    syntax = "[player Player Name] [string New Name optional]",
+    syntax = "[player Name] [string New Name optional]",
     AdminStick = {
         Name = "adminStickSetCharNameName",
         Category = "characterManagement",
@@ -1084,7 +1084,7 @@ lia.command.add("charsetscale", {
     adminOnly = true,
     privilege = "Manage Character Stats",
     desc = "setScaleDesc",
-    syntax = "[player Player Name] [number Scale optional]",
+    syntax = "[player Name] [number Scale optional]",
     AdminStick = {
         Name = "adminStickSetCharScaleName",
         Category = "characterManagement",
@@ -1108,7 +1108,7 @@ lia.command.add("charsetjump", {
     adminOnly = true,
     privilege = "Manage Character Stats",
     desc = "setJumpDesc",
-    syntax = "[player Player Name] [number Power optional]",
+    syntax = "[player Name] [number Power optional]",
     AdminStick = {
         Name = "adminStickSetCharJumpName",
         Category = "characterManagement",
@@ -1132,7 +1132,7 @@ lia.command.add("charsetbodygroup", {
     adminOnly = true,
     privilege = "Manage Bodygroups",
     desc = "setBodygroupDesc",
-    syntax = "[player Player Name] [string BodyGroup Name] [number Value]",
+    syntax = "[player Name] [string BodyGroup Name] [number Value]",
     onRun = function(client, arguments)
         local name = arguments[1]
         local bodyGroup = arguments[2]
@@ -1161,7 +1161,7 @@ lia.command.add("charsetskin", {
     adminOnly = true,
     privilege = "Manage Character Stats",
     desc = "setSkinDesc",
-    syntax = "[player Player Name] [number Skin]",
+    syntax = "[player Name] [number Skin]",
     AdminStick = {
         Name = "adminStickSetCharSkinName",
         Category = "characterManagement",
@@ -1187,7 +1187,7 @@ lia.command.add("charsetmoney", {
     superAdminOnly = true,
     privilege = "Manage Characters",
     desc = "setMoneyDesc",
-    syntax = "[player Player Name] [number Amount]",
+    syntax = "[player Name] [number Amount]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local amount = tonumber(arguments[2])
@@ -1211,7 +1211,7 @@ lia.command.add("charaddmoney", {
     superAdminOnly = true,
     privilege = "Manage Characters",
     desc = "addMoneyDesc",
-    syntax = "[player Player Name] [number Amount]",
+    syntax = "[player Name] [number Amount]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local amount = tonumber(arguments[2])
@@ -1286,7 +1286,7 @@ lia.command.add("forcesay", {
     superAdminOnly = true,
     privilege = "Force Say",
     desc = "forceSayDesc",
-    syntax = "[player Player Name] [string Message]",
+    syntax = "[player Name] [string Message]",
     AdminStick = {
         Name = "forceSayName",
         Category = "moderationTools",
@@ -1327,7 +1327,7 @@ lia.command.add("getmodel", {
 
 lia.command.add("pm", {
     desc = "pmDesc",
-    syntax = "[player Player Name] [string Message]",
+    syntax = "[player Name] [string Message]",
     onRun = function(client, arguments)
         if not lia.config.get("AllowPMs") then
             client:notifyLocalized("pmsDisabled")
@@ -1355,7 +1355,7 @@ lia.command.add("chargetmodel", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = "getCharModelDesc",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     AdminStick = {
         Name = "adminStickGetCharModelName",
         Category = "characterManagement",
@@ -1389,7 +1389,7 @@ lia.command.add("checkflags", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = "checkFlagsDesc",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     AdminStick = {
         Name = "adminStickGetCharFlagsName",
         Category = "characterManagement",
@@ -1416,7 +1416,7 @@ lia.command.add("chargetname", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = "getCharNameDesc",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     AdminStick = {
         Name = "adminStickGetCharNameName",
         Category = "characterManagement",
@@ -1438,7 +1438,7 @@ lia.command.add("chargethealth", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = "getHealthDesc",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     AdminStick = {
         Name = "adminStickGetCharHealthName",
         Category = "characterManagement",
@@ -1460,7 +1460,7 @@ lia.command.add("chargetmoney", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = "getMoneyDesc",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     AdminStick = {
         Name = "adminStickGetCharMoneyName",
         Category = "characterManagement",
@@ -1483,7 +1483,7 @@ lia.command.add("chargetinventory", {
     adminOnly = true,
     privilege = "Get Character Info",
     desc = "getInventoryDesc",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     AdminStick = {
         Name = "adminStickGetCharInventoryName",
         Category = "characterManagement",

--- a/gamemode/modules/administration/submodules/tickets/commands.lua
+++ b/gamemode/modules/administration/submodules/tickets/commands.lua
@@ -2,7 +2,7 @@
     adminOnly = true,
     privilege = "View Claims",
     desc = "plyViewClaimsDesc",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     AdminStick = {
         Name = "viewTicketClaims",
         Category = "moderationTools",

--- a/gamemode/modules/attributes/commands.lua
+++ b/gamemode/modules/attributes/commands.lua
@@ -1,7 +1,7 @@
 ﻿lia.command.add("charsetattrib", {
     superAdminOnly = true,
     desc = "setAttributes",
-    syntax = "[player Player Name] [string Attribute Name] [number Level]",
+    syntax = "[player Name] [string Attribute Name] [number Level]",
     privilege = "Manage Attributes",
     AdminStick = {
         Name = "setAttributes",
@@ -36,7 +36,7 @@
 lia.command.add("checkattributes", {
     adminOnly = true,
     desc = "checkAttributes",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     privilege = "Manage Attributes",
     AdminStick = {
         Name = "checkAttributes",
@@ -98,7 +98,7 @@ lia.command.add("checkattributes", {
 lia.command.add("charaddattrib", {
     superAdminOnly = true,
     desc = "addAttributes",
-    syntax = "[player Player Name] [string Attribute Name] [number Level]",
+    syntax = "[player Name] [string Attribute Name] [number Level]",
     privilege = "Manage Attributes",
     AdminStick = {
         Name = "addAttributes",

--- a/gamemode/modules/chatbox/commands.lua
+++ b/gamemode/modules/chatbox/commands.lua
@@ -4,7 +4,7 @@ lia.command.add("banooc", {
     adminOnly = true,
     privilege = "Ban OOC",
     desc = "banOOCCommandDesc",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     AdminStick = {
         Name = "banOOCCommandName",
         Category = "moderationTools",
@@ -28,7 +28,7 @@ lia.command.add("unbanooc", {
     adminOnly = true,
     privilege = "Unban OOC",
     desc = "unbanOOCCommandDesc",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     AdminStick = {
         Name = "unbanOOCCommandName",
         Category = "moderationTools",

--- a/gamemode/modules/chatbox/libraries/shared.lua
+++ b/gamemode/modules/chatbox/libraries/shared.lua
@@ -211,7 +211,7 @@ lia.chat.register("roll", {
 })
 
 lia.chat.register("pm", {
-    syntax = "[string Player Name] [string Message]",
+    syntax = "[player Name] [string Message]",
     desc = "pmDesc",
     format = "pmFormat",
     color = Color(249, 211, 89),

--- a/gamemode/modules/inventory/commands.lua
+++ b/gamemode/modules/inventory/commands.lua
@@ -2,7 +2,7 @@
     adminOnly = true,
     privilege = "Set Inventory Size",
     desc = "updateInventorySizeDesc",
-    syntax = "[player Player Name]",
+    syntax = "[player Name]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -42,7 +42,7 @@ lia.command.add("setinventorysize", {
     adminOnly = true,
     privilege = "Set Inventory Size",
     desc = "setInventorySizeDesc",
-    syntax = "[player Player Name] [number Width] [number Height]",
+    syntax = "[player Name] [number Width] [number Height]",
     onRun = function(client, args)
         local target = lia.util.findPlayer(client, args[1])
         if not target or not IsValid(target) then

--- a/gamemode/modules/teams/commands.lua
+++ b/gamemode/modules/teams/commands.lua
@@ -252,7 +252,7 @@ lia.command.add("setclass", {
     adminOnly = true,
     privilege = "Manage Classes",
     desc = "setClassDesc",
-    syntax = "[player Player Name] [class Class]",
+    syntax = "[player Name] [class Class]",
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then


### PR DESCRIPTION
## Summary
- update admin commands to use [type Name] format consistently
- mark optional arguments correctly
- remove unused jail duration parameter
- clarify that blindfadeall's time argument is optional
- replace remaining `Player Name` tokens with `Name` for consistency
- fix leftover player syntax in SAM compatibility library

## Testing
- `grep -r "syntax = \"<" gamemode | wc -l`
- `grep -n "syntax = \"<" gamemode/modules/administration/commands.lua`

------
https://chatgpt.com/codex/tasks/task_e_687ca13d925483278cfb6ea13f1459ea