### PR TITLE
Move warnings to dedicated table

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -270,6 +270,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS `lia_sitrooms`;
     DROP TABLE IF EXISTS `lia_saveditems`;
     DROP TABLE IF EXISTS `lia_persistence`;
+    DROP TABLE IF EXISTS `lia_warnings`;
 ]])
             local done = 0
             for i = 1, #queries do
@@ -303,6 +304,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS lia_sitrooms;
     DROP TABLE IF EXISTS lia_saveditems;
     DROP TABLE IF EXISTS lia_persistence;
+    DROP TABLE IF EXISTS lia_warnings;
     DROP TABLE IF EXISTS lia_chardata;
 ]], realCallback)
     end
@@ -412,6 +414,15 @@ function lia.db.loadTables()
                 _request TEXT,
                 _admin TEXT,
                 _timestamp INTEGER
+            );
+
+            CREATE TABLE IF NOT EXISTS lia_warnings (
+                _id INTEGER PRIMARY KEY AUTOINCREMENT,
+                _charID INTEGER,
+                _steamID TEXT,
+                _timestamp DATETIME,
+                _reason TEXT,
+                _admin TEXT
             );
 
             CREATE TABLE IF NOT EXISTS lia_doors (
@@ -555,6 +566,16 @@ function lia.db.loadTables()
                 `_request` VARCHAR(64) NOT NULL COLLATE 'utf8mb4_general_ci',
                 `_admin` VARCHAR(64) NOT NULL COLLATE 'utf8mb4_general_ci',
                 `_timestamp` INT(32) NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS `lia_warnings` (
+                `_id` INT(12) NOT NULL AUTO_INCREMENT,
+                `_charID` INT(12) NULL DEFAULT NULL,
+                `_steamID` VARCHAR(64) NULL DEFAULT NULL COLLATE 'utf8mb4_general_ci',
+                `_timestamp` DATETIME NOT NULL,
+                `_reason` TEXT NULL COLLATE 'utf8mb4_general_ci',
+                `_admin` TEXT NULL COLLATE 'utf8mb4_general_ci',
+                PRIMARY KEY (`_id`)
             );
 
             CREATE TABLE IF NOT EXISTS `lia_doors` (

--- a/gamemode/modules/administration/submodules/logging/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/logging/libraries/server.lua
@@ -193,13 +193,15 @@ function MODULE:TicketSystemClose(admin, requester)
 end
 
 function MODULE:WarningIssued(admin, target, reason, index)
-    local warns = target:getLiliaData("warns") or {}
-    lia.log.add(admin, "warningIssued", target, reason, #warns, index)
+    lia.db.count("warnings", "_charID = " .. lia.db.convertDataType(target:getChar():getID())):next(function(count)
+        lia.log.add(admin, "warningIssued", target, reason, count, index)
+    end)
 end
 
 function MODULE:WarningRemoved(admin, target, warning, index)
-    local warns = target:getLiliaData("warns") or {}
-    lia.log.add(admin, "warningRemoved", target, warning, #warns, index)
+    lia.db.count("warnings", "_charID = " .. lia.db.convertDataType(target:getChar():getID())):next(function(count)
+        lia.log.add(admin, "warningRemoved", target, warning, count, index)
+    end)
 end
 
 function MODULE:ItemTransfered(context)

--- a/gamemode/modules/administration/submodules/warns/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/warns/libraries/server.lua
@@ -1,4 +1,35 @@
-﻿net.Receive("RequestRemoveWarning", function(_, client)
+local MODULE = MODULE
+
+function MODULE:GetWarnings(charID)
+    local condition = "_charID = " .. lia.db.convertDataType(charID)
+    return lia.db.select({"_id", "_timestamp", "_reason", "_admin"}, "warnings", condition):next(function(res)
+        return res.results or {}
+    end)
+end
+
+function MODULE:AddWarning(charID, steamID, timestamp, reason, admin)
+    lia.db.insertTable({
+        _charID = charID,
+        _steamID = steamID,
+        _timestamp = timestamp,
+        _reason = reason,
+        _admin = admin
+    }, nil, "warnings")
+end
+
+function MODULE:RemoveWarning(charID, index)
+    local d = deferred.new()
+    self:GetWarnings(charID):next(function(rows)
+        if index < 1 or index > #rows then return d:resolve(nil) end
+        local row = rows[index]
+        lia.db.delete("warnings", "_id = " .. lia.db.convertDataType(row._id)):next(function()
+            d:resolve(row)
+        end)
+    end)
+    return d
+end
+
+net.Receive("RequestRemoveWarning", function(_, client)
     if not client:hasPrivilege("Staff Permissions - Can Remove Warns") then return end
     local charID = net.ReadInt(32)
     local rowData = net.ReadTable()
@@ -8,28 +39,26 @@
         return
     end
 
-    local targetClient = lia.char.getBySteamID(charID)
-    if not IsValid(targetClient) then
-        client:notifyLocalized("playerNotFound")
-        return
-    end
-
-    local targetChar = targetClient:getChar()
+    local targetChar = lia.char.loaded[charID]
     if not targetChar then
         client:notifyLocalized("characterNotFound")
         return
     end
 
-    local warns = targetClient:getLiliaData("warns") or {}
-    if warnIndex < 1 or warnIndex > #warns then
-        client:notifyLocalized("invalidWarningIndex")
+    local targetClient = targetChar:getPlayer()
+    if not IsValid(targetClient) then
+        client:notifyLocalized("playerNotFound")
         return
     end
 
-    local warning = warns[warnIndex]
-    table.remove(warns, warnIndex)
-    targetClient:setLiliaData("warns", warns)
-    targetClient:notifyLocalized("warningRemovedNotify", client:Nick())
-    client:notifyLocalized("warningRemoved", warnIndex, targetClient:Nick())
-    hook.Run("WarningRemoved", client, targetClient, warning, warnIndex)
+    MODULE:RemoveWarning(charID, warnIndex):next(function(warn)
+        if not warn then
+            client:notifyLocalized("invalidWarningIndex")
+            return
+        end
+
+        targetClient:notifyLocalized("warningRemovedNotify", client:Nick())
+        client:notifyLocalized("warningRemoved", warnIndex, targetClient:Nick())
+        hook.Run("WarningRemoved", client, targetClient, {reason = warn._reason, admin = warn._admin}, warnIndex)
+    end)
 end)

--- a/gamemode/modules/protection/commands.lua
+++ b/gamemode/modules/protection/commands.lua
@@ -1,4 +1,6 @@
-﻿lia.command.add("togglecheater", {
+local MODULE = MODULE
+
+lia.command.add("togglecheater", {
     adminOnly = true,
     privilege = "Toggle Cheater Status",
     desc = "toggleCheaterDesc",
@@ -20,18 +22,17 @@
         else
             client:notifyLocalized("cheaterMarked", target:Name())
             target:notifyLocalized("cheaterMarkedByAdmin")
-            local warning = {
-                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
-                reason = L("cheaterWarningReason"),
-                admin = client:Nick() .. " (" .. client:SteamID() .. ")"
-            }
-
-            local warns = target:getLiliaData("warns") or {}
-            table.insert(warns, warning)
-            target:setLiliaData("warns", warns)
-            target:notifyLocalized("playerWarned", warning.admin, warning.reason)
-            client:notifyLocalized("warningIssued", target:Nick())
-            hook.Run("WarningIssued", client, target, warning.reason, #warns)
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            local adminStr = client:Nick() .. " (" .. client:SteamID() .. ")"
+            local warnsModule = lia.module.list["warns"]
+            if warnsModule and warnsModule.AddWarning then
+                warnsModule:AddWarning(target:getChar():getID(), target:SteamID64(), timestamp, L("cheaterWarningReason"), adminStr)
+                lia.db.count("warnings", "_charID = " .. lia.db.convertDataType(target:getChar():getID())):next(function(count)
+                    target:notifyLocalized("playerWarned", adminStr, L("cheaterWarningReason"))
+                    client:notifyLocalized("warningIssued", target:Nick())
+                    hook.Run("WarningIssued", client, target, L("cheaterWarningReason"), count)
+                end)
+            end
         end
 
         lia.log.add(client, "cheaterToggle", target:Name(), isCheater and "Unmarked" or "Marked")


### PR DESCRIPTION
## Summary
- store player warnings in new `lia_warnings` table
- log warning activity using new table
- adjust warn commands and cheater toggle command to use database
- support removal via database

## Testing
- `luac` not available, unable to run syntax checks

------
https://chatgpt.com/codex/tasks/task_e_687fb6fcaff483278c518303c7f86b9e