### PR TITLE
Fix realm docs for lia.config.forceSet

### DIFF
--- a/documentation/docs/libraries/lia.config.md
+++ b/documentation/docs/libraries/lia.config.md
@@ -106,7 +106,7 @@ Sets a config value directly without running callbacks or networking the update.
 
 **Realm**
 
-`Shared`
+`Server`
 
 **Returns**
 


### PR DESCRIPTION
## Summary
- correct the realm annotation for `lia.config.forceSet`

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_687fe4a4a75c832781f627c96f97e7a3