### PR TITLE
Fix bots command

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -891,6 +891,10 @@ local hl2Weapons = {
     "weapon_rpg"
 }
 
+local function SpawnBot()
+    player.CreateNextBot("Bot_" .. CurTime())
+end
+
 local function SpawnArmedBot()
     local bot = player.CreateNextBot("ArmedBot_" .. CurTime())
     if IsValid(bot) then
@@ -907,7 +911,7 @@ concommand.Add("bots", function(ply)
     local toSpawn = maxPlayers - currentCount
     if toSpawn <= 0 then return end
     timer.Remove("BotsSpawnTimer")
-    timer.Create("BotsSpawnTimer", 1.5, toSpawn, function() SpawnArmedBot() end)
+    timer.Create("BotsSpawnTimer", 1.5, toSpawn, function() SpawnBot() end)
 end)
 
 concommand.Add("armed_bot", function(ply)


### PR DESCRIPTION
## Summary
- ensure `bots` console command spawns normal bots
- keep `armed_bot` and `armed_bots` for armed bots

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cea959820832781efa89cce2a414d