### PR TITLE
Fix stamina drain for vehicle sprinting

### DIFF
--- a/gamemode/modules/attributes/libraries/shared.lua
+++ b/gamemode/modules/attributes/libraries/shared.lua
@@ -3,7 +3,11 @@
     if not char or client:isNoClipping() then return 1 end
     local walkSpeed = lia.config.get("WalkSpeed", client:GetWalkSpeed())
     local offset
-    if client:KeyDown(IN_SPEED) and client:GetVelocity():LengthSqr() >= walkSpeed * walkSpeed then
+    local draining = client:KeyDown(IN_SPEED) and (
+        client:GetVelocity():LengthSqr() >= walkSpeed * walkSpeed or
+        (client:InVehicle() and not client:OnGround())
+    )
+    if draining then
         offset = -lia.config.get("StaminaDrain", 1)
     else
         offset = client:Crouching() and lia.config.get("StaminaCrouchRegeneration", 2) or lia.config.get("StaminaRegeneration", 1.75)


### PR DESCRIPTION
## Summary
- update stamina check so holding Sprint while in a vehicle and off the ground drains stamina

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fd34233b48327b93e8af613ab7f7c