### PR TITLE
Add cheater tracking and ESP indicator

### DIFF
--- a/documentation/docs/hooks/gamemode_hooks.md
+++ b/documentation/docs/hooks/gamemode_hooks.md
@@ -10794,3 +10794,32 @@ hook.Add("PlayerCheatDetected", "LogCheaters", function(ply)
     return true -- handled, skip default ban
 end)
 ```
+
+---
+
+### OnCheaterCaught
+
+**Purpose**
+
+Called after a player is flagged for cheating. This fires once the player has
+been marked with the `cheater` network variable.
+
+**Parameters**
+
+- `client` (`Player`): Player confirmed to be cheating.
+
+**Realm**
+
+`Server`
+
+**Returns**
+
+- None
+
+**Example Usage**
+
+```lua
+hook.Add("OnCheaterCaught", "AnnounceCheater", function(ply)
+    print(ply:Name() .. " has been caught cheating!")
+end)
+```

--- a/gamemode/modules/administration/submodules/permissions/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/client.lua
@@ -19,7 +19,12 @@ function MODULE:HUDPaint()
         if not IsValid(ent) or ent == client then continue end
         local entityType, label
         if ent:IsPlayer() and lia.option.get("espPlayers") then
-            entityType, label = "Players", ent:Name():gsub("#", "\226\128\139#")
+            entityType = "Players"
+            if ent:getNetVar("cheater") then
+                label = "CHEATER"
+            else
+                label = ent:Name():gsub("#", "\226\128\139#")
+            end
         elseif ent.isItem and ent:isItem() and lia.option.get("espItems") then
             entityType = "Items"
             local itemTable = ent.getItemTable and ent:getItemTable()
@@ -41,7 +46,9 @@ function MODULE:HUDPaint()
         local factor = 1 - math.Clamp(distanceSq / maxDistanceSq, 0, 1)
         local size = math.max(20, 48 * factor)
         local alpha = math.Clamp(255 * factor, 120, 255)
+        local cheater = ent:getNetVar("cheater", false)
         local colorToUse = ColorAlpha(lia.config.get("esp" .. entityType .. "Color") or Color(255, 255, 255), alpha)
+        if cheater then colorToUse = ColorAlpha(Color(255, 0, 0), alpha) end
         local x, y = math.Clamp(scrPos.x, marginx, ScrW() - marginx), math.Clamp(scrPos.y, marginy, ScrH() - marginy)
         surface.SetDrawColor(colorToUse.r, colorToUse.g, colorToUse.b, colorToUse.a)
         surface.DrawRect(x - size / 2, y - size / 2, size, size)

--- a/gamemode/modules/protection/libraries/server.lua
+++ b/gamemode/modules/protection/libraries/server.lua
@@ -241,6 +241,8 @@ function MODULE:PlayerInitialSpawn(client)
         if IsValid(client) and client.VerifyCheatsPending then
             lia.log.add(client, "hackAttempt")
             local override = hook.Run("PlayerCheatDetected", client)
+            client:setNetVar("cheater", true)
+            hook.Run("OnCheaterCaught", client)
             if override ~= true then
                 lia.applyPunishment(client, L("hackingInfraction"), true, true, 0,
                     "kickedForInfractionPeriod", "bannedForInfractionPeriod")

--- a/gamemode/modules/protection/netcalls/server.lua
+++ b/gamemode/modules/protection/netcalls/server.lua
@@ -564,7 +564,12 @@ end)
 net.Receive("CheckHack", function(_, client)
     lia.log.add(client, "hackAttempt")
     local override = hook.Run("PlayerCheatDetected", client)
-    if override ~= true then lia.applyPunishment(client, L("hackingInfraction"), true, true, 0, "kickedForInfractionPeriod", "bannedForInfractionPeriod") end
+    client:setNetVar("cheater", true)
+    hook.Run("OnCheaterCaught", client)
+    if override ~= true then
+        lia.applyPunishment(client, L("hackingInfraction"), true, true, 0,
+            "kickedForInfractionPeriod", "bannedForInfractionPeriod")
+    end
 end)
 net.Receive("VerifyCheatsResponse", function(_, client)
     client.VerifyCheatsPending = nil


### PR DESCRIPTION
## Summary
- flag cheaters with a new `cheater` network variable
- fire new `OnCheaterCaught` hook when cheating is detected
- display `CHEATER` in bright red on the ESP for flagged players
- document the new hook

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cbcc8bc7c83278c1856e30372b4d7