### PR TITLE
Fix path generation when folder/map are NULL

### DIFF
--- a/gamemode/core/libraries/data.lua
+++ b/gamemode/core/libraries/data.lua
@@ -184,7 +184,14 @@ if SERVER then
             hook.Run("OnDataSet", key, value, folder, map)
         end)
 
-        return "lilia/" .. (folder and folder .. "/" or "") .. (map and map .. "/" or "")
+        local path = "lilia/"
+        if folder and folder ~= NULL then
+            path = path .. folder .. "/"
+        end
+        if map and map ~= NULL then
+            path = path .. map .. "/"
+        end
+        return path
     end
 
     function lia.data.delete(key, global, ignoreMap)


### PR DESCRIPTION
## Summary
- handle `NULL` constants when building the data path

## Testing
- `luacheck --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d16d22e988327ad82a3f623b6e3ae