### PR TITLE
Remove ESP toggle, auto-enable in noclip

### DIFF
--- a/gamemode/modules/administration/submodules/permissions/config.lua
+++ b/gamemode/modules/administration/submodules/permissions/config.lua
@@ -4,15 +4,6 @@
     type = "Boolean"
 })
 
-lia.option.add("espActive", "ESP Active", "Enable ESP to highlight entities", false, nil, {
-    category = "ESP",
-    visible = function()
-        local ply = LocalPlayer()
-        if not IsValid(ply) then return false end
-        return ply:isStaffOnDuty() or ply:hasPrivilege("Staff Permissions - No Clip Outside Staff Character")
-    end
-})
-
 lia.option.add("espPlayers", "ESP Players", "Enable ESP for players", false, nil, {
     category = "ESP",
     visible = function()

--- a/gamemode/modules/administration/submodules/permissions/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/client.lua
@@ -9,10 +9,9 @@ function MODULE:PrePlayerDraw(client)
 end
 
 function MODULE:HUDPaint()
-    if not lia.option.get("espActive") then return end
     local client = LocalPlayer()
     if not client:getChar() or not client:IsValid() or not client:IsPlayer() then return end
-    if not client:isNoClipping() and not client:hasValidVehicle() then return end
+    if not client:isNoClipping() then return end
     if not (client:hasPrivilege("Staff Permissions - No Clip ESP Outside Staff Character") or client:isStaffOnDuty()) then return end
     local marginx, marginy = ScrW() * 0.1, ScrH() * 0.1
     local maxDistanceSq = 4096


### PR DESCRIPTION
## Summary
- remove the `espActive` option from permissions config
- enable ESP automatically while noclipping if you have permission

## Testing
- `luacheck gamemode --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cb99c5b9c8327ac8b4780ed0d25c8