### PR TITLE
Increase view distance cap

### DIFF
--- a/gamemode/core/libraries/config.lua
+++ b/gamemode/core/libraries/config.lua
@@ -441,12 +441,13 @@ lia.config.add("MaxThirdPersonHeight", "Maximum Third-Person Height Offset", 30,
     type = "Int"
 })
 
-lia.config.add("MaxViewDistance", "Maximum View Distance", 5000, nil, {
-    desc = "The maximum distance (in units) at which players are visible.",
+lia.config.add("MaxViewDistance", "Maximum View Distance", 32768, nil, {
+    desc = "The maximum distance (in units) at which players are visible."
+        .. " This default covers an entire Source map (~32k units).",
     category = "Quality of Life",
     type = "Int",
     min = 1000,
-    max = 5000,
+    max = 32768,
 })
 
 lia.config.add("AutoDownloadWorkshop", "Auto Download Workshop Content", true, nil, {


### PR DESCRIPTION
## Summary
- extend `MaxViewDistance` setting so the maximum possible is the size of a Source engine map (32k units)

## Testing
- `luacheck .` *(fails: command not found)*
- `apt-get update` *(fails: internet is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_687fd5e6cc64832792f8f125d55795da