### PR TITLE
Add vendor preset clearing option

### DIFF
--- a/gamemode/modules/inventory/submodules/vendor/derma/client.lua
+++ b/gamemode/modules/inventory/submodules/vendor/derma/client.lua
@@ -676,18 +676,17 @@ function PANEL:Init()
     self.faction:SetTextColor(color_white)
     self.faction:DockMargin(0, 4, 0, 0)
     self.faction.DoClick = function() vgui.Create("VendorFactionEditor"):MoveLeftOf(self, 4) end
-    if table.Count(lia.vendor.presets or {}) > 0 then
-        self.preset = self:Add("DComboBox")
-        self.preset:Dock(TOP)
-        self.preset:SetSortItems(false)
-        self.preset:DockMargin(0, 4, 0, 0)
-        self.preset:SetValue(L("vendorSelectPreset"))
-        for name in pairs(lia.vendor.presets) do
-            self.preset:AddChoice(name)
-        end
-
-        self.preset.OnSelect = function(_, _, value) lia.vendor.editor.preset(value) end
+    self.preset = self:Add("DComboBox")
+    self.preset:Dock(TOP)
+    self.preset:SetSortItems(false)
+    self.preset:DockMargin(0, 4, 0, 0)
+    self.preset:SetValue(L("vendorSelectPreset"))
+    self.preset:AddChoice(L("none"))
+    for name in pairs(lia.vendor.presets or {}) do
+        self.preset:AddChoice(name)
     end
+
+    self.preset.OnSelect = function(_, _, value) lia.vendor.editor.preset(value) end
 
     self.items = self:Add("DListView")
     self.items:Dock(FILL)

--- a/gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/init.lua
+++ b/gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/init.lua
@@ -191,6 +191,15 @@ function ENT:setSellScale(scale)
 end
 
 function ENT:applyPreset(name)
+    name = string.lower(name)
+    if name == "none" then
+        self.items = {}
+        for _, client in ipairs(self.receivers) do
+            self:sync(client)
+        end
+        return
+    end
+
     local preset = lia.vendor and lia.vendor.getPreset(name)
     if not preset then return end
     for itemType, data in pairs(preset) do


### PR DESCRIPTION
## Summary
- always show preset selector in vendor editor
- add `None` entry that sends a preset change
- handle preset name `none` server-side by wiping all items and resyncing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f845a18488327a70d99071bb17d72