### PR TITLE
Fix door class display

### DIFF
--- a/gamemode/modules/doors/libraries/server.lua
+++ b/gamemode/modules/doors/libraries/server.lua
@@ -49,6 +49,7 @@ function MODULE:LoadData()
                     end
                 elseif k == "class" then
                     ent.liaClassID = v
+                    ent:setNetVar("class", v)
                 else
                     ent:setNetVar(k, v)
                 end


### PR DESCRIPTION
## Summary
- ensure door class netvar is sent to clients when loading saved data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d459347648327a3b72801558506d0