### PR TITLE
Fix net hooks and logging

### DIFF
--- a/gamemode/modules/administration/submodules/logging/logs.lua
+++ b/gamemode/modules/administration/submodules/logging/logs.lua
@@ -213,6 +213,15 @@
         func = function(_, name, steamID, netMessage) return string.format("Player '%s' [%s] triggered exploit net message '%s'.", name, steamID, netMessage) end,
         category = "Exploits"
     },
+    ["backdoorDetected"] = {
+        func = function(_, netMessage, file, line)
+            if file then
+                return string.format("Detected backdoor net '%s' defined in %s:%s.", netMessage, file, tostring(line))
+            end
+            return string.format("Detected backdoor net '%s' during initialization.", netMessage)
+        end,
+        category = "Exploits"
+    },
     ["steamIDMissing"] = {
         func = function(_, name, steamID) return string.format("SteamID missing for '%s' [%s] during CheckSeed.", name, steamID) end,
         category = "Connections"
@@ -222,7 +231,16 @@
         category = "Connections"
     },
     ["hackAttempt"] = {
-        func = function(client) return string.format("Client %s triggered hack detection.", client:Name()) end,
+        func = function(client, netName)
+            if netName then
+                return string.format("Client %s triggered hack detection via '%s'.", client:Name(), netName)
+            end
+            return string.format("Client %s triggered hack detection.", client:Name())
+        end,
+        category = "Cheating"
+    },
+    ["verifyCheatsOK"] = {
+        func = function(client) return string.format("Client %s responded to VerifyCheats.", client:Name()) end,
         category = "Cheating"
     },
     ["doorSetClass"] = {

--- a/gamemode/modules/protection/libraries/server.lua
+++ b/gamemode/modules/protection/libraries/server.lua
@@ -253,7 +253,7 @@ function MODULE:PlayerInitialSpawn(client)
     net.Send(client)
     timer.Create(timerName, 10, 1, function()
         if IsValid(client) and client.VerifyCheatsPending then
-            lia.log.add(client, "hackAttempt")
+            lia.log.add(client, "hackAttempt", "VerifyCheatsTimeout")
             local override = hook.Run("PlayerCheatDetected", client)
             client:setNetVar("cheater", true)
             client:setLiliaData("cheater", true)

--- a/gamemode/modules/protection/netcalls/server.lua
+++ b/gamemode/modules/protection/netcalls/server.lua
@@ -543,11 +543,15 @@ function MODULE:InitializedModules()
             if isfunction(net.Receivers[netName]) then
                 local backdoorInfos = debug.getinfo(net.Receivers[netName], "S")
                 print(netName .. [[" was declared in ]] .. backdoorInfos.short_src .. [[ line ]] .. backdoorInfos.linedefined)
+                lia.log.add(nil, "backdoorDetected", netName, backdoorInfos.short_src, backdoorInfos.linedefined)
+            else
+                lia.log.add(nil, "backdoorDetected", netName)
             end
 
-            net.Receive(netName, function()
+            net.Receive(netName, function(_, client)
+                lia.log.add(client, "exploitAttempt", client:Name(), client:SteamID64(), tostring(netName))
                 for _, p in player.Iterator() do
-                    if p:isStaffOnDuty() or p:IsSuperAdmin() then p:notifyLocalized("exploitAttempt", client:Name(), client:SteamID64(), tostring(name)) end
+                    if p:isStaffOnDuty() or p:IsSuperAdmin() then p:notifyLocalized("exploitAttempt", client:Name(), client:SteamID64(), tostring(netName)) end
                 end
             end)
         end
@@ -558,14 +562,18 @@ net.Receive("CheckSeed", function(_, client)
     local sentSteamID = net.ReadString()
     if not sentSteamID or sentSteamID == "" then
         lia.notifyAdmin(L("steamIDMissing", client:Name(), client:SteamID64()))
+        lia.log.add(client, "steamIDMissing", client:Name(), client:SteamID64())
         return
     end
 
-    if client:SteamID64() ~= sentSteamID then lia.notifyAdmin(L("steamIDMismatch", client:Name(), client:SteamID64(), sentSteamID)) end
+    if client:SteamID64() ~= sentSteamID then
+        lia.notifyAdmin(L("steamIDMismatch", client:Name(), client:SteamID64(), sentSteamID))
+        lia.log.add(client, "steamIDMismatch", client:Name(), client:SteamID64(), sentSteamID)
+    end
 end)
 
 net.Receive("CheckHack", function(_, client)
-    lia.log.add(client, "hackAttempt")
+    lia.log.add(client, "hackAttempt", "CheckHack")
     local override = hook.Run("PlayerCheatDetected", client)
     client:setNetVar("cheater", true)
     client:setLiliaData("cheater", true)
@@ -575,6 +583,7 @@ net.Receive("CheckHack", function(_, client)
 end)
 
 net.Receive("VerifyCheatsResponse", function(_, client)
+    lia.log.add(client, "verifyCheatsOK")
     client.VerifyCheatsPending = nil
     if client.VerifyCheatsTimer then
         timer.Remove(client.VerifyCheatsTimer)


### PR DESCRIPTION
## Summary
- fix exploit/cheat detection hook in protection module
- add logging when net 'CheckSeed' mismatches occur
- expand hack attempt logs with the source of the detection
- log when known backdoor nets are present and when VerifyCheats replies

## Testing
- `luacheck gamemode --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d3da227c08327a129e3fd1256663a