### PR TITLE
Add auto-warning when cheater flagged

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -851,6 +851,7 @@ LANGUAGE = {
     ipInChat = "Typing IP addresses in chat",
     caughtExploiting = "You were caught exploiting. Staff have been notified.",
     caughtCheating = "Cheating detected. Staff have been notified.",
+    cheaterWarningReason = "Cheating or exploiting",
     cheaterDetectedStaff = "%s (%s) was flagged for cheating.",
     spawnDeletedByName = "Deleted %s spawn point(s) for faction: %s.",
     noSpawnsForFaction = "No spawn points exist for this faction.",

--- a/gamemode/modules/protection/commands.lua
+++ b/gamemode/modules/protection/commands.lua
@@ -21,6 +21,17 @@ lia.command.add("togglecheater", {
         else
             client:notifyLocalized("cheaterMarked", target:Name())
             target:notifyLocalized("cheaterMarkedByAdmin")
+            local warning = {
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                reason = L("cheaterWarningReason"),
+                admin = client:Nick() .. " (" .. client:SteamID() .. ")"
+            }
+            local warns = target:getLiliaData("warns") or {}
+            table.insert(warns, warning)
+            target:setLiliaData("warns", warns)
+            target:notifyLocalized("playerWarned", warning.admin, warning.reason)
+            client:notifyLocalized("warningIssued", target:Nick())
+            hook.Run("WarningIssued", client, target, warning.reason, #warns)
         end
 
         lia.log.add(client, "cheaterToggle", target:Name(), isCheater and "Unmarked" or "Marked")


### PR DESCRIPTION
## Summary
- add `cheaterWarningReason` localization string
- issue a warning automatically when a player is marked as a cheater using `togglecheater` command

## Testing
- `luacheck` not installed


------
https://chatgpt.com/codex/tasks/task_e_687ceca22db88327aeb33bcd8dc60e6e