### PR TITLE
Fix persistence angles and improve usergroup panel

### DIFF
--- a/gamemode/core/libraries/data.lua
+++ b/gamemode/core/libraries/data.lua
@@ -41,13 +41,19 @@ end
 local function decodeAngle(data)
     if isangle(data) then return data end
     if istable(data) then
-        if data.p then return Angle(data.p, data.y, data.r) end
-        if data[1] and data[2] and data[3] then return Angle(data[1], data[2], data[3]) end
+        if data.p or data.y or data.r then
+            return Angle(data.p or 0, data.y or 0, data.r or 0)
+        end
+        if data[1] and data[2] and data[3] then
+            return Angle(data[1], data[2], data[3])
+        end
+    elseif isvector(data) then
+        return Angle(data.x, data.y, data.z)
     elseif isstring(data) then
         local p, y, r = data:match("%{([-%d%.]+)%s+([-%d%.]+)%s+([-%d%.]+)%}")
         if p then return Angle(tonumber(p), tonumber(y), tonumber(r)) end
     end
-    return data
+    return Angle(0, 0, 0)
 end
 
 local function deepDecode(value)

--- a/gamemode/modules/administration/submodules/usergroups/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/usergroups/libraries/client.lua
@@ -15,11 +15,44 @@ local function openGroupsPanel(parent)
 end
 local function buildGroupsUI(panel, groups)
     panel:Clear()
+
+    local top = panel:Add("Panel")
+    top:Dock(TOP)
+    top:SetTall(28)
+    top:DockMargin(0, 0, 0, 5)
+
+    local add = top:Add("liaSmallButton")
+    add:Dock(LEFT)
+    add:SetText(L("addGroup"))
+    add:SetWide(100)
+    add.DoClick = function()
+        Derma_StringRequest(L("addGroup"), L("groupName"), "", function(name)
+            if name == "" then return end
+            net.Start("liaGroupsAdd")
+            net.WriteString(name)
+            net.SendToServer()
+        end)
+    end
+
+    local remove = top:Add("liaSmallButton")
+    remove:Dock(LEFT)
+    remove:DockMargin(5, 0, 0, 0)
+    remove:SetText(L("removeGroup"))
+    remove:SetWide(100)
+
     local list = panel:Add("DListView")
     list:Dock(FILL)
     list:AddColumn(L("name"))
     for name in pairs(groups) do
         list:AddLine(name)
+    end
+
+    remove.DoClick = function()
+        local line = list:GetSelectedLine() and list:GetLine(list:GetSelectedLine())
+        if not line then return end
+        net.Start("liaGroupsRemove")
+        net.WriteString(line:GetColumnText(1))
+        net.SendToServer()
     end
 end
 

--- a/gamemode/modules/administration/submodules/usergroups/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/usergroups/libraries/server.lua
@@ -4,3 +4,30 @@ net.Receive("liaGroupsRequest", function(_, client)
     net.WriteTable(CAMI.GetUsergroups() or {})
     net.Send(client)
 end)
+
+util.AddNetworkString("liaGroupsAdd")
+util.AddNetworkString("liaGroupsRemove")
+
+local function broadcastGroups()
+    net.Start("liaGroupsData")
+    net.WriteTable(CAMI.GetUsergroups() or {})
+    net.Broadcast()
+end
+
+net.Receive("liaGroupsAdd", function(_, client)
+    if not client:hasPrivilege("Staff Permissions - Manage UserGroups") then return end
+    local name = net.ReadString()
+    if name and name ~= "" then
+        lia.admin.createGroup(name)
+        broadcastGroups()
+    end
+end)
+
+net.Receive("liaGroupsRemove", function(_, client)
+    if not client:hasPrivilege("Staff Permissions - Manage UserGroups") then return end
+    local name = net.ReadString()
+    if name and name ~= "" then
+        lia.admin.removeGroup(name)
+        broadcastGroups()
+    end
+end)


### PR DESCRIPTION
## Summary
- fix decoding angles for persisted entities so SetAngles gets a valid Angle
- add add/remove buttons to the usergroup tab and position them at the top
- implement server handlers for creating and removing usergroups

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d63f008208327bd370527fc8f908f