### PR TITLE
Use LiliaTablesLoaded hook for DB tasks

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -601,13 +601,11 @@ function GM:SaveData()
     lia.data.savePersistence(data.entities)
     local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
     local map = game.GetMap()
-    lia.db.waitForTablesToLoad():next(function()
-        return lia.db.upsert({
-            _schema = folder,
-            _map = map,
-            _data = lia.data.serialize(data.items)
-        }, "saveditems")
-    end)
+    lia.db.upsert({
+        _schema = folder,
+        _map = map,
+        _data = lia.data.serialize(data.items)
+    }, "saveditems")
 end
 
 function GM:LoadData()
@@ -648,7 +646,7 @@ function GM:LoadData()
     local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
     local map = game.GetMap()
     local condition = "_schema = " .. lia.db.convertDataType(folder) .. " AND _map = " .. lia.db.convertDataType(map)
-    lia.db.waitForTablesToLoad():next(function() return lia.db.selectOne({"_data"}, "saveditems", condition) end):next(function(res)
+    lia.db.selectOne({"_data"}, "saveditems", condition):next(function(res)
         local items = res and lia.data.deserialize(res._data) or {}
         if #items > 0 then
             local idRange, positions, angles = {}, {}, {}
@@ -902,6 +900,11 @@ end
 
 function GM:LiliaTablesLoaded()
     lia.db.addDatabaseFields()
+    lia.log.loadTables()
+    lia.data.loadTables()
+    lia.data.loadPersistence()
+    lia.admin.load()
+    lia.config.load()
     hook.Run("LoadData")
     hook.Run("PostLoadData")
     lia.faction.formatModelData()

--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -55,9 +55,7 @@ function lia.admin.load()
         lia.bootstrap("Administration", L("adminSystemLoaded"))
     end
 
-    lia.db.waitForTablesToLoad():next(function()
-        return lia.db.selectOne({"_data"}, "admingroups")
-    end):next(function(res)
+    lia.db.selectOne({"_data"}, "admingroups"):next(function(res)
         local data = res and util.JSONToTable(res._data or "") or {}
         continueLoad(data)
     end)
@@ -121,11 +119,9 @@ if SERVER then
 
     function lia.admin.save(network)
         if lia.admin.isDisabled() then return end
-        lia.db.waitForTablesToLoad():next(function()
-            return lia.db.upsert({
-                _data = util.TableToJSON(lia.admin.groups)
-            }, "admingroups")
-        end)
+        lia.db.upsert({
+            _data = util.TableToJSON(lia.admin.groups)
+        }, "admingroups")
         if network then
             net.Start("lilia_updateAdminGroups")
             net.WriteTable(lia.admin.groups)
@@ -176,11 +172,6 @@ if SERVER then
         if ban.duration == 0 then return false end
         return ban.start + ban.duration <= os.time()
     end
-
-    hook.Add("InitPostEntity", "lia_LoadAdmin", function()
-        if lia.admin.isDisabled() then return end
-        lia.admin.load()
-    end)
 
     hook.Add("ShutDown", "lia_SaveAdmin", function()
         if lia.admin.isDisabled() then return end

--- a/gamemode/core/libraries/config.lua
+++ b/gamemode/core/libraries/config.lua
@@ -67,11 +67,10 @@ end
 
 function lia.config.load()
     if SERVER then
-        lia.db.waitForTablesToLoad():next(function()
-            local schema = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-            lia.db.select({"_key", "_value"}, "config", "_schema = " .. lia.db.convertDataType(schema)):next(function(res)
-                local rows = res.results or {}
-                local existing = {}
+        local schema = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
+        lia.db.select({"_key", "_value"}, "config", "_schema = " .. lia.db.convertDataType(schema)):next(function(res)
+            local rows = res.results or {}
+            local existing = {}
                 for _, row in ipairs(rows) do
                     local decoded = util.JSONToTable(row._value)
                     lia.config.stored[row._key] = lia.config.stored[row._key] or {}
@@ -107,7 +106,6 @@ function lia.config.load()
                     finalize()
                 end
             end)
-        end)
     else
         net.Start("cfgList")
         net.SendToServer()
@@ -143,15 +141,13 @@ if SERVER then
             }
         end
 
-        lia.db.waitForTablesToLoad():next(function()
-            local schema = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-            local queries = {"DELETE FROM lia_config WHERE _schema = " .. lia.db.convertDataType(schema)}
+        local schema = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
+        local queries = {"DELETE FROM lia_config WHERE _schema = " .. lia.db.convertDataType(schema)}
             for _, row in ipairs(rows) do
                 queries[#queries + 1] = "INSERT INTO lia_config (_schema,_key,_value) VALUES (" .. lia.db.convertDataType(schema) .. ", " .. lia.db.convertDataType(row._key) .. ", " .. lia.db.convertDataType(row._value) .. ")"
             end
 
             lia.db.transaction(queries)
-        end)
     end
 end
 

--- a/gamemode/core/libraries/core.lua
+++ b/gamemode/core/libraries/core.lua
@@ -523,7 +523,6 @@ function GM:Initialize()
         hasInitializedModules = true
     end
 
-    lia.config.load()
     if CLIENT then
         lia.option.load()
         lia.keybind.load()

--- a/gamemode/core/libraries/data.lua
+++ b/gamemode/core/libraries/data.lua
@@ -231,10 +231,9 @@ if SERVER then
 
 
     function lia.data.loadTables()
-        lia.db.waitForTablesToLoad():next(function()
-            local query = lia.db.module == "sqlite" and "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'lia_data_%'" or "SHOW TABLES LIKE 'lia_data_%'"
-            lia.db.query(query, function(res)
-                local tables = {}
+        local query = lia.db.module == "sqlite" and "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'lia_data_%'" or "SHOW TABLES LIKE 'lia_data_%'"
+        lia.db.query(query, function(res)
+            local tables = {}
                 if res then
                     if lia.db.module == "sqlite" then
                         for _, row in ipairs(res) do
@@ -279,7 +278,6 @@ if SERVER then
 
                 loadNext()
             end)
-        end)
     end
 
     local function createPersistenceTable()
@@ -344,10 +342,8 @@ if SERVER then
     end
 
     function lia.data.loadPersistence()
-        lia.db.waitForTablesToLoad():next(function()
-            createPersistenceTable()
-            return ensurePersistenceColumns(baseCols)
-        end)
+        createPersistenceTable()
+        return ensurePersistenceColumns(baseCols)
     end
 
     function lia.data.savePersistence(entities)
@@ -366,14 +362,11 @@ if SERVER then
             end
         end
 
-        lia.db.waitForTablesToLoad():next(function()
-            createPersistenceTable()
-        end):next(function()
-            local cols = {}
-            for _, c in ipairs(baseCols) do cols[#cols + 1] = c end
-            for _, c in ipairs(dynamicList) do cols[#cols + 1] = c end
-            return ensurePersistenceColumns(cols)
-        end):next(function()
+        createPersistenceTable()
+        local cols = {}
+        for _, c in ipairs(baseCols) do cols[#cols + 1] = c end
+        for _, c in ipairs(dynamicList) do cols[#cols + 1] = c end
+        ensurePersistenceColumns(cols):next(function()
             return lia.db.delete("persistence", condition)
         end):next(function()
             local rows = {}
@@ -399,10 +392,8 @@ if SERVER then
         local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
         local map = game.GetMap()
         local condition = buildCondition(folder, map)
-        lia.db.waitForTablesToLoad():next(function()
-            createPersistenceTable()
-            return ensurePersistenceColumns(baseCols)
-        end):next(function()
+        createPersistenceTable()
+        ensurePersistenceColumns(baseCols):next(function()
             return lia.db.select("*", "persistence", condition)
         end):next(function(res)
             local rows = res.results or {}

--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -935,11 +935,6 @@ end
 
 function GM:DatabaseConnected()
     lia.bootstrap("Database", L("databaseConnected", lia.db.module), Color(0, 255, 0))
-    if SERVER then
-        lia.log.loadTables()
-        lia.data.loadTables()
-        lia.data.loadPersistence()
-    end
 end
 
 function GM:OnMySQLOOConnected()

--- a/gamemode/core/libraries/logger.lua
+++ b/gamemode/core/libraries/logger.lua
@@ -27,9 +27,7 @@ if SERVER then
     end
 
     function lia.log.loadTables()
-        lia.db.waitForTablesToLoad():next(function()
-            createLogsTable()
-        end)
+        createLogsTable()
     end
 
     function lia.log.addType(logType, func, category)

--- a/gamemode/modules/chatbox/libraries/server.lua
+++ b/gamemode/modules/chatbox/libraries/server.lua
@@ -7,22 +7,18 @@ end
 function MODULE:SaveData()
     local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
     local map = game.GetMap()
-    lia.db.waitForTablesToLoad():next(function()
-        return lia.db.upsert({
-            _schema = folder,
-            _map = map,
-            _data = lia.data.serialize({bans = self.OOCBans})
-        }, TABLE)
-    end)
+    lia.db.upsert({
+        _schema = folder,
+        _map = map,
+        _data = lia.data.serialize({bans = self.OOCBans})
+    }, TABLE)
 end
 
 function MODULE:LoadData()
     local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
     local map = game.GetMap()
     local condition = buildCondition(folder, map)
-    lia.db.waitForTablesToLoad():next(function()
-        return lia.db.selectOne({"_data"}, TABLE, condition)
-    end):next(function(res)
+    lia.db.selectOne({"_data"}, TABLE, condition):next(function(res)
         local data = res and lia.data.deserialize(res._data) or {}
         self.OOCBans = {}
 

--- a/gamemode/modules/spawns/libraries/server.lua
+++ b/gamemode/modules/spawns/libraries/server.lua
@@ -13,9 +13,7 @@ function MODULE:LoadData(attempt)
     local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
     local map = game.GetMap()
     local condition = buildCondition(folder, map)
-    lia.db.waitForTablesToLoad():next(function()
-        return lia.db.selectOne({"_data"}, TABLE, condition)
-    end):next(function(res)
+    lia.db.selectOne({"_data"}, TABLE, condition):next(function(res)
         local data = res and lia.data.deserialize(res._data) or {}
         local factions = data.factions or data
         if (not factions or next(factions) == nil) and attempt < 5 then
@@ -49,13 +47,11 @@ function MODULE:SaveData()
     local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
     local map = game.GetMap()
     local condition = buildCondition(folder, map)
-    lia.db.waitForTablesToLoad():next(function()
-        return lia.db.upsert({
-            _schema = folder,
-            _map = map,
-            _data = lia.data.serialize({factions = factions})
-        }, TABLE)
-    end)
+    lia.db.upsert({
+        _schema = folder,
+        _map = map,
+        _data = lia.data.serialize({factions = factions})
+    }, TABLE)
 end
 
 local function SpawnPlayer(client)


### PR DESCRIPTION
## Summary
- rely on `LiliaTablesLoaded` hook to initialize modules
- drop redundant `waitForTablesToLoad` usage
- load config/admin/log/data modules after DB tables are ready
- cleanup server initialization accordingly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d749794748327b7f958cb1f37b5fb