### PR TITLE
Remove single faction door field

### DIFF
--- a/gamemode/modules/doors/commands.lua
+++ b/gamemode/modules/doors/commands.lua
@@ -109,7 +109,8 @@ lia.command.add("doorbuy", {
         end
         local door = client:getTracedEntity()
         if IsValid(door) and door:isDoor() and not door:getNetVar("disabled", false) then
-            if door:getNetVar("noSell") or door:getNetVar("faction") or door:getNetVar("class") then return client:notifyLocalized("doorNotAllowedToOwn") end
+            local factions = door:getNetVar("factions")
+            if door:getNetVar("noSell") or (factions and factions ~= "[]") or door:getNetVar("class") then return client:notifyLocalized("doorNotAllowedToOwn") end
             if IsValid(door:GetDTEntity(0)) then
                 client:notifyLocalized("doorOwnedBy", door:GetDTEntity(0):Name())
                 return false
@@ -431,7 +432,6 @@ lia.command.add("doorinfo", {
             local name = door:getNetVar("title", door:getNetVar("name", L("doorTitle")))
             local price = door:getNetVar("price", 0)
             local noSell = door:getNetVar("noSell", false)
-            local faction = door:getNetVar("faction", L("none"))
             local factions = door:getNetVar("factions", "[]")
             local class = door:getNetVar("class", L("none"))
             local hidden = door:getNetVar("hidden", false)
@@ -452,10 +452,6 @@ lia.command.add("doorinfo", {
                 {
                     property = L("doorInfoNoSell"),
                     value = tostring(noSell)
-                },
-                {
-                    property = L("faction"),
-                    value = tostring(faction)
                 },
                 {
                     property = L("doorInfoFactions"),
@@ -511,7 +507,6 @@ lia.command.add("dooraddfaction", {
             end
 
             if faction then
-                door.liaFactionID = faction.uniqueID
                 local facs = door:getNetVar("factions", "[]")
                 facs = util.JSONToTable(facs)
                 facs[faction.index] = true
@@ -561,7 +556,6 @@ lia.command.add("doorremovefaction", {
             end
 
             if faction then
-                door.liaFactionID = nil
                 local facs = door:getNetVar("factions", "[]")
                 facs = util.JSONToTable(facs)
                 facs[faction.index] = nil

--- a/gamemode/modules/doors/libraries/server.lua
+++ b/gamemode/modules/doors/libraries/server.lua
@@ -3,7 +3,6 @@
     ["name"] = true,
     ["price"] = true,
     ["noSell"] = true,
-    ["faction"] = true,
     ["factions"] = true,
     ["class"] = true,
     ["hidden"] = true,
@@ -82,7 +81,6 @@ function MODULE:SaveData()
 
         if door.liaChildren then doorData.children = door.liaChildren end
         if door.liaClassID then doorData.class = door.liaClassID end
-        if door.liaFactionID then doorData.faction = door.liaFactionID end
         if not table.IsEmpty(doorData) then data[id] = doorData end
     end
 
@@ -171,21 +169,24 @@ end
 
 function MODULE:ShowTeam(client)
     local entity = client:getTracedEntity()
-    if IsValid(entity) and entity:isDoor() and not entity:getNetVar("faction") and not entity:getNetVar("class") then
-        if entity:checkDoorAccess(client, DOOR_TENANT) then
-            local door = entity
-            if IsValid(door.liaParent) then door = door.liaParent end
-            net.Start("doorMenu")
-            net.WriteEntity(door)
-            net.WriteTable(door.liaAccess)
-            net.WriteEntity(entity)
-            net.Send(client)
-        elseif not IsValid(entity:GetDTEntity(0)) then
-            lia.command.run(client, "doorbuy")
-        else
-            client:notifyLocalized("notNow")
+    if IsValid(entity) and entity:isDoor() then
+        local factions = entity:getNetVar("factions")
+        if (not factions or factions == "[]") and not entity:getNetVar("class") then
+            if entity:checkDoorAccess(client, DOOR_TENANT) then
+                local door = entity
+                if IsValid(door.liaParent) then door = door.liaParent end
+                net.Start("doorMenu")
+                net.WriteEntity(door)
+                net.WriteTable(door.liaAccess)
+                net.WriteEntity(entity)
+                net.Send(client)
+            elseif not IsValid(entity:GetDTEntity(0)) then
+                lia.command.run(client, "doorbuy")
+            else
+                client:notifyLocalized("notNow")
+            end
+            return true
         end
-        return true
     end
 end
 


### PR DESCRIPTION
## Summary
- drop obsolete `faction` door field
- rely solely on `factions` table when saving/loading doors
- adjust admin commands to update only the `factions` list
- update door interaction logic to check `factions`

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d34308a748327b4aed3a650672f0c