### PR TITLE
Fix last position restore

### DIFF
--- a/gamemode/core/libraries/character.lua
+++ b/gamemode/core/libraries/character.lua
@@ -403,7 +403,7 @@ lia.char.registerVar("RecognizedAs", {
 lia.char.registerVar("lastPos", {
     field = "lastpos",
     fieldType = "text",
-    default = nil,
+    default = {},
     isLocal = true,
     noDisplay = true
 })


### PR DESCRIPTION
## Summary
- fix last position variable not being parsed on load

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d6b024f788327a0730fa097c4dbe3