### PR TITLE
Add last used column in charlist

### DIFF
--- a/gamemode/modules/administration/submodules/permissions/commands.lua
+++ b/gamemode/modules/administration/submodules/permissions/commands.lua
@@ -148,6 +148,13 @@ lia.command.add("charlist", {
                     allVars[varName] = value
                 end
 
+                local lastUsedText
+                if stored then
+                    lastUsedText = L("onlineNow")
+                else
+                    lastUsedText = row._lastJoinTime
+                end
+
                 local entry = {
                     ID = row._id,
                     Name = row._name,
@@ -158,6 +165,7 @@ lia.command.add("charlist", {
                     BanningAdminSteamID = info.charBanInfo and info.charBanInfo.steamID or "",
                     BanningAdminRank = info.charBanInfo and info.charBanInfo.rank or "",
                     Money = row._money,
+                    LastUsed = lastUsedText,
                     allVars = allVars
                 }
 

--- a/gamemode/modules/administration/submodules/permissions/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/client.lua
@@ -115,6 +115,10 @@ net.Receive("DisplayCharList", function()
         {
             name = "CharMoney",
             field = "Money"
+        },
+        {
+            name = "LastUsed",
+            field = "LastUsed"
         }
     }
 
@@ -141,7 +145,7 @@ net.Receive("DisplayCharList", function()
 
             line.CharID = rowData and rowData.ID
             if rowData and rowData.extraDetails then
-                local colIndex = 10
+                local colIndex = 11
                 for _, name in ipairs(extraOrder) do
                     line:SetColumnText(colIndex, tostring(rowData.extraDetails[name] or ""))
                     colIndex = colIndex + 1


### PR DESCRIPTION
## Summary
- show when characters were last joined in the charlist
- show "Online now" for characters currently being used

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880c6a21e1483279a3198a397d92fc1