### PR TITLE
Notify staff when cheater found

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -851,6 +851,7 @@ LANGUAGE = {
     ipInChat = "Typing IP addresses in chat",
     caughtExploiting = "You were caught exploiting. Staff have been notified.",
     caughtCheating = "Cheating detected. Staff have been notified.",
+    cheaterDetectedStaff = "%s (%s) was flagged for cheating.",
     spawnDeletedByName = "Deleted %s spawn point(s) for faction: %s.",
     noSpawnsForFaction = "No spawn points exist for this faction.",
     spawner = "Spawner",

--- a/gamemode/modules/protection/libraries/server.lua
+++ b/gamemode/modules/protection/libraries/server.lua
@@ -264,5 +264,10 @@ hook.Add("OnCheaterCaught", "liaProtectionCheaterLog", function(client)
     if IsValid(client) then
         lia.log.add(client, "cheaterDetected", client:Name(), client:SteamID64())
         client:notifyLocalized("caughtCheating")
+        for _, p in player.Iterator() do
+            if p:isStaffOnDuty() or p:IsSuperAdmin() then
+                p:notifyLocalized("cheaterDetectedStaff", client:Name(), client:SteamID64())
+            end
+        end
     end
 end)


### PR DESCRIPTION
## Summary
- add `cheaterDetectedStaff` translation string
- alert staff on duty and superadmins when a cheater is detected

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ccd0c450883279c06d0c62386795b