### PR TITLE
Fix example constant in entity doc

### DIFF
--- a/documentation/docs/meta/entity.md
+++ b/documentation/docs/meta/entity.md
@@ -184,7 +184,7 @@ Defaults to `DOOR_GUEST` when no access level is provided.
 
 ```lua
 -- Block a player from opening the door without access
-if not door:checkDoorAccess(client, DOOR_ACCESS_OPEN) then
+if not door:checkDoorAccess(client, DOOR_GUEST) then
     client:notifyLocalized("doorLocked")
 end
 ```


### PR DESCRIPTION
## Summary
- fix door access constant in `entity.md`

## Testing
- `grep -n "DOOR_GUEST" -n documentation/docs/meta/entity.md | head`


------
https://chatgpt.com/codex/tasks/task_e_687fe512c10c832789827b2f005ac353