### PR TITLE
Use styled checkboxes for user groups

### DIFF
--- a/documentation/docs/definitions/panels.md
+++ b/documentation/docs/definitions/panels.md
@@ -62,6 +62,7 @@ Panels provide the building blocks for Lilia's user interface. Most derive from 
 | `liaMiniButton` | `DButton` | Very small button variant. |
 | `liaNoBGButton` | `DButton` | Text-only button with no background. |
 | `liaQuick` | `EditablePanel` | Quick settings panel showing options flagged with `isQuick`. |
+| `liaCheckBox` | `DButton` | Checkbox that draws the config icons. |
 
 ---
 
@@ -658,6 +659,25 @@ Quick settings menu that lists options flagged with `isQuick`.
 
 ```lua
 vgui.Create("liaQuick")
+```
+
+---
+
+### `liaCheckBox`
+
+**Base Panel:**
+
+`DButton`
+
+**Description:**
+
+Checkbox that paints the same checkmark icons used in the configuration menu.
+
+**Example Usage:**
+
+```lua
+local cb = vgui.Create("liaCheckBox")
+cb:SetChecked(true)
 ```
 
 ---

--- a/gamemode/core/derma/panels/checkbox.lua
+++ b/gamemode/core/derma/panels/checkbox.lua
@@ -1,0 +1,32 @@
+local PANEL = {}
+
+function PANEL:Init()
+    self:SetText("")
+    self:SetToggle(true)
+    self:SetSize(22, 22)
+    self.checked = false
+end
+
+function PANEL:SetChecked(state)
+    self.checked = state and true or false
+    self:SetSelected(self.checked)
+    if self.OnChange then
+        self:OnChange(self.checked)
+    end
+end
+
+function PANEL:GetChecked()
+    return self.checked
+end
+
+function PANEL:DoClick()
+    self:SetChecked(not self.checked)
+end
+
+function PANEL:Paint(w, h)
+    local icon = self.checked and "checkbox.png" or "unchecked.png"
+    lia.util.drawTexture(icon, color_white, 0, 0, w, h)
+    return true
+end
+
+vgui.Register("liaCheckBox", PANEL, "DButton")

--- a/gamemode/modules/administration/submodules/usergroups/module.lua
+++ b/gamemode/modules/administration/submodules/usergroups/module.lua
@@ -249,10 +249,10 @@ else
             setFont(lbl, "liaMediumFont")
             lbl:SizeToContents()
             lbl:DockMargin(0, lblOffset, 8, 0)
-            local chk = row:Add("DCheckBox")
+            local chk = row:Add("liaCheckBox")
             chk:Dock(LEFT)
             chk:SetWide(22)
-            chk:SetValue(current[priv] and 1 or 0)
+            chk:SetChecked(current[priv] and true or false)
             chk.OnChange = function(_, v)
                 if v then
                     current[priv] = true
@@ -273,7 +273,7 @@ else
         listHolder:SetTall(totalH)
         local function setAll(state)
             for _, cb in ipairs(checkboxes) do
-                cb:SetValue(state)
+                cb:SetChecked(state)
             end
         end
 


### PR DESCRIPTION
## Summary
- add a new `liaCheckBox` panel that draws checkbox icons used in the config menu
- switch user group privilege rows to use `liaCheckBox`
- update usergroups UI to use `SetChecked` for toggling all checkboxes
- document the `liaCheckBox` panel in the panel reference

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68802c991208832789406d64f10a8d45