### PR TITLE
Ensure defaults persist in empty DB

### DIFF
--- a/gamemode/core/libraries/config.lua
+++ b/gamemode/core/libraries/config.lua
@@ -75,13 +75,19 @@ function lia.config.load()
                 for _, row in ipairs(rows) do
                     local decoded = util.JSONToTable(row._value)
                     lia.config.stored[row._key] = lia.config.stored[row._key] or {}
-                    lia.config.stored[row._key].value = decoded and decoded[1]
-                    existing[row._key] = true
+                    local value = decoded and decoded[1]
+                    if value == nil or value == "" then
+                        lia.config.stored[row._key].value = lia.config.stored[row._key].default
+                    else
+                        lia.config.stored[row._key].value = value
+                        existing[row._key] = true
+                    end
                 end
 
                 local inserts = {}
                 for k, v in pairs(lia.config.stored) do
                     if not existing[k] then
+                        lia.config.stored[k].value = v.default
                         inserts[#inserts + 1] = {
                             _schema = schema,
                             _key = k,
@@ -92,7 +98,11 @@ function lia.config.load()
 
                 local finalize = function() hook.Run("InitializedConfig") end
                 if #inserts > 0 then
-                    lia.db.bulkInsert("config", inserts):next(finalize)
+                    local ops = {}
+                    for _, row in ipairs(inserts) do
+                        ops[#ops + 1] = lia.db.upsert(row, "config")
+                    end
+                    deferred.all(ops):next(finalize, finalize)
                 else
                     finalize()
                 end


### PR DESCRIPTION
## Summary
- populate `lia.config` entries with defaults when values are missing
- remove stray comments

## Testing
- `luacheck gamemode/core/libraries/config.lua` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687d2be4d1188327878ae4853ada8182