### PR TITLE
Fix character switch cooldown rejection

### DIFF
--- a/gamemode/core/derma/mainmenu/character.lua
+++ b/gamemode/core/derma/mainmenu/character.lua
@@ -495,7 +495,11 @@ function PANEL:createSelectedCharacterInfoPanel(character)
     end
 
     self.selectBtn.DoClick = function()
-        lia.module.list["mainmenu"]:chooseCharacter(character:getID())
+        lia.module.list["mainmenu"]:chooseCharacter(character:getID()):catch(function(err)
+            if err and err ~= "" then
+                LocalPlayer():notifyLocalized(err)
+            end
+        end)
         self:Remove()
     end
 

--- a/gamemode/modules/administration/netcalls/client.lua
+++ b/gamemode/modules/administration/netcalls/client.lua
@@ -78,6 +78,12 @@ net.Receive("AdminModeSwapCharacter", function()
         end
     end)
 
+    d:catch(function(err)
+        if err and err ~= "" then
+            LocalPlayer():notifyLocalized(err)
+        end
+    end)
+
     net.Start("liaCharChoose")
     net.WriteUInt(id, 32)
     net.SendToServer()


### PR DESCRIPTION
## Summary
- handle character switch rejections from the server
- do the same when switching characters in admin mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880a625f5b883278f052e4a0fc8b16d