### PR TITLE
Add vendor preset support

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -85,6 +85,7 @@ LANGUAGE = {
     vendorEditor = "Vendor Editor",
     vendorEditorWelcomeMessage = "Welcome Message",
     vendorUseMoney = "Use Money",
+    vendorSelectPreset = "Select Preset",
     vendorFaction = "Faction Access",
     mode = "Trade Mode",
     moneyTaken = "You picked up %s.",

--- a/gamemode/modules/inventory/submodules/vendor/derma/client.lua
+++ b/gamemode/modules/inventory/submodules/vendor/derma/client.lua
@@ -1,6 +1,7 @@
-﻿local MODULE = MODULE
+local MODULE = MODULE
 local sw, sh = ScrW(), ScrH()
-local EDITOR = include(MODULE.folder .. "/libs/cl_vendor.lua")
+include(MODULE.folder .. "/libs/cl_vendor.lua")
+local EDITOR = lia.vendor.editor
 local COLS_MODE = 2
 local COLS_PRICE = 3
 local COLS_STOCK = 4
@@ -685,6 +686,20 @@ function PANEL:Init()
     self.faction:SetTextColor(color_white)
     self.faction:DockMargin(0, 4, 0, 0)
     self.faction.DoClick = function() vgui.Create("VendorFactionEditor"):MoveLeftOf(self, 4) end
+
+    if table.Count(lia.vendor.presets or {}) > 0 then
+        self.preset = self:Add("DComboBox")
+        self.preset:Dock(TOP)
+        self.preset:SetSortItems(false)
+        self.preset:DockMargin(0, 4, 0, 0)
+        self.preset:SetValue(L("vendorSelectPreset"))
+        for name in pairs(lia.vendor.presets) do
+            self.preset:AddChoice(name)
+        end
+        self.preset.OnSelect = function(_, _, value)
+            EDITOR.preset(value)
+        end
+    end
     self.items = self:Add("DListView")
     self.items:Dock(FILL)
     self.items:DockMargin(0, 4, 0, 0)

--- a/gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/init.lua
+++ b/gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/init.lua
@@ -190,6 +190,17 @@ function ENT:setSellScale(scale)
     net.Send(self.receivers)
 end
 
+function ENT:applyPreset(name)
+    local preset = lia.vendor and lia.vendor.getPreset(name)
+    if not preset then return end
+    for itemType, data in pairs(preset) do
+        if data.mode ~= nil then self:setTradeMode(itemType, data.mode) end
+        if data.price ~= nil then self:setItemPrice(itemType, data.price) end
+        if data.maxStock ~= nil then self:setMaxStock(itemType, data.maxStock) end
+        if data.stock ~= nil then self:setStock(itemType, data.stock) end
+    end
+end
+
 function ENT:sync(client)
     net.Start("VendorSync")
     net.WriteEntity(self)

--- a/gamemode/modules/inventory/submodules/vendor/libraries/shared.lua
+++ b/gamemode/modules/inventory/submodules/vendor/libraries/shared.lua
@@ -1,0 +1,19 @@
+-- Global vendor utilities
+lia.vendor = lia.vendor or {}
+lia.vendor.editor = lia.vendor.editor or {}
+lia.vendor.presets = lia.vendor.presets or {}
+
+function lia.vendor.addPreset(name, items)
+    assert(isstring(name), "preset name must be a string")
+    assert(istable(items), "preset items must be a table")
+    lia.vendor.presets[string.lower(name)] = items
+end
+
+function lia.vendor.getPreset(name)
+    return lia.vendor.presets[string.lower(name)]
+end
+
+-- compatibility wrapper
+function AddVendorPreset(name, items)
+    lia.vendor.addPreset(name, items)
+end

--- a/gamemode/modules/inventory/submodules/vendor/libs/cl_vendor.lua
+++ b/gamemode/modules/inventory/submodules/vendor/libs/cl_vendor.lua
@@ -1,4 +1,4 @@
-﻿local EDITOR = {}
+local EDITOR = lia.vendor.editor
 local function addEditor(name, callback)
     EDITOR[name] = function(...)
         net.Start("VendorEdit")
@@ -61,4 +61,5 @@ addEditor("useMoney", function(useMoney) net.WriteBool(useMoney) end)
 addEditor("scale", function(scale) net.WriteFloat(scale) end)
 addEditor("name", function(name) net.WriteString(name) end)
 addEditor("welcome", function(message) net.WriteString(message) end)
+addEditor("preset", function(name) net.WriteString(name) end)
 return EDITOR

--- a/gamemode/modules/inventory/submodules/vendor/libs/sv_vendor.lua
+++ b/gamemode/modules/inventory/submodules/vendor/libs/sv_vendor.lua
@@ -1,4 +1,4 @@
-﻿local EDITOR = {}
+local EDITOR = lia.vendor.editor
 EDITOR.name = function(vendor)
     local name = net.ReadString()
     vendor:setName(name)
@@ -77,5 +77,10 @@ end
 EDITOR.scale = function(vendor)
     local scale = net.ReadFloat()
     vendor:setSellScale(scale)
+end
+
+EDITOR.preset = function(vendor)
+    local preset = net.ReadString()
+    vendor:applyPreset(preset)
 end
 return EDITOR

--- a/gamemode/modules/inventory/submodules/vendor/netcalls/server.lua
+++ b/gamemode/modules/inventory/submodules/vendor/netcalls/server.lua
@@ -1,5 +1,6 @@
-﻿local MODULE = MODULE
-local EDITOR = include(MODULE.path .. "/libs/sv_vendor.lua")
+local MODULE = MODULE
+include(MODULE.path .. "/libs/sv_vendor.lua")
+local EDITOR = lia.vendor.editor
 net.Receive("VendorExit", function(_, client)
     local vendor = client.liaVendor
     if IsValid(vendor) then vendor:removeReceiver(client, true) end


### PR DESCRIPTION
## Summary
- add vendor presets library with `lia.vendor.addPreset`
- implement `applyPreset` for vendor entities
- handle preset selection in vendor editor and networking
- include string for preset selection in English locale
- move editor utilities to global `lia.vendor.editor`
- move vendor globals to shared library

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687f5298e9988327ba860160751643a5