### PR TITLE
Fix entity persistence support

### DIFF
--- a/documentation/docs/meta/entity.md
+++ b/documentation/docs/meta/entity.md
@@ -152,7 +152,7 @@ Determines if the entity is persistent in Lilia.
 ```lua
 -- Save this entity across map resets if persistent
 if ent:isLiliaPersistent() then
-    lia.persist.saveEntity(ent)
+    -- Lilia will automatically add it to persistence
 end
 ```
 

--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -661,23 +661,28 @@ end
 
 function GM:OnEntityCreated(ent)
     if not IsValid(ent) or not ent:isLiliaPersistent() then return end
+
     local saved = lia.data.get("persistence", {}) or {}
     local seen = {}
-    for _, e in ipairs(saved) do
-        seen[makeKey(e)] = true
+    for _, data in ipairs(saved) do
+        seen[makeKey(data)] = true
     end
 
     local key = makeKey(ent)
-    if not seen[key] then
-        saved[#saved + 1] = {
-            pos = encodeVector(ent:GetPos()),
-            class = ent:GetClass(),
-            model = ent:GetModel(),
-            angles = encodeAngle(ent:GetAngles())
-        }
+    if seen[key] then return end
 
-        lia.data.set("persistence", saved)
-    end
+    local entData = {
+        pos = encodeVector(ent:GetPos()),
+        class = ent:GetClass(),
+        model = ent:GetModel(),
+        angles = encodeAngle(ent:GetAngles())
+    }
+
+    local extra = hook.Run("GetEntitySaveData", ent)
+    if extra ~= nil then entData.data = extra end
+    saved[#saved + 1] = entData
+    lia.data.set("persistence", saved)
+    hook.Run("OnEntityPersisted", ent, entData)
 end
 
 local hasChttp = util.IsBinaryModuleInstalled("chttp")

--- a/gamemode/core/meta/entity.lua
+++ b/gamemode/core/meta/entity.lua
@@ -24,6 +24,10 @@ function entityMeta:isSimfphysCar()
 end
 
 function entityMeta:isLiliaPersistent()
+    if self.GetPersistent and self:GetPersistent() then
+        return true
+    end
+
     return self.IsLeonNPC or self.IsPersistent
 end
 

--- a/gamemode/modules/inventory/submodules/storage/entities/entities/lia_storage/shared.lua
+++ b/gamemode/modules/inventory/submodules/storage/entities/entities/lia_storage/shared.lua
@@ -5,6 +5,7 @@ ENT.Category = "Lilia"
 ENT.Spawnable = false
 ENT.isStorageEntity = true
 ENT.DrawEntityInfo = true
+ENT.IsPersistent = true
 function ENT:getInv()
     return lia.inventory.instances[self:getNetVar("id")]
 end

--- a/gamemode/modules/inventory/submodules/storage/libraries/server.lua
+++ b/gamemode/modules/inventory/submodules/storage/libraries/server.lua
@@ -62,25 +62,7 @@ function MODULE:CanSaveData()
 end
 
 function MODULE:SaveData()
-    local data = {}
-    for _, entity in ipairs(ents.FindByClass("lia_storage")) do
-        if hook.Run("CanSaveData", entity, entity:getInv()) == false then
-            entity.liaForceDelete = true
-            continue
-        end
-
-        if entity:getInv() then
-            data[#data + 1] = {
-                encodeVector(entity:GetPos()),
-                encodeAngle(entity:GetAngles()),
-                entity:getNetVar("id"),
-                entity:GetModel():lower(),
-                entity.password
-            }
-        end
-    end
-
-    self:setData(data)
+    GAMEMODE.SaveData(GAMEMODE)
 end
 
 function MODULE:StorageItemRemoved()
@@ -88,41 +70,7 @@ function MODULE:StorageItemRemoved()
 end
 
 function MODULE:LoadData()
-    local data = self:getData()
-    if not data then return end
-    for _, info in ipairs(data) do
-        local position, angles, invID, model, password = unpack(info)
-        position = decodeVector(position)
-        angles = decodeAngle(angles)
-        local storageDef = self.StorageDefinitions[model]
-        if not storageDef then continue end
-        local storage = ents.Create("lia_storage")
-        storage:SetPos(position)
-        storage:SetAngles(angles)
-        storage:Spawn()
-        storage:SetModel(model)
-        storage:SetSolid(SOLID_VPHYSICS)
-        storage:PhysicsInit(SOLID_VPHYSICS)
-        if password then
-            storage.password = password
-            storage:setNetVar("locked", true)
-        end
-
-        lia.inventory.loadByID(invID):next(function(inventory)
-            if inventory and IsValid(storage) then
-                inventory.isStorage = true
-                storage:setInventory(inventory)
-                hook.Run("StorageRestored", storage, inventory)
-            elseif IsValid(storage) then
-                SafeRemoveEntityDelayed(storage, 1)
-            end
-        end)
-
-        local physObject = storage:GetPhysicsObject()
-        if physObject then physObject:EnableMotion() end
-    end
-
-    self.loadedData = true
+    -- storage restored by persistence
 end
 
 local PROHIBITED_ACTIONS = {
@@ -163,5 +111,33 @@ end
 
 function MODULE:StorageInventorySet(_, inventory, isCar)
     inventory:addAccessRule(isCar and RULES.AccessIfCarStorageReceiver or RULES.AccessIfStorageReceiver)
+end
+
+function MODULE:GetEntitySaveData(ent)
+    if ent:GetClass() ~= "lia_storage" then return end
+    return {
+        id = ent:getNetVar("id"),
+        password = ent.password
+    }
+end
+
+function MODULE:OnEntityLoaded(ent, data)
+    if ent:GetClass() ~= "lia_storage" or not data then return end
+    if data.password then
+        ent.password = data.password
+        ent:setNetVar("locked", true)
+    end
+    local invID = data.id
+    if invID then
+        lia.inventory.loadByID(invID):next(function(inventory)
+            if inventory and IsValid(ent) then
+                inventory.isStorage = true
+                ent:setInventory(inventory)
+                hook.Run("StorageRestored", ent, inventory)
+            elseif IsValid(ent) then
+                SafeRemoveEntityDelayed(ent, 1)
+            end
+        end)
+    end
 end
 return RULES

--- a/gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/shared.lua
+++ b/gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/shared.lua
@@ -8,6 +8,7 @@ ENT.isVendor = true
 ENT.NoPhysgun = true
 ENT.NoRemover = true
 ENT.DrawEntityInfo = true
+ENT.IsPersistent = true
 function ENT:setupVars()
     if SERVER then
         self:setNetVar("name", "John Doe")

--- a/gamemode/modules/inventory/submodules/vendor/libraries/server.lua
+++ b/gamemode/modules/inventory/submodules/vendor/libraries/server.lua
@@ -4,43 +4,11 @@ local decodeVector = lia.data.decodeVector
 local decodeAngle = lia.data.decodeAngle
 
 function MODULE:SaveData()
-    local data = {}
-    for _, v in ipairs(ents.FindByClass("lia_vendor")) do
-        data[#data + 1] = {
-            name = v:getNetVar("name"),
-            pos = encodeVector(v:GetPos()),
-            angles = encodeAngle(v:GetAngles()),
-            model = v:GetModel(),
-            items = v.items,
-            factions = v.factions,
-            classes = v.classes,
-            money = v.money,
-            flag = v:getNetVar("flag"),
-            scale = v:getNetVar("scale"),
-            welcomeMessage = v:getNetVar("welcomeMessage"),
-        }
-    end
-
-    self:setData(data)
-    lia.information(L("vendorSaved", table.Count(data)))
+    GAMEMODE.SaveData(GAMEMODE)
 end
 
 function MODULE:LoadData()
-    for _, v in ipairs(self:getData() or {}) do
-        local entity = ents.Create("lia_vendor")
-        entity:SetPos(decodeVector(v.pos))
-        entity:SetAngles(decodeAngle(v.angles))
-        entity:Spawn()
-        entity:SetModel(v.model)
-        entity:setNetVar("name", v.name)
-        entity:setNetVar("flag", v.flag)
-        entity:setNetVar("scale", v.scale or 0.5)
-        entity:setNetVar("welcomeMessage", v.welcomeMessage)
-        entity.items = v.items or {}
-        entity.factions = v.factions or {}
-        entity.classes = v.classes or {}
-        entity.money = v.money
-    end
+    -- vendors restored by persistence
 end
 
 function MODULE:OnCharTradeVendor(client, vendor, item, isSellingToVendor, _, _, isFailed)
@@ -211,4 +179,30 @@ function MODULE:PlayerAccessVendor(client, vendor)
             net.Send(client)
         end
     end
+end
+
+function MODULE:GetEntitySaveData(ent)
+    if ent:GetClass() ~= "lia_vendor" then return end
+    return {
+        name = ent:getNetVar("name"),
+        items = ent.items,
+        factions = ent.factions,
+        classes = ent.classes,
+        money = ent.money,
+        flag = ent:getNetVar("flag"),
+        scale = ent:getNetVar("scale"),
+        welcomeMessage = ent:getNetVar("welcomeMessage"),
+    }
+end
+
+function MODULE:OnEntityLoaded(ent, data)
+    if ent:GetClass() ~= "lia_vendor" or not data then return end
+    ent:setNetVar("name", data.name)
+    ent:setNetVar("flag", data.flag)
+    ent:setNetVar("scale", data.scale or 0.5)
+    ent:setNetVar("welcomeMessage", data.welcomeMessage)
+    ent.items = data.items or {}
+    ent.factions = data.factions or {}
+    ent.classes = data.classes or {}
+    ent.money = data.money
 end


### PR DESCRIPTION
## Summary
- inline persistent entity saving in `OnEntityCreated`
- recognize `Entity:GetPersistent()` inside `isLiliaPersistent`
- remove the unused persistence library
- update docs for automatic persistence
- make storage and vendor modules integrate with persistence

## Testing
- `luacheck gamemode/modules/inventory/submodules/vendor/libraries/server.lua gamemode/modules/inventory/submodules/storage/libraries/server.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cbfe0f9d883279e92d19089dd88f9