### PR TITLE
Enable CAMI integration for usergroup changes

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -3,6 +3,11 @@ lia.admin.bans = lia.admin.bans or {}
 lia.admin.groups = lia.admin.groups or {}
 lia.admin.banList = lia.admin.banList or {}
 lia.admin.privileges = lia.admin.privileges or {}
+local DEFAULT_GROUPS = {
+    user = true,
+    admin = true,
+    superadmin = true,
+}
 function lia.admin.isDisabled()
     local sysDisabled = hook.Run("ShouldLiliaAdminLoad") == false
     local cmdDisabled = hook.Run("ShouldLiliaAdminCommandsLoad") == false
@@ -71,7 +76,15 @@ function lia.admin.createGroup(groupName, info)
     end
 
     lia.admin.groups[groupName] = info or {}
-    if SERVER then lia.admin.save(true) end
+    if SERVER then
+        if not CAMI.GetUsergroup(groupName) then
+            CAMI.RegisterUsergroup({
+                Name = groupName,
+                Inherits = "user",
+            })
+        end
+        lia.admin.save(true)
+    end
 end
 
 function lia.admin.registerPrivilege(privilege)
@@ -93,7 +106,10 @@ function lia.admin.removeGroup(groupName)
     end
 
     lia.admin.groups[groupName] = nil
-    if SERVER then lia.admin.save(true) end
+    if SERVER then
+        CAMI.UnregisterUsergroup(groupName)
+        lia.admin.save(true)
+    end
 end
 
 if SERVER then
@@ -104,8 +120,13 @@ if SERVER then
             return
         end
 
+        if DEFAULT_GROUPS[groupName] then return end
+
         lia.admin.groups[groupName][permission] = true
-        if SERVER then lia.admin.save(true) end
+        if SERVER then
+            lia.admin.save(true)
+            hook.Run("CAMI.OnUsergroupPermissionsChanged", groupName, lia.admin.groups[groupName])
+        end
     end
 
     function lia.admin.removePermission(groupName, permission)
@@ -115,8 +136,13 @@ if SERVER then
             return
         end
 
+        if DEFAULT_GROUPS[groupName] then return end
+
         lia.admin.groups[groupName][permission] = nil
-        if SERVER then lia.admin.save(true) end
+        if SERVER then
+            lia.admin.save(true)
+            hook.Run("CAMI.OnUsergroupPermissionsChanged", groupName, lia.admin.groups[groupName])
+        end
     end
 
     function lia.admin.save(network)
@@ -134,7 +160,9 @@ if SERVER then
 
     function lia.admin.setPlayerGroup(ply, usergroup)
         if lia.admin.isDisabled() then return end
+        local old = ply:GetUserGroup()
         ply:SetUserGroup(usergroup)
+        CAMI.SignalUserGroupChanged(ply, old, usergroup, "Lilia")
         lia.db.query(Format("UPDATE lia_players SET _userGroup = '%s' WHERE _steamID = %s", lia.db.escape(usergroup), ply:SteamID64()))
     end
 
@@ -317,5 +345,16 @@ concommand.Add("plysetgroup", function(ply, _, args)
         else
             MsgC(Color(200, 20, 20), "[Lilia Administration] Error: specified player not found.\n")
         end
+    end
+end)
+
+hook.Add("CAMI.PlayerHasAccess", "liaAdminPermissions", function(_, ply, priv, cb)
+    if lia.admin.isDisabled() then return end
+    if not IsValid(ply) then return end
+    local group = ply:GetUserGroup()
+    local perms = lia.admin.groups[group]
+    if perms and perms[priv] then
+        cb(true)
+        return true
     end
 end)


### PR DESCRIPTION
## Summary
- register/unregister CAMI usergroups when creating/removing groups
- propagate permission changes through CAMI hooks
- signal player group changes via CAMI
- add a `CAMI.PlayerHasAccess` hook so CAMI checks use Lilia's groups
- prevent editing default usergroups

## Testing
- `luacheck gamemode --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68802f61b8b883279a6d71a080e008ca