### PR TITLE
Fix DB sync when inventory size config changes

### DIFF
--- a/gamemode/modules/inventory/config.lua
+++ b/gamemode/modules/inventory/config.lua
@@ -1,4 +1,4 @@
-﻿lia.config.add("invW", "Inventory Width", 6, function(_, newW)
+lia.config.add("invW", "Inventory Width", 6, function(_, newW)
     if not SERVER then return end
     for _, client in player.Iterator() do
         if not IsValid(client) then continue end
@@ -12,6 +12,11 @@
             inv:sync(client)
         end
     end
+    local json = util.TableToJSON({newW})
+    lia.db.query(
+        "UPDATE lia_invdata SET _value = '" .. lia.db.escape(json) .. "' " ..
+        "WHERE _key = 'w' AND _invID IN (SELECT _invID FROM lia_inventories WHERE _charID IS NOT NULL)"
+    )
 end, {
     desc = "Defines the width of the default inventory.",
     category = "Character",
@@ -34,6 +39,11 @@ lia.config.add("invH", "Inventory Height", 4, function(_, newH)
             inv:sync(client)
         end
     end
+    local json = util.TableToJSON({newH})
+    lia.db.query(
+        "UPDATE lia_invdata SET _value = '" .. lia.db.escape(json) .. "' " ..
+        "WHERE _key = 'h' AND _invID IN (SELECT _invID FROM lia_inventories WHERE _charID IS NOT NULL)"
+    )
 end, {
     desc = "Defines the height of the default inventory.",
     category = "Character",


### PR DESCRIPTION
## Summary
- update all stored inventory sizes when inventory width/height configs change

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880094a84dc83279d0e572702b93e00