### PR TITLE
Fix spawn errors with type safety

### DIFF
--- a/gamemode/modules/spawns/commands.lua
+++ b/gamemode/modules/spawns/commands.lua
@@ -47,7 +47,10 @@ lia.command.add("spawnremoveinradius", {
             for faction, list in pairs(spawns) do
                 for i = #list, 1, -1 do
                     local spawn = list[i].pos or list[i]
-                    if spawn:Distance(position) <= radius then
+                    if not isvector(spawn) then
+                        spawn = lia.data.decodeVector(spawn)
+                    end
+                    if isvector(spawn) and spawn:Distance(position) <= radius then
                         table.remove(list, i)
                         removedCount = removedCount + 1
                     end

--- a/gamemode/modules/spawns/libraries/server.lua
+++ b/gamemode/modules/spawns/libraries/server.lua
@@ -91,8 +91,21 @@ local function SpawnPlayer(client)
             print("[SpawnPlayer] spawn count", factionSpawns and #factionSpawns or 0)
             if factionSpawns and #factionSpawns > 0 then
                 local data = table.Random(factionSpawns)
-                local pos = (data.pos or data) + Vector(0, 0, 16)
-                local ang = data.ang or angle_zero
+                local basePos = data.pos or data
+                if not isvector(basePos) then
+                    basePos = lia.data.decodeVector(basePos)
+                end
+
+                if not isvector(basePos) then
+                    basePos = Vector(0, 0, 0)
+                end
+
+                local pos = basePos + Vector(0, 0, 16)
+
+                local ang = data.ang
+                if not isangle(ang) then
+                    ang = lia.data.decodeAngle(ang) or angle_zero
+                end
                 print("[SpawnPlayer] selected pos", pos, "ang", ang)
                 client:SetPos(pos)
                 client:SetEyeAngles(ang)


### PR DESCRIPTION
## Summary
- handle non-vector spawn data when spawning
- guard spawn removal against malformed data

## Testing
- `luacheck gamemode/modules/spawns/libraries/server.lua gamemode/modules/spawns/commands.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880c903fde08327ae37d003a0497f0d