### PR TITLE
Add ticket claim logging table

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -406,6 +406,12 @@ function lia.db.loadTables()
                 _steamID VARCHAR
             );
 
+            CREATE TABLE IF NOT EXISTS lia_ticketclaims (
+                _request TEXT,
+                _admin TEXT,
+                _timestamp INTEGER
+            );
+
             CREATE TABLE IF NOT EXISTS lia_doors (
                 _folder TEXT,
                 _map TEXT,
@@ -533,6 +539,12 @@ function lia.db.loadTables()
                 `_charID` INT(12) NULL,
                 `_steamID` VARCHAR(20) NULL COLLATE 'utf8mb4_general_ci',
                 PRIMARY KEY (`_id`)
+            );
+
+            CREATE TABLE IF NOT EXISTS `lia_ticketclaims` (
+                `_request` VARCHAR(64) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `_admin` VARCHAR(64) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `_timestamp` INT(32) NOT NULL
             );
 
             CREATE TABLE IF NOT EXISTS `lia_doors` (

--- a/gamemode/modules/administration/submodules/tickets/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/tickets/libraries/server.lua
@@ -16,6 +16,12 @@
     caseclaims[admin:SteamID64()].lastclaim = os.time()
     caseclaims[admin:SteamID64()].claimedFor[requester:SteamID64()] = requester:Nick()
     lia.data.set("caseclaims", caseclaims, true)
+
+    lia.db.insertTable({
+        _request = requester:SteamID64(),
+        _admin = admin:SteamID64(),
+        _timestamp = os.time()
+    }, nil, "ticketclaims")
 end
 
 function MODULE:PlayerSay(client, text)


### PR DESCRIPTION
## Summary
- create `lia_ticketclaims` DB table for ticket claims
- log ticket claims to this new table when a staff member claims a ticket

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fac7bf18483278396c5f72afa5b9f