### PR TITLE
Fix SAM rank override by disabling lia admin

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -178,6 +178,13 @@ end
 hook.Add("PlayerAuthed", "lia_SetUserGroup", function(ply, steamID)
     if lia.admin.isDisabled() then return end
     local steam64 = util.SteamIDTo64(steamID)
+    -- If a CAMI based admin mod (e.g. SAM) has already assigned a usergroup,
+    -- store that value instead of overwriting it with Lilia's records.
+    if CAMI and CAMI.GetUsergroup and CAMI.GetUsergroup(ply:GetUserGroup()) and ply:GetUserGroup() ~= "user" then
+        lia.db.query(Format("UPDATE lia_players SET _userGroup = '%s' WHERE _steamID = %s", lia.db.escape(ply:GetUserGroup()), steam64))
+        return
+    end
+
     lia.db.query(Format("SELECT _userGroup FROM lia_players WHERE _steamID = %s", steam64), function(data)
         local group = istable(data) and data[1] and data[1]._userGroup
         if not group or group == "" then

--- a/gamemode/core/libraries/compatibility/sam.lua
+++ b/gamemode/core/libraries/compatibility/sam.lua
@@ -248,4 +248,5 @@ lia.config.add("SAMEnforceStaff", "Enforce Staff Rank To SAM", true, nil, {
     category = "Staff",
     type = "Boolean"
 })
-hook.Add("ShouldLiliaAdminLoad", "liaSam", function() return false end)
+-- CAMI sync allows both admin systems to coexist, so don't disable Lilia admin.
+--hook.Add("ShouldLiliaAdminLoad", "liaSam", function() return false end)

--- a/gamemode/core/libraries/compatibility/sam.lua
+++ b/gamemode/core/libraries/compatibility/sam.lua
@@ -248,4 +248,4 @@ lia.config.add("SAMEnforceStaff", "Enforce Staff Rank To SAM", true, nil, {
     category = "Staff",
     type = "Boolean"
 })
---hook.Add("ShouldLiliaAdminLoad", "liaSam", function() return false end)
+hook.Add("ShouldLiliaAdminLoad", "liaSam", function() return false end)


### PR DESCRIPTION
## Summary
- ensure Lilia's admin system doesn't override SAM ranks

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d2efc9e9c832784601ff1b0fad91b