### PR TITLE
Implement ticket logging

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -413,8 +413,9 @@ function lia.db.loadTables()
             );
 
             CREATE TABLE IF NOT EXISTS lia_ticketclaims (
-                _request TEXT,
+                _requester TEXT,
                 _admin TEXT,
+                _message TEXT,
                 _timestamp INTEGER
             );
 
@@ -592,8 +593,9 @@ function lia.db.loadTables()
             );
 
             CREATE TABLE IF NOT EXISTS `lia_ticketclaims` (
-                `_request` VARCHAR(64) NOT NULL COLLATE 'utf8mb4_general_ci',
-                `_admin` VARCHAR(64) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `_requester` VARCHAR(64) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `_admin` VARCHAR(128) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `_message` TEXT NOT NULL COLLATE 'utf8mb4_general_ci',
                 `_timestamp` INT(32) NOT NULL
             );
 

--- a/gamemode/modules/administration/submodules/logging/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/logging/libraries/server.lua
@@ -181,11 +181,13 @@ function MODULE:OnPlayerObserve(client, state)
 end
 
 function MODULE:TicketSystemClaim(admin, requester)
-    lia.db.count("ticketclaims", "_admin = " .. lia.db.convertDataType(admin:SteamID64())):next(function(count) lia.log.add(admin, "ticketClaimed", requester:Name(), count) end)
+    local pattern = "_admin LIKE '%" .. admin:SteamID64() .. "'"
+    lia.db.count("ticketclaims", pattern):next(function(count) lia.log.add(admin, "ticketClaimed", requester:Name(), count) end)
 end
 
 function MODULE:TicketSystemClose(admin, requester)
-    lia.db.count("ticketclaims", "_admin = " .. lia.db.convertDataType(admin:SteamID64())):next(function(count) lia.log.add(admin, "ticketClosed", requester:Name(), count) end)
+    local pattern = "_admin LIKE '%" .. admin:SteamID64() .. "'"
+    lia.db.count("ticketclaims", pattern):next(function(count) lia.log.add(admin, "ticketClosed", requester:Name(), count) end)
 end
 
 function MODULE:WarningIssued(admin, target, reason, index)


### PR DESCRIPTION
## Summary
- track tickets in `lia_ticketclaims`
- store requester, message and admin claim info
- update logging for new admin string format

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880f16b6f648327bc267bde70c3dde1