### PR TITLE
Fix door table name prefix

### DIFF
--- a/gamemode/modules/doors/libraries/server.lua
+++ b/gamemode/modules/doors/libraries/server.lua
@@ -42,7 +42,7 @@ function MODULE:LoadData()
     local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
     local map = game.GetMap()
     local condition = buildCondition(folder, map)
-    lia.db.waitForTablesToLoad():next(function() return lia.db.select("*", "lia_doors", condition) end):next(function(res)
+    lia.db.waitForTablesToLoad():next(function() return lia.db.select("*", "doors", condition) end):next(function(res)
         for _, row in ipairs(res.results or {}) do
             local ent = ents.GetMapCreatedEntity(tonumber(row._id))
             if IsValid(ent) and ent:isDoor() then
@@ -84,7 +84,7 @@ function MODULE:SaveData()
     local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
     local map = game.GetMap()
     local condition = buildCondition(folder, map)
-    lia.db.waitForTablesToLoad():next(function() return lia.db.delete("lia_doors", condition) end):next(function()
+    lia.db.waitForTablesToLoad():next(function() return lia.db.delete("doors", condition) end):next(function()
         local rows = {}
         for _, door in ipairs(ents.GetAll()) do
             if door:isDoor() then
@@ -107,7 +107,7 @@ function MODULE:SaveData()
 
         local count = #rows
         if count > 0 then
-            return lia.db.bulkInsert("lia_doors", rows):next(function() lia.information(L("doorSaveData", count)) end)
+            return lia.db.bulkInsert("doors", rows):next(function() lia.information(L("doorSaveData", count)) end)
         else
             lia.information(L("doorSaveData", 0))
         end


### PR DESCRIPTION
## Summary
- load doors from `doors` table instead of `lia_lia_doors`
- save doors to the correct `doors` table

This resolves a bug where door data was not saved or loaded because the table name was prefixed twice.

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687d6d92d2688327a0d19b379b60241a