### PR TITLE
Fix bodygroup preview on character load

### DIFF
--- a/gamemode/core/derma/mainmenu/character.lua
+++ b/gamemode/core/derma/mainmenu/character.lua
@@ -719,3 +719,12 @@ function PANEL:Think()
 end
 
 vgui.Register("liaCharacter", PANEL, "EditablePanel")
+
+hook.Add("CharDataLoaded", "liaUpdateCharacterMenuModel", function(character)
+    if not (IsValid(lia.gui.character) and lia.gui.character.isLoadMode) then return end
+    if not lia.characters then return end
+    local index = lia.gui.character.currentIndex or 1
+    if lia.characters[index] == character:getID() then
+        lia.gui.character:updateModelEntity(character)
+    end
+end)

--- a/gamemode/core/netcalls/client.lua
+++ b/gamemode/core/netcalls/client.lua
@@ -789,4 +789,5 @@ net.Receive("liaCharacterData", function()
         local value = net.ReadType()
         character.dataVars[key] = value
     end
+    hook.Run("CharDataLoaded", character)
 end)


### PR DESCRIPTION
## Summary
- trigger `CharDataLoaded` when receiving character data
- refresh main menu model after bodygroups load

## Testing
- `luajit` is not available; no tests were run

------
https://chatgpt.com/codex/tasks/task_e_6880cd59d8ec8327a9c7df8d31aa375b