### PR TITLE
Add recognition notification

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -307,6 +307,7 @@ LANGUAGE = {
     recognizeOption = "Recognize",
     recogFakeNamePrompt = "Enter fake name",
     noRecog = "You do not recognize this person.",
+    recognitionGiven = "Gave Recognition to %s people.",
     someone = "Someone",
     options = "Options",
     optionsTitle = "%s Options",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -307,6 +307,7 @@ LANGUAGE = {
     recognizeOption = "Reconnaître",
     recogFakeNamePrompt = "Entrer un faux nom",
     noRecog = "Vous ne reconnaissez pas cette personne.",
+    recognitionGiven = "Reconnaissance accordée à %s personnes.",
     someone = "Quelqu’un",
     options = "Options",
     optionsTitle = "Options de %s",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -307,6 +307,7 @@ LANGUAGE = {
     recognizeOption = "Riconosci",
     recogFakeNamePrompt = "Inserisci nome falso",
     noRecog = "Non riconosci questa persona.",
+    recognitionGiven = "Riconoscimento dato a %s persone.",
     someone = "Qualcuno",
     options = "Opzioni",
     optionsTitle = "Opzioni di %s",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -307,6 +307,7 @@ LANGUAGE = {
     recognizeOption = "Reconhecer",
     recogFakeNamePrompt = "Introduz nome falso",
     noRecog = "Não reconheces esta pessoa.",
+    recognitionGiven = "Reconhecimento concedido a %s pessoas.",
     someone = "Alguém",
     options = "Opções",
     optionsTitle = "Opções de %s",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -307,6 +307,7 @@ LANGUAGE = {
     recognizeOption = "Узнать",
     recogFakeNamePrompt = "Введите фальшивое имя",
     noRecog = "Вы не узнаёте этого человека.",
+    recognitionGiven = "Вы выдали опознание %s людям.",
     someone = "Кто‑то",
     options = "Опции",
     optionsTitle = "Опции %s",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -307,6 +307,7 @@ LANGUAGE = {
     recognizeOption = "Reconocer",
     recogFakeNamePrompt = "Introduce nombre falso",
     noRecog = "No reconoces a esta persona.",
+    recognitionGiven = "Se otorgó reconocimiento a %s personas.",
     someone = "Alguien",
     options = "Opciones",
     optionsTitle = "Opciones de %s",

--- a/gamemode/modules/interactionmenu/libraries/shared.lua
+++ b/gamemode/modules/interactionmenu/libraries/shared.lua
@@ -157,6 +157,7 @@ local function CharRecognize(ply, lvl, nm)
     end
 
     if count == 0 then return end
+    ply:notifyLocalized("recognitionGiven", count)
     for _, v in ipairs(tgt) do
         lia.log.add(ply, "charRecognize", v:getChar():getID(), nm)
     end
@@ -209,6 +210,7 @@ AddInteraction(L("recognizeOption"), {
         if CLIENT then return end
         promptName(ply, function(nm)
             if tgt:getChar():recognize(ply:getChar(), nm) then
+                ply:notifyLocalized("recognitionGiven", 1)
                 lia.log.add(ply, "charRecognize", tgt:getChar():getID(), nm)
                 net.Start("rgnDone")
                 net.Send(ply)


### PR DESCRIPTION
## Summary
- notify the player how many people were recognized from the actions menu
- provide translations for the new message in each language file

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6880c6722e608327bf708e4c7b718ca2