### PR TITLE
Track item entities in saveditems

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -550,10 +550,7 @@ end
 
 function GM:SaveData()
     local seen = {}
-    local data = {
-        entities = {},
-        items = {}
-    }
+    local data = {}
 
     for _, ent in ents.Iterator() do
         if ent:isLiliaPersistent() then
@@ -584,40 +581,14 @@ function GM:SaveData()
                 if bodygroups then entData.bodygroups = bodygroups end
                 local extra = hook.Run("GetEntitySaveData", ent)
                 if extra ~= nil then entData.data = extra end
-                data.entities[#data.entities + 1] = entData
+                data[#data + 1] = entData
                 hook.Run("OnEntityPersisted", ent, entData)
             end
         end
     end
 
-    local itemsList = ents.FindByClass("lia_item")
-    print("SaveData: found", #itemsList, "lia_item entities")
-    for _, item in ipairs(itemsList) do
-        if item.liaItemID and not item.temp then
-            local itemID = item.liaItemID
-            local itemPos = item:GetPos()
-            local itemAng = item:GetAngles()
-            print("SaveData: saving item", itemID, "at pos", tostring(itemPos), "angles", tostring(itemAng))
-            data.items[#data.items + 1] = {itemID, lia.data.encodetable(itemPos), lia.data.encodetable(itemAng)}
-        end
-    end
-
-    local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-    local map = game.GetMap()
-    local condition = "_schema = " .. lia.db.convertDataType(folder) .. " AND _map = " .. lia.db.convertDataType(map)
-    local rows = {}
-    for _, itm in ipairs(data.items) do
-        rows[#rows + 1] = {
-            _schema = folder,
-            _map = map,
-            _itemID = itm[1],
-            _pos = itm[2],
-            _angles = itm[3]
-        }
-    end
-
-    lia.db.delete("saveditems", condition):next(function() return lia.db.bulkInsert("saveditems", rows) end)
-    lia.data.savePersistence(data.entities)
+    -- items are handled individually on spawn and removal
+    lia.data.savePersistence(data)
     lia.information(L("dataSaved"))
 end
 

--- a/gamemode/entities/entities/lia_item/init.lua
+++ b/gamemode/entities/entities/lia_item/init.lua
@@ -66,6 +66,24 @@ function ENT:setItem(itemID)
         physObj:Wake()
     end
 
+    -- add item to saveditems table when spawned
+    if SERVER and not itemTable.temp then
+        local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
+        local map = game.GetMap()
+        local condition = "_schema = " .. lia.db.convertDataType(folder)
+            .. " AND _map = " .. lia.db.convertDataType(map)
+            .. " AND _itemID = " .. tonumber(itemID)
+        lia.db.delete("saveditems", condition):next(function()
+            lia.db.insertTable({
+                _schema = folder,
+                _map = map,
+                _itemID = itemID,
+                _pos = lia.data.encodetable(self:GetPos()),
+                _angles = lia.data.encodetable(self:GetAngles())
+            }, nil, "saveditems")
+        end)
+    end
+
     hook.Run("OnItemCreated", itemTable, self)
 end
 
@@ -88,6 +106,14 @@ function ENT:OnRemove()
     end
 
     if not lia.shuttingDown and not self.liaIsSafe and self.liaItemID then lia.item.deleteByID(self.liaItemID) end
+    if SERVER and not lia.shuttingDown and self.liaItemID then
+        local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
+        local map = game.GetMap()
+        local condition = "_schema = " .. lia.db.convertDataType(folder)
+            .. " AND _map = " .. lia.db.convertDataType(map)
+            .. " AND _itemID = " .. tonumber(self.liaItemID)
+        lia.db.delete("saveditems", condition)
+    end
 end
 
 function ENT:Think()


### PR DESCRIPTION
## Summary
- persist items individually on spawn and removal
- flatten entity list in `SaveData`

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687eb02a4fe48327a53d63922891e232