### PR TITLE
Switch modules to dedicated tables

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -264,6 +264,10 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS `lia_logs`;
     DROP TABLE IF EXISTS `lia_bans`;
     DROP TABLE IF EXISTS `lia_doors`;
+    DROP TABLE IF EXISTS `lia_spawns`;
+    DROP TABLE IF EXISTS `lia_chatbox`;
+    DROP TABLE IF EXISTS `lia_admingroups`;
+    DROP TABLE IF EXISTS `lia_saveditems`;
     DROP TABLE IF EXISTS `lia_persistence`;
 ]])
             local done = 0
@@ -292,6 +296,10 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS lia_logs;
     DROP TABLE IF EXISTS lia_bans;
     DROP TABLE IF EXISTS lia_doors;
+    DROP TABLE IF EXISTS lia_spawns;
+    DROP TABLE IF EXISTS lia_chatbox;
+    DROP TABLE IF EXISTS lia_admingroups;
+    DROP TABLE IF EXISTS lia_saveditems;
     DROP TABLE IF EXISTS lia_persistence;
 ]], realCallback)
     end
@@ -408,6 +416,31 @@ function lia.db.loadTables()
                 _children TEXT,
                 PRIMARY KEY (_folder, _map, _id)
             );
+
+            CREATE TABLE IF NOT EXISTS lia_spawns (
+                _schema TEXT,
+                _map TEXT,
+                _data TEXT,
+                PRIMARY KEY (_schema, _map)
+            );
+
+            CREATE TABLE IF NOT EXISTS lia_chatbox (
+                _schema TEXT,
+                _map TEXT,
+                _data TEXT,
+                PRIMARY KEY (_schema, _map)
+            );
+
+            CREATE TABLE IF NOT EXISTS lia_saveditems (
+                _schema TEXT,
+                _map TEXT,
+                _data TEXT,
+                PRIMARY KEY (_schema, _map)
+            );
+
+            CREATE TABLE IF NOT EXISTS lia_admingroups (
+                _data TEXT
+            );
         ]], done)
     else
         local queries = string.Explode(";", [[
@@ -510,6 +543,31 @@ function lia.db.loadTables()
                 `_locked` TINYINT(1) NULL,
                 `_children` TEXT NULL,
                 PRIMARY KEY (`_folder`, `_map`, `_id`)
+            );
+
+            CREATE TABLE IF NOT EXISTS `lia_spawns` (
+                `_schema` TEXT NULL,
+                `_map` TEXT NULL,
+                `_data` TEXT NULL,
+                PRIMARY KEY (`_schema`, `_map`)
+            );
+
+            CREATE TABLE IF NOT EXISTS `lia_chatbox` (
+                `_schema` TEXT NULL,
+                `_map` TEXT NULL,
+                `_data` TEXT NULL,
+                PRIMARY KEY (`_schema`, `_map`)
+            );
+
+            CREATE TABLE IF NOT EXISTS `lia_saveditems` (
+                `_schema` TEXT NULL,
+                `_map` TEXT NULL,
+                `_data` TEXT NULL,
+                PRIMARY KEY (`_schema`, `_map`)
+            );
+
+            CREATE TABLE IF NOT EXISTS `lia_admingroups` (
+                `_data` TEXT NULL
             );
         ]])
         local i = 1

--- a/gamemode/modules/chatbox/libraries/server.lua
+++ b/gamemode/modules/chatbox/libraries/server.lua
@@ -1,24 +1,43 @@
-﻿function MODULE:SaveData()
-    self:setData({
-        bans = self.OOCBans
-    })
+local TABLE = "chatbox"
+
+local function buildCondition(folder, map)
+    return "_schema = " .. lia.db.convertDataType(folder) .. " AND _map = " .. lia.db.convertDataType(map)
+end
+
+function MODULE:SaveData()
+    local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
+    local map = game.GetMap()
+    lia.db.waitForTablesToLoad():next(function()
+        return lia.db.upsert({
+            _schema = folder,
+            _map = map,
+            _data = lia.data.serialize({bans = self.OOCBans})
+        }, TABLE)
+    end)
 end
 
 function MODULE:LoadData()
-    local data = self:getData()
-    self.OOCBans = {}
+    local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
+    local map = game.GetMap()
+    local condition = buildCondition(folder, map)
+    lia.db.waitForTablesToLoad():next(function()
+        return lia.db.selectOne({"_data"}, TABLE, condition)
+    end):next(function(res)
+        local data = res and lia.data.deserialize(res._data) or {}
+        self.OOCBans = {}
 
-    if istable(data) and istable(data.bans) then
-        if data.bans[1] then
-            self.OOCBans = data.bans
-        else
-            for id, banned in pairs(data.bans) do
-                if banned then
-                    table.insert(self.OOCBans, id)
+        if istable(data) and istable(data.bans) then
+            if data.bans[1] then
+                self.OOCBans = data.bans
+            else
+                for id, banned in pairs(data.bans) do
+                    if banned then
+                        table.insert(self.OOCBans, id)
+                    end
                 end
             end
         end
-    end
+    end)
 end
 
 function MODULE:InitializedModules()


### PR DESCRIPTION
## Summary
- add new tables for spawns, chatbox bans, saved items and admin groups
- write/load those modules using lia.db instead of lia.data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d610a2e14832780d376c3b030ae3b