### PR TITLE
Fix bodygroups and skin on loadout

### DIFF
--- a/documentation/docs/hooks/gamemode_hooks.md
+++ b/documentation/docs/hooks/gamemode_hooks.md
@@ -2875,6 +2875,7 @@ end)
 **Purpose**
 
 Called after the player has been equipped. Last chance to modify the loadout.
+The character's stored bodygroups and skin are also restored here.
 
 **Parameters**
 

--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -335,6 +335,12 @@ function GM:PostPlayerLoadout(client)
     if not character then return end
     client:Give("lia_hands")
     client:SetupHands()
+    for k, v in pairs(character:getData("groups", {})) do
+        local index = tonumber(k)
+        local value = tonumber(v) or 0
+        if index then client:SetBodygroup(index, value) end
+    end
+    client:SetSkin(character:getData("skin", 0))
     client:setNetVar("VoiceType", "Talking")
 end
 


### PR DESCRIPTION
## Summary
- restore character bodygroups/skin in `PostPlayerLoadout`
- document that bodygroups and skin are restored at this hook

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880cbb4fdc08327b3a427e29ff05a39