### PR TITLE
Update bot model

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -507,7 +507,7 @@ function GM:SetupBotPlayer(client)
         name = client:Name(),
         faction = faction and faction.uniqueID or "unknown",
         desc = L("botDesc", botID),
-        model = "models/gman.mdl",
+        model = "models/player/phoenix.mdl",
     }, botID, client, client:SteamID64())
 
     local defaultClass = lia.faction.getDefaultClass(faction.index)


### PR DESCRIPTION
## Summary
- set bot default model to `models/player/phoenix.mdl`

## Testing
- `luacheck gamemode` *(fails: `luacheck` not found)*
- `apt-get update -y` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687d380e0f4883279cd8d0068832380b