### PR TITLE
Fix color picker config timer

### DIFF
--- a/gamemode/core/libraries/config.lua
+++ b/gamemode/core/libraries/config.lua
@@ -730,12 +730,13 @@ hook.Add("PopulateConfigurationButtons", "liaConfigPopulate", function(pages)
                 end
 
                 apply.DoClick = function()
+                    local color = m:GetColor()
                     local t = "ConfigChange_" .. key .. "_" .. os.time()
                     timer.Create(t, 0.5, 1, function()
                         net.Start("cfgSet")
                         net.WriteString(key)
                         net.WriteString(name)
-                        net.WriteType(m:GetColor())
+                        net.WriteType(color)
                         net.SendToServer()
                     end)
 


### PR DESCRIPTION
## Summary
- fix error when closing color picker before network message is sent

## Testing
- `luacheck gamemode/core/libraries/config.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d2921fae483278d44f205cc5898c1