### PR TITLE
Fix char data cleanup on deletion

### DIFF
--- a/gamemode/core/libraries/character.lua
+++ b/gamemode/core/libraries/character.lua
@@ -616,6 +616,7 @@ if SERVER then
 
         lia.char.loaded[id] = nil
         lia.db.query("DELETE FROM lia_characters WHERE _id = " .. id)
+        lia.db.delete("chardata", "_charID = " .. id)
         lia.db.query("SELECT _invID FROM lia_inventories WHERE _charID = " .. id, function(data)
             if data then
                 for _, inventory in ipairs(data) do


### PR DESCRIPTION
## Summary
- ensure lia_chardata entries are removed when deleting a character

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fa5805b088327bc30e6dfe4bad68a