### PR TITLE
Add universal encoding helper

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -1,6 +1,5 @@
 local GM = GM or GAMEMODE
-local encodeVector = lia.data.encodeVector
-local encodeAngle = lia.data.encodeAngle
+local encodetable = lia.data.encodetable
 local decodeVector = lia.data.decodeVector
 local decodeAngle = lia.data.decodeAngle
 function GM:CharPreSave(character)
@@ -595,7 +594,13 @@ function GM:SaveData()
     end
 
     for _, item in ipairs(ents.FindByClass("lia_item")) do
-        if item.liaItemID and not item.temp then data.items[#data.items + 1] = {item.liaItemID, encodeVector(item:GetPos()), encodeAngle(item:GetAngles())} end
+        if item.liaItemID and not item.temp then
+            data.items[#data.items + 1] = {
+                item.liaItemID,
+                encodetable(item:GetPos()),
+                encodetable(item:GetAngles())
+            }
+        end
     end
 
     lia.data.savePersistence(data.entities)

--- a/gamemode/core/libraries/data.lua
+++ b/gamemode/core/libraries/data.lua
@@ -1,26 +1,24 @@
 ﻿file.CreateDir("lilia")
 lia.data = lia.data or {}
 lia.data.stored = lia.data.stored or {}
-function lia.data.encodeVector(vec)
-    return {vec.x, vec.y, vec.z}
-end
-
-function lia.data.encodeAngle(ang)
-    return {ang.p, ang.y, ang.r}
-end
-
-local function deepEncode(value)
+--[[
+    Recursively convert tables so they can be safely serialized. Vectors and
+    Angles are translated into simple table formats. This replaces the old
+    encodeVector and encodeAngle helpers.
+--]]
+function lia.data.encodetable(value)
     if isvector(value) then
-        return lia.data.encodeVector(value)
+        return {value.x, value.y, value.z}
     elseif isangle(value) then
-        return lia.data.encodeAngle(value)
+        return {value.p, value.y, value.r}
     elseif istable(value) then
         local t = {}
         for k, v in pairs(value) do
-            t[k] = deepEncode(v)
+            t[k] = lia.data.encodetable(v)
         end
         return t
     end
+
     return value
 end
 
@@ -80,7 +78,7 @@ function lia.data.decode(value)
 end
 
 function lia.data.serialize(value)
-    return util.TableToJSON(deepEncode(value) or {})
+    return util.TableToJSON(lia.data.encodetable(value) or {})
 end
 
 function lia.data.deserialize(raw)

--- a/gamemode/modules/spawns/libraries/server.lua
+++ b/gamemode/modules/spawns/libraries/server.lua
@@ -1,7 +1,7 @@
 local MODULE = MODULE
 MODULE.spawns = MODULE.spawns or {}
 local decodeVector = lia.data.decodeVector
-local encodeVector = lia.data.encodeVector
+local encodetable = lia.data.encodetable
 local TABLE = "spawns"
 local function buildCondition(folder, map)
     return "_schema = " .. lia.db.convertDataType(folder) .. " AND _map = " .. lia.db.convertDataType(map)
@@ -39,7 +39,7 @@ function MODULE:SaveData()
     for fac, spawns in pairs(self.spawns or {}) do
         factions[fac] = {}
         for _, pos in ipairs(spawns) do
-            factions[fac][#factions[fac] + 1] = encodeVector(pos)
+            factions[fac][#factions[fac] + 1] = encodetable(pos)
         end
     end
 


### PR DESCRIPTION
## Summary
- add `lia.data.encodetable` for recursive serialization of vectors, angles and tables
- update modules to use new helper instead of the obsolete functions
- drop `encodeVector`, `encodeAngle` and `deepEncode`

## Testing
- `luacheck gamemode` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687e11e071048327a801fd94e301d824