### PR TITLE
Add example command for setting character data

### DIFF
--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -612,4 +612,23 @@ if not lia.admin.isDisabled() then
             end
         end
     })
+
+    lia.command.add("setdatatype", {
+        adminOnly = true,
+        desc = "Sets several example character data values.",
+        onRun = function(client)
+            local char = client:getChar()
+            if not char then
+                client:notifyLocalized("noCharacterLoaded")
+                return
+            end
+
+            char:setData("sampleNumber", 42)
+            char:setData("sampleString", "hello")
+            char:setData("sampleBool", true)
+            char:setData("sampleTable", {a = 1, b = 2})
+
+            client:notify("Example character data set.")
+        end
+    })
 end


### PR DESCRIPTION
## Summary
- add new admin command `setdatatype` that demonstrates storing multiple types of values via `char:setData`

## Testing
- `git commit -m "Add setdatatype command"`

------
https://chatgpt.com/codex/tasks/task_e_687f9af1c0748327810589002191bf99