### PR TITLE
Fix module field type docs

### DIFF
--- a/documentation/docs/definitions/module.md
+++ b/documentation/docs/definitions/module.md
@@ -43,7 +43,7 @@ A `MODULE` table defines a self-contained add-on for the Lilia framework. Each f
 
 **Type:**
 
-`number`
+`string`
 
 **Description:**
 
@@ -61,7 +61,7 @@ MODULE.name = "My Module"
 
 **Type:**
 
-`number`
+`string`
 
 **Description:**
 
@@ -79,7 +79,7 @@ MODULE.author = "Samael"
 
 **Type:**
 
-`number`
+`string`
 
 **Description:**
 


### PR DESCRIPTION
## Summary
- correct `name`, `author`, and `discord` field types in the module documentation

## Testing
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687fe46ae07883279578b50a84a8dd6b