### PR TITLE
Fix door data loading

### DIFF
--- a/gamemode/modules/doors/libraries/server.lua
+++ b/gamemode/modules/doors/libraries/server.lua
@@ -73,9 +73,12 @@ function MODULE:LoadData()
                 end
 
                 local name = row._name
-                if name then ent:setNetVar("name", name) end
-                local price = tonumber(row._price)
-                if price then ent:setNetVar("price", price) end
+                if name and name ~= "NULL" then
+                    ent:setNetVar("name", name)
+                end
+
+                local price = tonumber(row._price) or 0
+                ent:setNetVar("price", price)
                 if tonumber(row._locked) == 1 then ent:setNetVar("locked", true) end
                 if tonumber(row._disabled) == 1 then ent:setNetVar("disabled", true) end
                 if tonumber(row._hidden) == 1 then ent:setNetVar("hidden", true) end


### PR DESCRIPTION
## Summary
- avoid saving `NULL` door names
- default door price to 0 when loading

## Testing
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_687d5c6d3ea883279582612ad359ea0a