### PR TITLE
Fix markup docs

### DIFF
--- a/documentation/docs/libraries/lia.markup.md
+++ b/documentation/docs/libraries/lia.markup.md
@@ -60,7 +60,8 @@ Constructs an empty markup object (usually returned by `lia.markup.parse`).
 **Example Usage**
 
 ```lua
-local obj = lia.markup.MarkupObject:create()
+-- Usually markup objects are created via lia.markup.parse
+local obj = lia.markup.parse("")
 ```
 
 ---
@@ -174,7 +175,7 @@ Draws the markup object at the specified screen position.
 
 * `valign` (*number | nil*): Vertical alignment. *Optional*.
 
-* `alpha` (*number | nil*): Alpha override. *Optional*.
+* `alphaoverride` (*number | nil*): Alpha override. *Optional*.
 
 **Realm**
 


### PR DESCRIPTION
## Summary
- update `lia.markup` documentation example to show correct usage
- match parameter name `alphaoverride` with code

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fe4e381508327a2f0da1f6f2c30c4