### PR TITLE
Add admin usergroup management

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -1184,4 +1184,8 @@ Reload: Drop]],
     oilPumpNext = "Ready in %s",
     oilPumping = "Pumping oil...",
     weaponsDesc = "A Weapon.",
+    userGroups = "User Groups",
+    addGroup = "Add Group",
+    removeGroup = "Remove Group",
+    groupName = "Group Name",
 }

--- a/gamemode/modules/administration/submodules/usergroups/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/usergroups/libraries/client.lua
@@ -1,0 +1,95 @@
+-- usergroup management
+local ugPanel
+local ugPrivileges
+
+local function buildGroupsUI(panel, groups)
+    panel:Clear()
+    local sidebar = panel:Add("DScrollPanel")
+    sidebar:Dock(LEFT)
+    sidebar:SetWide(200)
+    sidebar:DockMargin(0, 20, 20, 20)
+
+    local addBtn = sidebar:Add("liaMediumButton")
+    addBtn:Dock(TOP)
+    addBtn:SetText(L("addGroup"))
+    addBtn:SetTall(30)
+    addBtn:DockMargin(0, 0, 0, 10)
+    addBtn.DoClick = function()
+        Derma_StringRequest(L("addGroup"), L("groupName"), "", function(text)
+            net.Start("liaGroupCreate")
+            net.WriteString(text)
+            net.SendToServer()
+        end)
+    end
+
+    local removeBtn = sidebar:Add("liaMediumButton")
+    removeBtn:Dock(TOP)
+    removeBtn:SetText(L("removeGroup"))
+    removeBtn:SetTall(30)
+    removeBtn:DockMargin(0, 0, 0, 10)
+
+    local list = sidebar:Add("DListView")
+    list:Dock(FILL)
+    list:AddColumn(L("name"))
+
+    local content = panel:Add("DScrollPanel")
+    content:Dock(FILL)
+    content:DockMargin(10, 10, 10, 10)
+
+    local function populate(group)
+        content:Clear()
+        removeBtn:SetEnabled(group ~= "user" and group ~= "admin" and group ~= "superadmin")
+        for name in pairs(ugPrivileges or {}) do
+            local cb = content:Add("DCheckBoxLabel")
+            cb:Dock(TOP)
+            cb:SetText(name)
+            cb:SetValue(groups[group] and groups[group][name] and true or false)
+            cb.OnChange = function(_, val)
+                net.Start("liaGroupSetPermission")
+                net.WriteString(group)
+                net.WriteString(name)
+                net.WriteBool(val)
+                net.SendToServer()
+            end
+        end
+    end
+
+    removeBtn.DoClick = function()
+        local line = list:GetSelectedLine()
+        if not line then return end
+        local group = list:GetLine(line):GetColumnText(1)
+        if group == "user" or group == "admin" or group == "superadmin" then return end
+        net.Start("liaGroupDelete")
+        net.WriteString(group)
+        net.SendToServer()
+    end
+
+    list.OnRowSelected = function(_, _, row)
+        populate(row:GetColumnText(1))
+    end
+
+    for name in pairs(groups) do
+        list:AddLine(name)
+    end
+end
+
+net.Receive("liaGroupsData", function()
+    local groups = net.ReadTable()
+    ugPrivileges = net.ReadTable()
+    lia.admin.groups = groups
+    if IsValid(ugPanel) then buildGroupsUI(ugPanel, groups) end
+end)
+
+net.Receive("lilia_updateAdminGroups", function()
+    lia.admin.groups = net.ReadTable()
+    if IsValid(ugPanel) then buildGroupsUI(ugPanel, lia.admin.groups) end
+end)
+
+function MODULE:CreateMenuButtons(tabs)
+    tabs[L("userGroups")] = function(panel)
+        if not LocalPlayer():hasPrivilege("Staff Permissions - Manage UserGroups") then return end
+        ugPanel = panel
+        net.Start("liaGroupsRequest")
+        net.SendToServer()
+    end
+end

--- a/gamemode/modules/administration/submodules/usergroups/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/usergroups/libraries/server.lua
@@ -1,0 +1,35 @@
+-- usergroup management
+net.Receive("liaGroupsRequest", function(_, client)
+    if not client:hasPrivilege("Staff Permissions - Manage UserGroups") then return end
+    net.Start("liaGroupsData")
+    net.WriteTable(lia.admin.groups)
+    net.WriteTable(CAMI.GetPrivileges() or {})
+    net.Send(client)
+end)
+
+net.Receive("liaGroupCreate", function(_, client)
+    if not client:hasPrivilege("Staff Permissions - Manage UserGroups") then return end
+    local name = string.Trim(net.ReadString())
+    if name == "" or lia.admin.groups[name] then return end
+    lia.admin.createGroup(name)
+end)
+
+net.Receive("liaGroupDelete", function(_, client)
+    if not client:hasPrivilege("Staff Permissions - Manage UserGroups") then return end
+    local name = net.ReadString()
+    if name == "user" or name == "admin" or name == "superadmin" then return end
+    lia.admin.removeGroup(name)
+end)
+
+net.Receive("liaGroupSetPermission", function(_, client)
+    if not client:hasPrivilege("Staff Permissions - Manage UserGroups") then return end
+    local group = net.ReadString()
+    local perm = net.ReadString()
+    local enable = net.ReadBool()
+    if not lia.admin.groups[group] then return end
+    if enable then
+        lia.admin.addPermission(group, perm)
+    else
+        lia.admin.removePermission(group, perm)
+    end
+end)

--- a/gamemode/modules/administration/submodules/usergroups/module.lua
+++ b/gamemode/modules/administration/submodules/usergroups/module.lua
@@ -1,0 +1,10 @@
+MODULE.name = "Usergroups"
+MODULE.author = "Samael"
+MODULE.discord = "@liliaplayer"
+MODULE.desc = "Provides an interface to manage administrative usergroups and permissions."
+MODULE.CAMIPrivileges = {
+    {
+        Name = "Staff Permissions - Manage UserGroups",
+        MinAccess = "superadmin",
+    },
+}


### PR DESCRIPTION
## Summary
- add UI strings for user group management
- implement admin usergroup management as a new submodule
- register a privilege for modifying user groups
- provide client UI and server netcalls for creating, deleting and editing groups

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cfcb808a08327b42b80201d96658e