### PR TITLE
Fix bodygroup data being loaded as strings

### DIFF
--- a/gamemode/core/derma/mainmenu/character.lua
+++ b/gamemode/core/derma/mainmenu/character.lua
@@ -520,9 +520,13 @@ function PANEL:updateModelEntity(character)
     self.modelEntity = ClientsideModel(model, RENDERGROUP_OPAQUE)
     if not IsValid(self.modelEntity) then return end
     self.modelEntity:SetSkin(character:getData("skin", 0))
+    local groups = character:getData("groups", {})
     for i = 0, self.modelEntity:GetNumBodyGroups() - 1 do
-        local groups = character:getData("groups", {})
-        if groups[i] then self.modelEntity:SetBodygroup(i, groups[i]) end
+        local value = groups[i]
+        if value == nil then value = groups[tostring(i)] end
+        if value ~= nil then
+            self.modelEntity:SetBodygroup(i, tonumber(value) or 0)
+        end
     end
 
     hook.Run("SetupPlayerModel", self.modelEntity, character)

--- a/gamemode/core/meta/character.lua
+++ b/gamemode/core/meta/character.lua
@@ -434,7 +434,11 @@ if SERVER then
             client:SetTeam(self:getFaction())
             client:setNetVar("char", self:getID())
             for k, v in pairs(self:getData("groups", {})) do
-                client:SetBodygroup(k, v)
+                local index = tonumber(k)
+                local value = tonumber(v) or 0
+                if index then
+                    client:SetBodygroup(index, value)
+                end
             end
 
             client:SetSkin(self:getData("skin", 0))


### PR DESCRIPTION
## Summary
- ensure bodygroup values are numeric when spawning the model in the main menu
- sanitize bodygroup indices and values on player setup

## Testing
- `luacheck gamemode --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: `luacheck` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880998cf3588327acf2ac8e9910952c