### PR TITLE
Add vendor rarity registration helper

### DIFF
--- a/gamemode/core/libraries/vendor.lua
+++ b/gamemode/core/libraries/vendor.lua
@@ -1,6 +1,17 @@
 lia.vendor = lia.vendor or {}
 lia.vendor.editor = lia.vendor.editor or {}
 lia.vendor.presets = lia.vendor.presets or {}
+lia.vendor.rarities = lia.vendor.rarities or {}
+
+--- Adds a rarity color to the vendor system.
+-- @param name Name of the rarity.
+-- @param color Color associated with the rarity.
+function lia.vendor.addRarities(name, color)
+    assert(isstring(name), "rarity name must be a string")
+    assert(IsColor(color), "color must be a Color")
+    lia.vendor.rarities[name] = color
+end
+
 function lia.vendor.addPreset(name, items)
     assert(isstring(name), "preset name must be a string")
     assert(istable(items), "preset items must be a table")
@@ -161,3 +172,11 @@ else
     addEditor("welcome", function(message) net.WriteString(message) end)
     addEditor("preset", function(name) net.WriteString(name) end)
 end
+-- Default rarity colors
+
+lia.vendor.addRarities("Common", Color(255, 255, 255))
+lia.vendor.addRarities("Uncommon", Color(30, 255, 0))
+lia.vendor.addRarities("Rare", Color(0, 112, 221))
+lia.vendor.addRarities("Epic", Color(163, 53, 238))
+lia.vendor.addRarities("Legendary", Color(255, 128, 0))
+

--- a/gamemode/modules/inventory/submodules/vendor/derma/client.lua
+++ b/gamemode/modules/inventory/submodules/vendor/derma/client.lua
@@ -4,13 +4,7 @@ include(MODULE.folder .. "/libs/cl_vendor.lua")
 local COLS_MODE = 2
 local COLS_PRICE = 3
 local COLS_STOCK = 4
-local RarityColors = {
-    ["Common"] = Color(255, 255, 255),
-    ["Uncommon"] = Color(30, 255, 0),
-    ["Rare"] = Color(0, 112, 221),
-    ["Epic"] = Color(163, 53, 238),
-    ["Legendary"] = Color(255, 128, 0),
-}
+local RarityColors = lia.vendor.rarities
 
 local VendorClick = {"buttons/button15.wav", 30, 250}
 local PANEL = {}


### PR DESCRIPTION
## Summary
- change `lia.vendor.addRarities` to register a single rarity color
- register the default rarities with individual calls

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687f5cb0f6588327af3e86d6540366f6