### PR TITLE
Remove comments from gamemode

### DIFF
--- a/gamemode/core/hooks/client.lua
+++ b/gamemode/core/hooks/client.lua
@@ -466,8 +466,8 @@ concommand.Add("weighpoint_stop", function() hook.Add("HUDPaint", "WeighPoint", 
 concommand.Add("dev_GetEntPos", function(client) if client:isStaff() then lia.information(client:getTracedEntity():GetPos().x, client:getTracedEntity():GetPos().y, client:getTracedEntity():GetPos().z) end end)
 concommand.Add("dev_GetEntAngles", function(client) if client:isStaff() then lia.information(math.ceil(client:getTracedEntity():GetAngles().x) .. ", " .. math.ceil(client:getTracedEntity():GetAngles().y) .. ", " .. math.ceil(client:getTracedEntity():GetAngles().z)) end end)
 concommand.Add("dev_GetRoundEntPos", function(client) if client:isStaff() then lia.information(math.ceil(client:getTracedEntity():GetPos().x) .. ", " .. math.ceil(client:getTracedEntity():GetPos().y) .. ", " .. math.ceil(client:getTracedEntity():GetPos().z)) end end)
-concommand.Add("dev_GetPos", function(client) if client:isStaff() then lia.information(math.ceil(client:GetPos().x) .. ", " .. math.ceil(client:GetPos().y) .. ", " .. math.ceil(client:GetPos().z)) end end)
--- Voice range visualization ----------------------------
+    concommand.Add("dev_GetPos", function(client) if client:isStaff() then lia.information(math.ceil(client:GetPos().x) .. ", " .. math.ceil(client:GetPos().y) .. ", " .. math.ceil(client:GetPos().z)) end end)
+
 local VoiceRanges = {
     Whispering = 120,
     Talking = 300,

--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -543,7 +543,7 @@ local function makeKey(ent)
     else
         class = ent.class
         if ent.pos then
-            pos = decodeVector(ent.pos) -- handle encoded table
+            pos = decodeVector(ent.pos)
         elseif ent.GetPos then
             pos = ent:GetPos()
         end


### PR DESCRIPTION
## Summary
- remove a leftover comment from client hook
- remove inline comment from server hook

## Testing
- `grep -nR -- "--" gamemode | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_687ce2a2892c8327b7d0506145f57db1