### PR TITLE
Fix item rotation overlap

### DIFF
--- a/gamemode/core/libraries/item.lua
+++ b/gamemode/core/libraries/item.lua
@@ -65,7 +65,39 @@ local DefaultFunctions = {
         tip = "rotateTip",
         icon = "icon16/arrow_rotate_clockwise.png",
         onRun = function(item)
-            item:setData("rotated", not item:getData("rotated", false))
+            local inv = lia.item.getInv(item.invID)
+            local x, y = item:getData("x"), item:getData("y")
+            local newRot = not item:getData("rotated", false)
+            if inv and x and y then
+                local w = newRot and (item.height or 1) or item.width or 1
+                local h = newRot and (item.width or 1) or item.height or 1
+                local invW, invH = inv:getSize()
+                if x < 1 or y < 1 or x + w - 1 > invW or y + h - 1 > invH then
+                    if item.player and item.player.notifyLocalized then
+                        item.player:notifyLocalized("itemNoFit", w, h)
+                    end
+                    return false
+                end
+                for _, v in pairs(inv:getItems(true)) do
+                    if v ~= item then
+                        local ix, iy = v:getData("x"), v:getData("y")
+                        if ix and iy then
+                            local ix2 = ix + v:getWidth() - 1
+                            local iy2 = iy + v:getHeight() - 1
+                            local x2 = x + w - 1
+                            local y2 = y + h - 1
+                            if x <= ix2 and ix <= x2 and y <= iy2 and iy <= y2 then
+                                if item.player and item.player.notifyLocalized then
+                                    item.player:notifyLocalized("itemNoFit", w, h)
+                                end
+                                return false
+                            end
+                        end
+                    end
+                end
+            end
+
+            item:setData("rotated", newRot)
             return false
         end,
         onCanRun = function(item) return not IsValid(item.entity) and item.width ~= item.height end


### PR DESCRIPTION
## Summary
- prevent items from rotating if the new orientation would overlap or exceed the grid

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880a2c39b7083279d1ce6110fa4acb4