### PR TITLE
Fix saving global data with nil keys

### DIFF
--- a/gamemode/core/libraries/data.lua
+++ b/gamemode/core/libraries/data.lua
@@ -138,10 +138,13 @@ if SERVER then
 
     function lia.data.set(key, value, global, ignoreMap)
         local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-        local map = ignoreMap and nil or game.GetMap()
+        local map = ignoreMap and NULL or game.GetMap()
         if global then
-            folder = nil
-            map = nil
+            folder = NULL
+            map = NULL
+        else
+            if folder == nil then folder = NULL end
+            if map == nil then map = NULL end
         end
 
         lia.data.stored[key] = value


### PR DESCRIPTION
## Summary
- avoid SQL syntax errors when saving global data

## Testing
- `luac -p gamemode/core/libraries/data.lua` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687d1473cc1c83279c4d14c0a43b69d5