### PR TITLE
Add SAM detection to disable built‑in admin commands

### DIFF
--- a/documentation/docs/hooks/gamemode_hooks.md
+++ b/documentation/docs/hooks/gamemode_hooks.md
@@ -3328,6 +3328,38 @@ end)
 
 ---
 
+### ShouldLiliaAdminCommandsLoad
+
+**Purpose**
+
+Controls whether the built-in admin commands should be registered. This allows
+external admin systems to take over while still letting the rest of Lilia load.
+
+**Parameters**
+
+- None
+
+**Realm**
+
+`Shared`
+
+**Returns**
+
+- `boolean?`: Return `false` to prevent Lilia's admin commands from loading.
+
+**Example Usage**
+
+```lua
+-- Use commands from another admin mod instead
+hook.Add("ShouldLiliaAdminCommandsLoad", "liaSam", function()
+    return false
+end)
+```
+
+This hook automatically returns `false` when SAM is detected so that SAM's command set can take over.
+
+---
+
 ### RunAdminSystemCommand
 
 **Purpose**

--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -4,7 +4,9 @@ lia.admin.groups = lia.admin.groups or {}
 lia.admin.banList = lia.admin.banList or {}
 lia.admin.privileges = lia.admin.privileges or {}
 function lia.admin.isDisabled()
-    return hook.Run("ShouldLiliaAdminLoad") == false
+    local sysDisabled = hook.Run("ShouldLiliaAdminLoad") == false
+    local cmdDisabled = hook.Run("ShouldLiliaAdminCommandsLoad") == false
+    return sysDisabled, cmdDisabled
 end
 
 function lia.admin.load()

--- a/gamemode/core/libraries/compatibility/sam.lua
+++ b/gamemode/core/libraries/compatibility/sam.lua
@@ -1,4 +1,9 @@
 ﻿hook.Remove("PostGamemodeLoaded", "SAM.DarkRP")
+-- Disable Lilia's default admin commands when SAM is installed
+hook.Add("ShouldLiliaAdminCommandsLoad", "liaSAM", function()
+    return false
+end)
+
 hook.Add("InitializedModules", "liaSAM", function()
     for _, commandInfo in ipairs(sam.command.get_commands()) do
         local customSyntax = ""

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -162,7 +162,8 @@ lia.command.add("returnsitroom", {
     end
 })
 
-if not lia.admin.isDisabled() then
+local sysDisabled, cmdsDisabled = lia.admin.isDisabled()
+if not sysDisabled and not cmdsDisabled then
     lia.command.add("plykick", {
         adminOnly = true,
         privilege = "Kick Player",


### PR DESCRIPTION
## Summary
- disable Lilia admin commands via `ShouldLiliaAdminCommandsLoad` when SAM is installed
- clarify that the hook returns false automatically if SAM is detected

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fd53e57648327b1e9c75153088e06