### PR TITLE
Use generic table serialization

### DIFF
--- a/gamemode/core/libraries/character.lua
+++ b/gamemode/core/libraries/character.lua
@@ -533,7 +533,7 @@ if SERVER then
                         elseif isbool(v2.default) then
                             value = tobool(value)
                         elseif istable(v2.default) then
-                            value = util.JSONToTable(value)
+                            value = lia.data.deserialize(value)
                         end
 
                         charData[k2] = value

--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -612,10 +612,16 @@ function lia.db.convertDataType(value, noEscape)
             return "'" .. lia.db.escape(value) .. "'"
         end
     elseif istable(value) then
-        if noEscape then
-            return util.TableToJSON(value)
+        local encoded
+        if lia and lia.data and lia.data.serialize then
+            encoded = lia.data.serialize(value)
         else
-            return "'" .. lia.db.escape(util.TableToJSON(value)) .. "'"
+            encoded = util.TableToJSON(value)
+        end
+        if noEscape then
+            return encoded
+        else
+            return "'" .. lia.db.escape(encoded) .. "'"
         end
     elseif value == NULL then
         return "NULL"


### PR DESCRIPTION
## Summary
- remove custom lastPos encoding
- automatically deserialize complex fields during character restore
- serialize tables through lia.data when sending to the DB

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687e00f7202883278f5330b7a57d0f8f