### PR TITLE
Update persistence data when editing vendors

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -685,6 +685,30 @@ function GM:OnEntityCreated(ent)
     hook.Run("OnEntityPersisted", ent, entData)
 end
 
+function GM:UpdateEntityPersistence(ent)
+    if not IsValid(ent) or not ent:isLiliaPersistent() then return end
+    local saved = lia.data.get("persistence", {}) or {}
+    local key = makeKey(ent)
+    for i, data in ipairs(saved) do
+        if makeKey(data) == key then
+            data.pos = encodeVector(ent:GetPos())
+            data.class = ent:GetClass()
+            data.model = ent:GetModel()
+            data.angles = encodeAngle(ent:GetAngles())
+            local extra = hook.Run("GetEntitySaveData", ent)
+            if extra ~= nil then
+                data.data = extra
+            else
+                data.data = nil
+            end
+
+            lia.data.set("persistence", saved)
+            hook.Run("OnEntityPersistUpdated", ent, data)
+            return
+        end
+    end
+end
+
 local hasChttp = util.IsBinaryModuleInstalled("chttp")
 if hasChttp then require("chttp") end
 local function fetchURL(url, onSuccess, onError)

--- a/gamemode/modules/inventory/submodules/vendor/netcalls/server.lua
+++ b/gamemode/modules/inventory/submodules/vendor/netcalls/server.lua
@@ -12,6 +12,7 @@ net.Receive("VendorEdit", function(_, client)
     if not IsValid(vendor) or not EDITOR[key] then return end
     lia.log.add(client, "vendorEdit", vendor, key)
     EDITOR[key](vendor, client, key)
+    hook.Run("UpdateEntityPersistence", vendor)
     MODULE:SaveData()
 end)
 


### PR DESCRIPTION
## Summary
- add `GM:UpdateEntityPersistence` hook
- sync persistence when a vendor is edited

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ce502d8dc8327865c34c9e5b3962a