### PR TITLE
Fix vector and angle decoding

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -649,8 +649,8 @@ function GM:LoadData()
             for _, row in ipairs(items) do
                 local id = tonumber(row._itemID)
                 idRange[#idRange + 1] = id
-                positions[id] = lia.data.deserialize(row._pos)
-                angles[id] = lia.data.deserialize(row._angles)
+                positions[id] = lia.data.decodeVector(row._pos)
+                angles[id] = lia.data.decodeAngle(row._angles)
             end
 
             if #idRange > 0 then


### PR DESCRIPTION
## Summary
- decode angles before vectors to avoid mis-parsing
- provide `lia.data.decodeVector`/`lia.data.decodeAngle` helpers
- use new helpers when loading saved items and persistence data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ebd65a45c832793640e281bc1f861