### PR TITLE
Fix default F1 tab fallback

### DIFF
--- a/gamemode/core/derma/f1menu/cl_menu.lua
+++ b/gamemode/core/derma/f1menu/cl_menu.lua
@@ -135,7 +135,24 @@ function PANEL:Init()
     end
 
     self:MakePopup()
-    self:setActiveTab(lia.config.get("DefaultMenuTab"))
+    local defaultTab = lia.config.get("DefaultMenuTab", L("status"))
+    if not self.tabList[defaultTab] then
+        local statusKey = L("status")
+        if self.tabList[statusKey] then
+            defaultTab = statusKey
+        else
+            local keys = {}
+            for k in pairs(self.tabList) do
+                keys[#keys + 1] = k
+            end
+            if #keys > 0 then
+                defaultTab = keys[math.random(#keys)]
+            end
+        end
+    end
+    if defaultTab then
+        self:setActiveTab(defaultTab)
+    end
 end
 
 function PANEL:addTab(name, callback)


### PR DESCRIPTION
## Summary
- ensure the F1 menu picks a random tab when neither the configured default nor the Status tab exist

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_687d13efe5b8832792e7bfb7d40ecbf8