### PR TITLE
Move table creation to database.lua

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -465,6 +465,34 @@ function lia.db.loadTables()
                 PRIMARY KEY (_folder, _map, _name)
             );
 
+            CREATE TABLE IF NOT EXISTS lia_data (
+                _folder TEXT,
+                _map TEXT,
+                _data TEXT,
+                PRIMARY KEY (_folder, _map)
+            );
+
+            CREATE TABLE IF NOT EXISTS lia_persistence (
+                _id INTEGER PRIMARY KEY AUTOINCREMENT,
+                _folder TEXT,
+                _map TEXT,
+                class TEXT,
+                pos TEXT,
+                angles TEXT,
+                model TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS lia_vendors (
+                _id INTEGER PRIMARY KEY AUTOINCREMENT,
+                _folder TEXT,
+                _map TEXT,
+                class TEXT,
+                pos TEXT,
+                angles TEXT,
+                model TEXT,
+                data TEXT
+            );
+
             CREATE TABLE IF NOT EXISTS lia_saveditems (
                 _id INTEGER PRIMARY KEY AUTOINCREMENT,
                 _schema TEXT,
@@ -616,6 +644,36 @@ function lia.db.loadTables()
                 `_name` TEXT NULL,
                 `_pos` TEXT NULL,
                 PRIMARY KEY (`_folder`, `_map`, `_name`)
+            );
+
+            CREATE TABLE IF NOT EXISTS `lia_data` (
+                `_folder` TEXT NULL,
+                `_map` TEXT NULL,
+                `_data` TEXT NULL,
+                PRIMARY KEY (`_folder`, `_map`)
+            );
+
+            CREATE TABLE IF NOT EXISTS `lia_persistence` (
+                `_id` INT(12) NOT NULL AUTO_INCREMENT,
+                `_folder` TEXT NULL,
+                `_map` TEXT NULL,
+                `class` TEXT NULL,
+                `pos` TEXT NULL,
+                `angles` TEXT NULL,
+                `model` TEXT NULL,
+                PRIMARY KEY (`_id`)
+            );
+
+            CREATE TABLE IF NOT EXISTS `lia_vendors` (
+                `_id` INT(12) NOT NULL AUTO_INCREMENT,
+                `_folder` TEXT NULL,
+                `_map` TEXT NULL,
+                `class` TEXT NULL,
+                `pos` TEXT NULL,
+                `angles` TEXT NULL,
+                `model` TEXT NULL,
+                `data` TEXT NULL,
+                PRIMARY KEY (`_id`)
             );
 
             CREATE TABLE IF NOT EXISTS `lia_saveditems` (

--- a/gamemode/core/libraries/logger.lua
+++ b/gamemode/core/libraries/logger.lua
@@ -1,33 +1,8 @@
 ﻿lia.log = lia.log or {}
 lia.log.types = lia.log.types or {}
 if SERVER then
-    local function createLogsTable()
-        if lia.db.module == "sqlite" then
-            lia.db.query([[CREATE TABLE IF NOT EXISTS lia_logs (
-                _id INTEGER PRIMARY KEY AUTOINCREMENT,
-                _timestamp DATETIME,
-                _gamemode VARCHAR,
-                _category VARCHAR,
-                _message TEXT,
-                _charID INTEGER,
-                _steamID VARCHAR
-            );]])
-        else
-            lia.db.query([[CREATE TABLE IF NOT EXISTS `lia_logs` (
-                `_id` INT(12) NOT NULL AUTO_INCREMENT,
-                `_timestamp` DATETIME NOT NULL,
-                `_gamemode` VARCHAR(50) NOT NULL COLLATE 'utf8mb4_general_ci',
-                `_category` VARCHAR(255) NOT NULL COLLATE 'utf8mb4_general_ci',
-                `_message` TEXT NOT NULL COLLATE 'utf8mb4_general_ci',
-                `_charID` INT(12) NULL,
-                `_steamID` VARCHAR(20) NULL COLLATE 'utf8mb4_general_ci',
-                PRIMARY KEY (`_id`)
-            );]])
-        end
-    end
-
     function lia.log.loadTables()
-        createLogsTable()
+        -- Table creation moved to lia.db.loadTables
     end
 
     function lia.log.addType(logType, func, category)


### PR DESCRIPTION
## Summary
- centralize database table creation inside `database.lua`
- rely on `database.lua` for persistence and log tables

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fd278a69883278703d2daa0eefda2