### PR TITLE
Persist entities per-row

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -263,6 +263,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS `lia_config`;
     DROP TABLE IF EXISTS `lia_logs`;
     DROP TABLE IF EXISTS `lia_bans`;
+    DROP TABLE IF EXISTS `lia_persistence`;
 ]])
             local done = 0
             for i = 1, #queries do
@@ -289,6 +290,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS lia_config;
     DROP TABLE IF EXISTS lia_logs;
     DROP TABLE IF EXISTS lia_bans;
+    DROP TABLE IF EXISTS lia_persistence;
 ]], realCallback)
     end
 end
@@ -833,6 +835,7 @@ function GM:DatabaseConnected()
     if SERVER then
         lia.log.loadTables()
         lia.data.loadTables()
+        lia.data.loadPersistence()
     end
 end
 


### PR DESCRIPTION
## Summary
- refactor persistence helpers into `lia.data`
- load persistence table at DB connection
- save and load per-entity rows via new `lia.data` methods with dynamic columns
- remove unused persistence library

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cee708a04832797a87acd986b305a