### PR TITLE
Use DB values for spawn operations

### DIFF
--- a/gamemode/modules/spawns/commands.lua
+++ b/gamemode/modules/spawns/commands.lua
@@ -18,16 +18,18 @@ lia.command.add("spawnadd", {
         end
 
         if factionInfo then
-            MODULE.spawns[factionInfo.uniqueID] = MODULE.spawns[factionInfo.uniqueID] or {}
-            table.insert(MODULE.spawns[factionInfo.uniqueID], {
-                pos = client:GetPos(),
-                ang = client:EyeAngles()
-            })
-            MODULE:SaveData()
-            lia.log.add(client, "spawnAdd", factionInfo.name)
-            return L("spawnAdded", L(factionInfo.name))
+            MODULE:FetchSpawns():next(function(spawns)
+                spawns[factionInfo.uniqueID] = spawns[factionInfo.uniqueID] or {}
+                table.insert(spawns[factionInfo.uniqueID], {
+                    pos = client:GetPos(),
+                    ang = client:EyeAngles()
+                })
+                MODULE:StoreSpawns(spawns)
+                lia.log.add(client, "spawnAdd", factionInfo.name)
+                client:notifyLocalized("spawnAdded", L(factionInfo.name))
+            end)
         else
-            return L("invalidFaction")
+            client:notifyLocalized("invalidFaction")
         end
     end
 })
@@ -40,20 +42,23 @@ lia.command.add("spawnremoveinradius", {
     onRun = function(client, arguments)
         local position = client:GetPos()
         local radius = tonumber(arguments[1]) or 120
-        local removedCount = 0
-        for faction, spawns in pairs(MODULE.spawns) do
-            for i = #spawns, 1, -1 do
-                local spawn = spawns[i].pos or spawns[i]
-                if spawn:Distance(position) <= radius then
-                    table.remove(MODULE.spawns[faction], i)
-                    removedCount = removedCount + 1
+        MODULE:FetchSpawns():next(function(spawns)
+            local removedCount = 0
+            for faction, list in pairs(spawns) do
+                for i = #list, 1, -1 do
+                    local spawn = list[i].pos or list[i]
+                    if spawn:Distance(position) <= radius then
+                        table.remove(list, i)
+                        removedCount = removedCount + 1
+                    end
                 end
+                if #list == 0 then spawns[faction] = nil end
             end
-        end
 
-        if removedCount > 0 then MODULE:SaveData() end
-        lia.log.add(client, "spawnRemoveRadius", radius, removedCount)
-        return L("spawnDeleted", removedCount)
+            if removedCount > 0 then MODULE:StoreSpawns(spawns) end
+            lia.log.add(client, "spawnRemoveRadius", radius, removedCount)
+            client:notifyLocalized("spawnDeleted", removedCount)
+        end)
     end
 })
 
@@ -75,17 +80,19 @@ lia.command.add("spawnremovebyname", {
         end
 
         if factionInfo then
-            if MODULE.spawns[factionInfo.uniqueID] then
-                local removedCount = #MODULE.spawns[factionInfo.uniqueID]
-                MODULE.spawns[factionInfo.uniqueID] = nil
-                MODULE:SaveData()
-                lia.log.add(client, "spawnRemoveByName", factionInfo.name, removedCount)
-                return L("spawnDeletedByName", L(factionInfo.name), removedCount)
-            else
-                return L("noSpawnsForFaction")
-            end
+            MODULE:FetchSpawns():next(function(spawns)
+                if spawns[factionInfo.uniqueID] then
+                    local removedCount = #spawns[factionInfo.uniqueID]
+                    spawns[factionInfo.uniqueID] = nil
+                    MODULE:StoreSpawns(spawns)
+                    lia.log.add(client, "spawnRemoveByName", factionInfo.name, removedCount)
+                    client:notifyLocalized("spawnDeletedByName", L(factionInfo.name), removedCount)
+                else
+                    client:notifyLocalized("noSpawnsForFaction")
+                end
+            end)
         else
-            return L("invalidFaction")
+            client:notifyLocalized("invalidFaction")
         end
     end
 })

--- a/gamemode/modules/spawns/libraries/server.lua
+++ b/gamemode/modules/spawns/libraries/server.lua
@@ -6,57 +6,66 @@ local function buildCondition(folder, map)
     return "_schema = " .. lia.db.convertDataType(folder) .. " AND _map = " .. lia.db.convertDataType(map)
 end
 
-function MODULE:LoadData(n)
-    n = n or 1
+function MODULE:FetchSpawns()
     local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
     local map = game.GetMap()
     local condition = buildCondition(folder, map)
-    lia.db.selectOne({"_data"}, TABLE, condition):next(function(res)
-        PrintTable(res)
+    return lia.db.selectOne({"_data"}, TABLE, condition):next(function(res)
         local data = res and lia.data.deserialize(res._data) or {}
         local factions = data.factions or data
-        if (not istable(factions) or table.IsEmpty(factions)) and n < 5 then
-            timer.Simple(1, function() if not self.loaded then self:LoadData(n + 1) end end)
-            return
-        end
-
-        self.spawns = {}
+        local result = {}
         for fac, spawns in pairs(factions or {}) do
             local t = {}
             for i = 1, #spawns do
                 local spawnData = lia.data.deserialize(spawns[i])
                 if isvector(spawnData) then
-                    -- Legacy data stored only as a vector
                     spawnData = {pos = spawnData, ang = angle_zero}
                 end
                 t[i] = spawnData
             end
-
-            self.spawns[fac] = t
+            result[fac] = t
         end
-
-        self.loaded = true
+        return result
     end)
 end
 
-function MODULE:SaveData()
+function MODULE:StoreSpawns(spawns)
     local factions = {}
-    for fac, spawns in pairs(self.spawns or {}) do
+    for fac, list in pairs(spawns or {}) do
         factions[fac] = {}
-        for _, data in ipairs(spawns) do
+        for _, data in ipairs(list) do
             factions[fac][#factions[fac] + 1] = encodetable(data)
         end
     end
 
     local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
     local map = game.GetMap()
-    lia.db.upsert({
+    return lia.db.upsert({
         _schema = folder,
         _map = map,
         _data = lia.data.serialize({
             factions = factions
         })
     }, TABLE)
+end
+
+function MODULE:LoadData(n)
+    n = n or 1
+    self:FetchSpawns():next(function(spawns)
+        if (not spawns or table.IsEmpty(spawns)) and n < 5 then
+            timer.Simple(1, function()
+                if not self.loaded then self:LoadData(n + 1) end
+            end)
+            return
+        end
+
+        self.spawns = spawns or {}
+        self.loaded = true
+    end)
+end
+
+function MODULE:SaveData()
+    self:StoreSpawns(self.spawns or {})
 end
 
 local function SpawnPlayer(client)
@@ -79,18 +88,18 @@ local function SpawnPlayer(client)
         end
     end
 
-    local spawnData
-    if factionID and MODULE.spawns then
-        local factionSpawns = MODULE.spawns[factionID]
-        if factionSpawns and #factionSpawns > 0 then spawnData = table.Random(factionSpawns) end
-    end
-
-    if spawnData then
-        local pos = (spawnData.pos or spawnData) + Vector(0, 0, 16)
-        local ang = spawnData.ang or angle_zero
-        client:SetPos(pos)
-        client:SetEyeAngles(ang)
-        hook.Run("PlayerSpawnPointSelected", client, pos, ang)
+    if factionID then
+        MODULE:FetchSpawns():next(function(spawns)
+            local factionSpawns = spawns[factionID]
+            if factionSpawns and #factionSpawns > 0 then
+                local data = table.Random(factionSpawns)
+                local pos = (data.pos or data) + Vector(0, 0, 16)
+                local ang = data.ang or angle_zero
+                client:SetPos(pos)
+                client:SetEyeAngles(ang)
+                hook.Run("PlayerSpawnPointSelected", client, pos, ang)
+            end
+        end)
     end
 end
 


### PR DESCRIPTION
## Summary
- read spawns from the database whenever they're needed
- save updated spawn tables directly to the database
- spawn players using DB spawns

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880a88fe328832784254ddb19ecee1f