### PR TITLE
Ensure vendor library loads

### DIFF
--- a/gamemode/core/libraries/core.lua
+++ b/gamemode/core/libraries/core.lua
@@ -151,6 +151,10 @@ local FilesToLoad = {
         realm = "shared"
     },
     {
+        path = "lilia/gamemode/core/libraries/vendor.lua",
+        realm = "shared"
+    },
+    {
         path = "lilia/gamemode/core/libraries/time.lua",
         realm = "shared"
     },


### PR DESCRIPTION
## Summary
- load `vendor.lua` by adding it to core library list

## Testing
- `luarocks` and `luacheck` were not available in the environment

------
https://chatgpt.com/codex/tasks/task_e_687f60f88cac8327a1cfb35a2b82605c