### PR TITLE
Fix bodygroup editor visibility

### DIFF
--- a/gamemode/modules/inventory/submodules/vendor/derma/client.lua
+++ b/gamemode/modules/inventory/submodules/vendor/derma/client.lua
@@ -632,7 +632,15 @@ function PANEL:Init()
         end
     end
 
-    if entity:GetNumBodyGroups() > 0 then
+    local hasBodygroups = false
+    for i = 0, entity:GetNumBodyGroups() - 1 do
+        if entity:GetBodygroupCount(i) > 1 then
+            hasBodygroups = true
+            break
+        end
+    end
+
+    if hasBodygroups or entity:SkinCount() > 1 then
         self.bodygroups = self:Add("DButton")
         self.bodygroups:Dock(TOP)
         self.bodygroups:DockMargin(0, 4, 0, 0)


### PR DESCRIPTION
## Summary
- check for adjustable bodygroups before adding the button
- only show the bodygroup editor when the model actually has bodygroups or multiple skins

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880a17bb8948327b560603c4b224e8e