### PR TITLE
Fix door menu network payload

### DIFF
--- a/gamemode/modules/doors/libraries/server.lua
+++ b/gamemode/modules/doors/libraries/server.lua
@@ -167,7 +167,12 @@ function MODULE:ShowTeam(client)
                 if IsValid(door.liaParent) then door = door.liaParent end
                 net.Start("doorMenu")
                 net.WriteEntity(door)
-                net.WriteTable(door.liaAccess)
+                local access = door.liaAccess or {}
+                net.WriteUInt(table.Count(access), 8)
+                for ply, perm in pairs(access) do
+                    net.WriteEntity(ply)
+                    net.WriteUInt(perm or 0, 2)
+                end
                 net.WriteEntity(entity)
                 net.Send(client)
             elseif not IsValid(entity:GetDTEntity(0)) then

--- a/gamemode/modules/doors/netcalls/client.lua
+++ b/gamemode/modules/doors/netcalls/client.lua
@@ -1,7 +1,13 @@
 ﻿net.Receive("doorMenu", function()
     if net.BytesLeft() > 0 then
         local entity = net.ReadEntity()
-        local access = net.ReadTable()
+        local count = net.ReadUInt(8)
+        local access = {}
+        for _ = 1, count do
+            local ply = net.ReadEntity()
+            local perm = net.ReadUInt(2)
+            access[ply] = perm
+        end
         local door2 = net.ReadEntity()
         if IsValid(lia.gui.door) then return lia.gui.door:Remove() end
         if IsValid(entity) then


### PR DESCRIPTION
## Summary
- avoid net.ReadType error when selling doors by serializing access list manually

## Testing
- `luacheck gamemode/modules/doors/netcalls/client.lua gamemode/modules/doors/libraries/server.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d3ffda5288327a293e903d9002492