### PR TITLE
Fix undo text to include item name

### DIFF
--- a/gamemode/modules/administration/submodules/itemspawner/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/itemspawner/libraries/server.lua
@@ -44,6 +44,7 @@ net.Receive("SpawnMenuSpawnItem", function(_, client)
         undo.SetPlayer(client)
         undo.AddEntity(ent)
         local name = lia.item.list[id] and lia.item.list[id].name or id
+        undo.SetCustomUndoText("Undone " .. name)
         undo.Finish("Item (" .. name .. ")")
         lia.log.add(client, "spawnItem", name, "SpawnMenuSpawnItem")
     end, angle_zero, {})


### PR DESCRIPTION
## Summary
- show item name when undoing spawned items

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68800904f7d48327be0c77f03d36dccb