### PR TITLE
Fix missing bodygroups on first character view

### DIFF
--- a/gamemode/core/libraries/character.lua
+++ b/gamemode/core/libraries/character.lua
@@ -563,6 +563,10 @@ if SERVER then
                 characters[#characters + 1] = charId
                 local character = lia.char.new(charData, charId, client)
                 if charData.recognition then lia.char.setCharData(charId, "rgn", nil) end
+                local dataVars = lia.char.getCharData(charId)
+                if not table.IsEmpty(dataVars) then
+                    character:setData(dataVars, nil, true)
+                end
                 hook.Run("CharRestored", character)
                 character.vars.inv = {}
                 lia.inventory.loadAllFromCharID(charId):next(function(inventories)

--- a/gamemode/modules/mainmenu/libraries/server.lua
+++ b/gamemode/modules/mainmenu/libraries/server.lua
@@ -3,7 +3,22 @@
         if not IsValid(client) then return end
         MsgN(L("loadedCharacters", table.concat(charList, ", "), client:Name()))
         for _, v in ipairs(charList) do
-            if lia.char.loaded[v] then lia.char.loaded[v]:sync(client) end
+            local char = lia.char.loaded[v]
+            if char then
+                char:sync(client)
+                local data = char:getData()
+                if not table.IsEmpty(data) then
+                    local keys = table.GetKeys(data)
+                    net.Start("liaCharacterData")
+                    net.WriteUInt(char:getID(), 32)
+                    net.WriteUInt(#keys, 32)
+                    for _, key in ipairs(keys) do
+                        net.WriteString(key)
+                        net.WriteType(data[key])
+                    end
+                    net.Send(client)
+                end
+            end
         end
 
         for _, v in player.Iterator() do


### PR DESCRIPTION
## Summary
- load character data when restoring characters
- send data for each character when a player joins

## Testing
- `luacheck gamemode/modules/mainmenu/libraries/server.lua gamemode/core/libraries/character.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880dce6c45c8327b1d5145420f4ed82