### PR TITLE
Fix duplicated UI entries after module reloads

### DIFF
--- a/gamemode/core/libraries/modularity.lua
+++ b/gamemode/core/libraries/modularity.lua
@@ -68,6 +68,11 @@ function lia.module.load(uniqueID, path, isSingleFile, variable, skipSubmodules)
     local coreFile = path .. "/" .. lowerVar .. ".lua"
     local prev = _G[variable]
     local existing = lia.module.list[uniqueID]
+    if existing then
+        for hookName, func in pairs(existing) do
+            if isfunction(func) then hook.Remove(hookName, existing) end
+        end
+    end
     MODULE = {
         folder = path,
         module = existing or prev,


### PR DESCRIPTION
## Summary
- clear old module hooks before reloading to prevent duplicated buttons and info panels when the gamemode is refreshed

## Testing
- `luacheck --version` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687d6a0d4c248327b5d5f1d99386ed65