### PR TITLE
Fix vendor preset updates

### DIFF
--- a/gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/init.lua
+++ b/gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/init.lua
@@ -215,6 +215,9 @@ function ENT:applyPreset(name)
         for _, client in ipairs(self.receivers) do
             self:sync(client)
         end
+        net.Start("VendorEdit")
+        net.WriteString("preset")
+        net.Send(self.receivers)
         return
     end
 
@@ -231,6 +234,9 @@ function ENT:applyPreset(name)
     for _, client in ipairs(self.receivers) do
         self:sync(client)
     end
+    net.Start("VendorEdit")
+    net.WriteString("preset")
+    net.Send(self.receivers)
 end
 
 function ENT:sync(client)


### PR DESCRIPTION
## Summary
- ensure changing a vendor preset broadcasts a `VendorEdit` update

## Testing
- `luacheck --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68801fe9e3608327a3bfbcaf55c90661