### PR TITLE
Simplify usergroups panel

### DIFF
--- a/gamemode/modules/administration/submodules/usergroups/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/usergroups/libraries/client.lua
@@ -1,5 +1,4 @@
 local ugPanel
-local ugPrivileges
 
 local function openGroupsPanel(parent)
     ugPanel = parent
@@ -16,63 +15,9 @@ local function openGroupsPanel(parent)
 end
 local function buildGroupsUI(panel, groups)
     panel:Clear()
-    local sidebar = panel:Add("DScrollPanel")
-    sidebar:Dock(LEFT)
-    sidebar:SetWide(200)
-    sidebar:DockMargin(0, 20, 20, 20)
-    local addBtn = sidebar:Add("liaMediumButton")
-    addBtn:Dock(TOP)
-    addBtn:SetText(L("addGroup"))
-    addBtn:SetTall(30)
-    addBtn:DockMargin(0, 0, 0, 10)
-    addBtn.DoClick = function()
-        Derma_StringRequest(L("addGroup"), L("groupName"), "", function(text)
-            net.Start("liaGroupCreate")
-            net.WriteString(text)
-            net.SendToServer()
-        end)
-    end
-
-    local removeBtn = sidebar:Add("liaMediumButton")
-    removeBtn:Dock(TOP)
-    removeBtn:SetText(L("removeGroup"))
-    removeBtn:SetTall(30)
-    removeBtn:DockMargin(0, 0, 0, 10)
-    local list = sidebar:Add("DListView")
+    local list = panel:Add("DListView")
     list:Dock(FILL)
     list:AddColumn(L("name"))
-    local content = panel:Add("DScrollPanel")
-    content:Dock(FILL)
-    content:DockMargin(10, 10, 10, 10)
-    local function populate(group)
-        content:Clear()
-        removeBtn:SetEnabled(group ~= "user" and group ~= "admin" and group ~= "superadmin")
-        for name in pairs(ugPrivileges or {}) do
-            local cb = content:Add("DCheckBoxLabel")
-            cb:Dock(TOP)
-            cb:SetText(name)
-            cb:SetValue(groups[group] and groups[group][name] and true or false)
-            cb.OnChange = function(_, val)
-                net.Start("liaGroupSetPermission")
-                net.WriteString(group)
-                net.WriteString(name)
-                net.WriteBool(val)
-                net.SendToServer()
-            end
-        end
-    end
-
-    removeBtn.DoClick = function()
-        local line = list:GetSelectedLine()
-        if not line then return end
-        local group = list:GetLine(line):GetColumnText(1)
-        if group == "user" or group == "admin" or group == "superadmin" then return end
-        net.Start("liaGroupDelete")
-        net.WriteString(group)
-        net.SendToServer()
-    end
-
-    list.OnRowSelected = function(_, _, row) populate(row:GetColumnText(1)) end
     for name in pairs(groups) do
         list:AddLine(name)
     end
@@ -80,7 +25,6 @@ end
 
 net.Receive("liaGroupsData", function()
     local groups = net.ReadTable()
-    ugPrivileges = net.ReadTable()
     lia.admin.groups = groups
     if IsValid(ugPanel) then buildGroupsUI(ugPanel, groups) end
 end)

--- a/gamemode/modules/administration/submodules/usergroups/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/usergroups/libraries/server.lua
@@ -1,34 +1,6 @@
 net.Receive("liaGroupsRequest", function(_, client)
     if not client:hasPrivilege("Staff Permissions - Manage UserGroups") then return end
     net.Start("liaGroupsData")
-    net.WriteTable(lia.admin.groups)
-    net.WriteTable(CAMI.GetPrivileges() or {})
+    net.WriteTable(CAMI.GetUsergroups() or {})
     net.Send(client)
-end)
-
-net.Receive("liaGroupCreate", function(_, client)
-    if not client:hasPrivilege("Staff Permissions - Manage UserGroups") then return end
-    local name = string.Trim(net.ReadString())
-    if name == "" or lia.admin.groups[name] then return end
-    lia.admin.createGroup(name)
-end)
-
-net.Receive("liaGroupDelete", function(_, client)
-    if not client:hasPrivilege("Staff Permissions - Manage UserGroups") then return end
-    local name = net.ReadString()
-    if name == "user" or name == "admin" or name == "superadmin" then return end
-    lia.admin.removeGroup(name)
-end)
-
-net.Receive("liaGroupSetPermission", function(_, client)
-    if not client:hasPrivilege("Staff Permissions - Manage UserGroups") then return end
-    local group = net.ReadString()
-    local perm = net.ReadString()
-    local enable = net.ReadBool()
-    if not lia.admin.groups[group] then return end
-    if enable then
-        lia.admin.addPermission(group, perm)
-    else
-        lia.admin.removePermission(group, perm)
-    end
 end)

--- a/gamemode/modules/administration/submodules/usergroups/module.lua
+++ b/gamemode/modules/administration/submodules/usergroups/module.lua
@@ -1,7 +1,7 @@
 MODULE.name = "Usergroups"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.desc = "Provides an interface to manage administrative usergroups and permissions."
+MODULE.desc = "Lists CAMI usergroups."
 MODULE.CAMIPrivileges = {
     {
         Name = "Staff Permissions - Manage UserGroups",


### PR DESCRIPTION
## Summary
- drop editing actions from usergroups menu
- trim server logic to only return CAMI usergroups
- update module description

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d5f2fa4c083278c7ce0e4c2c439d9