### PR TITLE
Run LoadData after database loads

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -897,6 +897,10 @@ end
 
 function GM:LiliaTablesLoaded()
     lia.db.addDatabaseFields()
+    hook.Run("LoadData")
+    hook.Run("PostLoadData")
+    lia.faction.formatModelData()
+    timer.Simple(2, function() lia.entityDataLoaded = true end)
 end
 
 function ClientAddText(client, ...)

--- a/gamemode/core/libraries/core.lua
+++ b/gamemode/core/libraries/core.lua
@@ -544,10 +544,7 @@ end
 
 function GM:InitPostEntity()
     if SERVER then
-        hook.Run("LoadData")
-        hook.Run("PostLoadData")
-        lia.faction.formatModelData()
-        timer.Simple(2, function() lia.entityDataLoaded = true end)
+        -- Database hooks are now invoked in GM:LiliaTablesLoaded
     else
         lia.joinTime = RealTime() - 0.9716
         if system.IsWindows() and not system.HasFocus() then system.FlashWindow() end


### PR DESCRIPTION
## Summary
- trigger data load hooks after database tables finish loading
- avoid calling data load hooks during `InitPostEntity`

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d735126788327be5f338a9acc8b83