### PR TITLE
Handle negative update count

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -890,7 +890,9 @@ local function checkFrameworkVersion()
             if localNum and remoteNum then
                 local diff = remoteNum - localNum
                 diff = math.Round(diff, 3)
-                lia.updater(L("frameworkBehindCount", diff))
+                if diff > 0 then
+                    lia.updater(L("frameworkBehindCount", diff))
+                end
             end
 
             lia.updater(L("frameworkOutdated"))


### PR DESCRIPTION
## Summary
- avoid showing negative update counts when comparing framework versions

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688033bc546483279b80d76ed79e54f4