### PR TITLE
Fix bag inventory panel positioning

### DIFF
--- a/gamemode/modules/inventory/libraries/client.lua
+++ b/gamemode/modules/inventory/libraries/client.lua
@@ -48,7 +48,18 @@ function MODULE:InventoryItemAdded(inventory, item)
     if hook.Run("CanOpenBagPanel", item) == false then return end
     if IsValid(lia.gui["inv" .. bagInv:getID()]) then return end
     local bagPanel = bagInv:show(mainPanel)
+    bagPanel:MoveRightOf(mainPanel, 4)
     lia.gui["inv" .. bagInv:getID()] = bagPanel
+end
+
+function MODULE:InventoryItemDataChanged(item, key, _, _, inventory)
+    if not item.isBag then return end
+    if key ~= "x" and key ~= "y" then return end
+    local bagInv = item:getInv()
+    if not bagInv then return end
+    local bagPanel = lia.gui["inv" .. bagInv:getID()]
+    local mainPanel = lia.gui["inv" .. inventory:getID()]
+    if IsValid(bagPanel) and IsValid(mainPanel) then bagPanel:MoveRightOf(mainPanel, 4) end
 end
 
 hook.Add("CreateMenuButtons", "liaInventory", function(tabs)


### PR DESCRIPTION
## Summary
- keep bag inventory panels aligned to the right of the main inventory
- reposition bag when its item moves

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880c9a5451c8327bf6b53919d2f882a