### PR TITLE
Fix F1 tab background

### DIFF
--- a/gamemode/core/derma/f1menu/cl_menu.lua
+++ b/gamemode/core/derma/f1menu/cl_menu.lua
@@ -163,6 +163,21 @@ function PANEL:addTab(name, callback)
     tab:SetTextColor(colors.text)
     tab:SetExpensiveShadow(1, Color(0, 0, 0, 100))
     tab:SetContentAlignment(5)
+    tab.Paint = function(p, w, h)
+        derma.SkinHook("Paint", "Button", p, w, h)
+        draw.SimpleText(p:GetText(), p:GetFont(), w / 2, h / 2, color_white, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
+        if p:IsHovered() or p:IsSelected() then
+            p.startTime = p.startTime or CurTime()
+            local elapsed = CurTime() - p.startTime
+            local anim = math.min(w, elapsed / 0.3 * w) / 2
+            local r, g, b = lia.config.get("Color")
+            surface.SetDrawColor(r, g, b)
+            surface.DrawLine(w / 2 - anim, h - 1, w / 2 + anim, h - 1)
+        else
+            p.startTime = nil
+        end
+        return true
+    end
     tab.DoClick = function()
         if IsValid(lia.gui.info) then lia.gui.info:Remove() end
         for _, t in pairs(self.tabList) do


### PR DESCRIPTION
## Summary
- draw F1 tabs with the same paint function as the selected skin

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d6277979c8327912ff869cf713cc1