### PR TITLE
Fix spawnmenu drawing error

### DIFF
--- a/gamemode/core/derma/panels/extended_spawnmenu.lua
+++ b/gamemode/core/derma/panels/extended_spawnmenu.lua
@@ -586,13 +586,15 @@ function PANEL:Paint()
     local _, th11 = DrawText(L("filesUnusedDelete"), "AddonInfo_Text", 0, y, color_white)
     y = y + th11
     local maxW2 = 0
+    local th12Height = 0
     for _, e in ipairs(self.workshopWasteFiles) do
         local tw6, th12 = DrawText(GetSize(e[2]) .. "    ", "AddonInfo_Small", 0, y, Color(220, 220, 220))
         maxW2 = math.max(maxW2, tw6)
+        th12Height = th12
         y = y + th12
     end
 
-    y = y - #self.workshopWasteFiles * th12
+    y = y - #self.workshopWasteFiles * th12Height
     for _, e in ipairs(self.workshopWasteFiles) do
         local _, th13 = DrawText(e[1], "AddonInfo_Small", maxW2, y, color_white)
         y = y + th13


### PR DESCRIPTION
## Summary
- fix undefined `th12` variable in extended spawn menu panel

## Testing
- `apt-get update` *(fails: repository access requires internet)*

------
https://chatgpt.com/codex/tasks/task_e_687cefa4d620832791a208ec490ce609