### PR TITLE
Add vendor preset support

### DIFF
--- a/gamemode/core/libraries/vendor.lua
+++ b/gamemode/core/libraries/vendor.lua
@@ -9,12 +9,14 @@ if SERVER then
     end
 
     lia.vendor.editor.mode = function(vendor)
+        if vendor:getNetVar("preset") ~= "none" then return end
         local itemType = net.ReadString()
         local mode = net.ReadInt(8)
         vendor:setTradeMode(itemType, mode)
     end
 
     lia.vendor.editor.price = function(vendor)
+        if vendor:getNetVar("preset") ~= "none" then return end
         local itemType = net.ReadString()
         local price = net.ReadInt(32)
         vendor:setItemPrice(itemType, price)
@@ -26,6 +28,7 @@ if SERVER then
     end
 
     lia.vendor.editor.stockDisable = function(vendor)
+        if vendor:getNetVar("preset") ~= "none" then return end
         local itemType = net.ReadString()
         vendor:setMaxStock(itemType, nil)
     end
@@ -36,12 +39,14 @@ if SERVER then
     end
 
     lia.vendor.editor.stockMax = function(vendor)
+        if vendor:getNetVar("preset") ~= "none" then return end
         local itemType = net.ReadString()
         local value = net.ReadUInt(32)
         vendor:setMaxStock(itemType, value)
     end
 
     lia.vendor.editor.stock = function(vendor)
+        if vendor:getNetVar("preset") ~= "none" then return end
         local itemType = net.ReadString()
         local value = net.ReadUInt(32)
         vendor:setStock(itemType, value)

--- a/gamemode/modules/inventory/submodules/vendor/derma/client.lua
+++ b/gamemode/modules/inventory/submodules/vendor/derma/client.lua
@@ -391,6 +391,11 @@ function PANEL:onVendorPropEdited(_, key)
         for _, v in pairs(self.items.me) do
             if IsValid(v) then v:updateLabel() end
         end
+    elseif key == "preset" then
+        local preset = liaVendorEnt:getNetVar("preset", "none")
+        if IsValid(self.preset) then
+            self.preset:SetValue(preset == "none" and L("none") or preset)
+        end
     end
 
     self:applyCategoryFilter()
@@ -680,11 +685,14 @@ function PANEL:Init()
     self.preset:Dock(TOP)
     self.preset:SetSortItems(false)
     self.preset:DockMargin(0, 4, 0, 0)
-    self.preset:SetValue(L("vendorSelectPreset"))
     self.preset:AddChoice(L("none"))
     for name in pairs(lia.vendor.presets or {}) do
         self.preset:AddChoice(name)
     end
+    local currentPreset = entity:getNetVar("preset", "none")
+    local presetLabel = currentPreset == "none" and L("none") or currentPreset
+    self.preset:SetValue(presetLabel)
+    self.preset:ChooseOption(presetLabel)
 
     self.preset.OnSelect = function(_, _, value) lia.vendor.editor.preset(value) end
 
@@ -806,6 +814,7 @@ end
 
 function PANEL:OnRowRightClick(line)
     local entity = liaVendorEnt
+    if entity:getNetVar("preset") ~= "none" then return end
     if IsValid(menu) then menu:Remove() end
     local uniqueID = line.item
     local itemTable = lia.item.list[uniqueID]

--- a/gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/init.lua
+++ b/gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/init.lua
@@ -192,6 +192,7 @@ end
 
 function ENT:applyPreset(name)
     name = string.lower(name)
+    self:setNetVar("preset", name)
     if name == "none" then
         self.items = {}
         for _, client in ipairs(self.receivers) do
@@ -202,11 +203,15 @@ function ENT:applyPreset(name)
 
     local preset = lia.vendor and lia.vendor.getPreset(name)
     if not preset then return end
+    self.items = {}
     for itemType, data in pairs(preset) do
         if data.mode ~= nil then self:setTradeMode(itemType, data.mode) end
         if data.price ~= nil then self:setItemPrice(itemType, data.price) end
         if data.maxStock ~= nil then self:setMaxStock(itemType, data.maxStock) end
         if data.stock ~= nil then self:setStock(itemType, data.stock) end
+    end
+    for _, client in ipairs(self.receivers) do
+        self:sync(client)
     end
 end
 

--- a/gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/shared.lua
+++ b/gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/shared.lua
@@ -19,6 +19,7 @@ function ENT:setupVars()
     self.factions = {}
     self.messages = {}
     self.classes = {}
+    self:setNetVar("preset", "none")
     self.hasSetupVars = true
 end
 
@@ -111,6 +112,10 @@ end
 
 function ENT:getName()
     return self:getNetVar("name", "")
+end
+
+function ENT:getPreset()
+    return self:getNetVar("preset", "none")
 end
 
 function ENT:setAnim()

--- a/gamemode/modules/inventory/submodules/vendor/libraries/server.lua
+++ b/gamemode/modules/inventory/submodules/vendor/libraries/server.lua
@@ -179,6 +179,7 @@ function MODULE:GetEntitySaveData(ent)
         flag = ent:getNetVar("flag"),
         scale = ent:getNetVar("scale"),
         welcomeMessage = ent:getNetVar("welcomeMessage"),
+        preset = ent:getNetVar("preset"),
     }
 end
 
@@ -188,6 +189,7 @@ function MODULE:OnEntityLoaded(ent, data)
     ent:setNetVar("flag", data.flag)
     ent:setNetVar("scale", data.scale or 0.5)
     ent:setNetVar("welcomeMessage", data.welcomeMessage)
+    ent:setNetVar("preset", data.preset or "none")
     ent.items = data.items or {}
     ent.factions = data.factions or {}
     ent.classes = data.classes or {}


### PR DESCRIPTION
## Summary
- lock item edits when a vendor preset is active
- save/restore vendor preset value
- show current preset in editor dropdown
- apply preset clears current items and syncs to clients

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687f8a44c0588327aa3605a875fb8fb9