### PR TITLE
Change OOC ban storage to list of steam IDs

### DIFF
--- a/gamemode/modules/chatbox/commands.lua
+++ b/gamemode/modules/chatbox/commands.lua
@@ -18,7 +18,10 @@ lia.command.add("banooc", {
             return
         end
 
-        MODULE.OOCBans[target:SteamID64()] = true
+        local id = target:SteamID64()
+        if not table.HasValue(MODULE.OOCBans, id) then
+            table.insert(MODULE.OOCBans, id)
+        end
         MODULE:SaveData()
         client:notifyLocalized("playerBannedFromOOC", target:Name())
         lia.log.add(client, "banOOC", target:Name(), target:SteamID64())
@@ -43,7 +46,8 @@ lia.command.add("unbanooc", {
             return
         end
 
-        MODULE.OOCBans[target:SteamID64()] = nil
+        local id = target:SteamID64()
+        table.RemoveByValue(MODULE.OOCBans, id)
         MODULE:SaveData()
         client:notifyLocalized("playerUnbannedFromOOC", target:Name())
         lia.log.add(client, "unbanOOC", target:Name(), target:SteamID64())

--- a/gamemode/modules/chatbox/libraries/server.lua
+++ b/gamemode/modules/chatbox/libraries/server.lua
@@ -6,7 +6,20 @@ end
 
 function MODULE:LoadData()
     local data = self:getData()
-    self.OOCBans = istable(data) and data.bans or {}
+    self.OOCBans = {}
+
+    if istable(data) and istable(data.bans) then
+        -- convert old key/value format into a sequential list
+        if data.bans[1] then
+            self.OOCBans = data.bans
+        else
+            for id, banned in pairs(data.bans) do
+                if banned then
+                    table.insert(self.OOCBans, id)
+                end
+            end
+        end
+    end
 end
 
 function MODULE:InitializedModules()

--- a/gamemode/modules/chatbox/libraries/shared.lua
+++ b/gamemode/modules/chatbox/libraries/shared.lua
@@ -252,7 +252,7 @@ lia.chat.register("ooc", {
             return false
         end
 
-        if MODULE.OOCBans[speaker:SteamID64()] then
+        if table.HasValue(MODULE.OOCBans, speaker:SteamID64()) then
             speaker:notifyLocalized("oocBanned")
             return false
         end


### PR DESCRIPTION
## Summary
- store OOC bans as a sequential list of SteamIDs
- update ban/unban commands to manipulate the list
- adapt check logic for speaking in OOC
- convert any old key/value data when loading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d35a1c70883279af9034b31068efe