### PR TITLE
Fix persistence table cleanup

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -728,6 +728,19 @@ function GM:UpdateEntityPersistence(ent)
     end
 end
 
+function GM:EntityRemoved(ent)
+    if not IsValid(ent) or not ent:isLiliaPersistent() then return end
+    local saved = lia.data.getPersistence()
+    local key = makeKey(ent)
+    for i, data in ipairs(saved) do
+        if makeKey(data) == key then
+            table.remove(saved, i)
+            lia.data.savePersistence(saved)
+            break
+        end
+    end
+end
+
 local hasChttp = util.IsBinaryModuleInstalled("chttp")
 if hasChttp then require("chttp") end
 local function fetchURL(url, onSuccess, onError)


### PR DESCRIPTION
## Summary
- remove persisted entity record when entity is deleted

## Testing
- `luacheck gamemode --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d2a8d3f0883279554b0969e472e97