### PR TITLE
Integrate CAMI groups

### DIFF
--- a/documentation/docs/libraries/lia.admin.md
+++ b/documentation/docs/libraries/lia.admin.md
@@ -36,7 +36,9 @@ Checks for third-party admin mods and returns `true` when the built-in system sh
 
 **Purpose**
 
-Loads stored admin groups and privileges from disk.
+Loads stored admin groups and privileges from disk. If CAMI usergroups are
+available, they will be used instead and the current CAMI permissions will be
+imported.
 
 **Parameters**
 


### PR DESCRIPTION
## Summary
- use CAMI usergroups if available and pull in permissions
- document CAMI integration for `lia.admin.load`

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d09864f888327a71e8700f8ea1ad5