### PR TITLE
Fix decodeVector not handling Angle values

### DIFF
--- a/gamemode/core/libraries/data.lua
+++ b/gamemode/core/libraries/data.lua
@@ -28,8 +28,10 @@ end
 
 local function decodeVector(data)
     if isvector(data) then return data end
+    if isangle(data) then return Vector(data.p, data.y, data.r) end
     if istable(data) then
         if data.x then return Vector(data.x, data.y, data.z) end
+        if data.p and data.y and data.r then return Vector(data.p, data.y, data.r) end
         if data[1] and data[2] and data[3] then return Vector(data[1], data[2], data[3]) end
     elseif isstring(data) then
         local x, y, z = data:match("%[([-%d%.]+)%s+([-%d%.]+)%s+([-%d%.]+)%]")


### PR DESCRIPTION
## Summary
- handle Angle values when decoding vectors so persistence data using angles as position doesn't crash

## Testing
- `luacheck gamemode/core/libraries/data.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d6ee24b408327991fbc04f66f2750