### PR TITLE
Fix door class admin command

### DIFF
--- a/gamemode/modules/doors/libraries/client.lua
+++ b/gamemode/modules/doors/libraries/client.lua
@@ -99,7 +99,7 @@ function MODULE:PopulateAdminStick(AdminMenu, target)
         local setClassMenu = AdminMenu:AddSubMenu(L("doorSetDoorClass"))
         for classID, classData in pairs(lia.class.list) do
             setClassMenu:AddOption(classData.name, function()
-                LocalPlayer():ConCommand('doorsetclass "' .. classID .. '"')
+                LocalPlayer():ConCommand('say /doorsetclass "' .. classID .. '"')
                 AdminStickIsOpen = false
             end)
         end
@@ -107,7 +107,7 @@ function MODULE:PopulateAdminStick(AdminMenu, target)
         local existingClasses = target:getNetVar("classes")
         if existingClasses and existingClasses ~= "[]" then
             setClassMenu:AddOption(L("doorRemoveDoorClass"), function()
-                LocalPlayer():ConCommand('doorsetclass ""')
+                LocalPlayer():ConCommand('say /doorsetclass ""')
                 AdminStickIsOpen = false
             end)
         end


### PR DESCRIPTION
## Summary
- ensure Admin Stick uses chat command for door class updates

## Testing
- `lua` parser not available; no tests were run

------
https://chatgpt.com/codex/tasks/task_e_687d63f6540c83279066ca22481e40fe