### PR TITLE
Add roster tab to F1 menu

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -450,6 +450,7 @@ LANGUAGE = {
     death = "Death",
     start = "Start",
     logs = "Logs",
+    roster = "Roster",
     failedRetrieveLogs = "Failed to retrieve logs.",
     searchLogs = "Search logs...",
     logMessage = "Message",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -450,6 +450,7 @@ LANGUAGE = {
     death = "Mort",
     start = "Début",
     logs = "Logs",
+    roster = "Roster",
     failedRetrieveLogs = "Échec récupération logs.",
     searchLogs = "Chercher dans les logs...",
     logMessage = "Message",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -450,6 +450,7 @@ LANGUAGE = {
     death = "Morte",
     start = "Inizio",
     logs = "Log",
+    roster = "Roster",
     failedRetrieveLogs = "Impossibile recuperare i log.",
     searchLogs = "Cerca log...",
     logMessage = "Messaggio",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -450,6 +450,7 @@ LANGUAGE = {
     death = "Morte",
     start = "Início",
     logs = "Registos",
+    roster = "Roster",
     failedRetrieveLogs = "Falha ao obter registos.",
     searchLogs = "Pesquisar registos...",
     logMessage = "Mensagem",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -450,6 +450,7 @@ LANGUAGE = {
     death = "Смерть",
     start = "Старт",
     logs = "Логи",
+    roster = "Roster",
     failedRetrieveLogs = "Не удалось получить логи.",
     searchLogs = "Поиск логов...",
     logMessage = "Сообщение",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -450,6 +450,7 @@ LANGUAGE = {
     death = "Muerte",
     start = "Inicio",
     logs = "Registros",
+    roster = "Roster",
     failedRetrieveLogs = "No se pudieron obtener logs.",
     searchLogs = "Buscar logs...",
     logMessage = "Mensaje",

--- a/gamemode/modules/teams/libraries/client.lua
+++ b/gamemode/modules/teams/libraries/client.lua
@@ -18,3 +18,17 @@ function MODULE:DrawCharInfo(client, _, info)
         info[#info + 1] = {className, classColor}
     end
 end
+
+function MODULE:CreateMenuButtons(tabs)
+    local client = LocalPlayer()
+    if not IsValid(client) then return end
+    local character = client:getChar()
+    if not character then return end
+    local isLeader = client:IsSuperAdmin() or character:getData("factionOwner") or character:getData("factionAdmin") or character:hasFlags("V")
+    if not isLeader then return end
+
+    tabs[L("roster")] = function(panel)
+        lia.gui.roster = panel
+        lia.command.send("roster")
+    end
+end

--- a/gamemode/modules/teams/netcalls/client.lua
+++ b/gamemode/modules/teams/netcalls/client.lua
@@ -12,13 +12,73 @@
     end
 end)
 
+lia.gui = lia.gui or {}
+
+local function OpenRosterUI(panel, columns, rows)
+    panel:Clear()
+    panel:DockPadding(10, 10, 10, 10)
+    local listView = panel:Add("DListView")
+    listView:Dock(FILL)
+    local totalFixedWidth, dynamicColumns = 0, 0
+    for _, col in ipairs(columns) do
+        if col.width then
+            totalFixedWidth = totalFixedWidth + col.width
+        else
+            dynamicColumns = dynamicColumns + 1
+        end
+    end
+
+    local availableWidth = panel:GetWide() - totalFixedWidth
+    local dynamicWidth = dynamicColumns > 0 and math.max(availableWidth / dynamicColumns, 50) or 0
+
+    for _, col in ipairs(columns) do
+        local name = col.name or L("na")
+        local width = col.width or dynamicWidth
+        listView:AddColumn(name):SetFixedWidth(width)
+    end
+
+    for _, row in ipairs(rows) do
+        local lineData = {}
+        for _, col in ipairs(columns) do
+            table.insert(lineData, row[col.field] or L("na"))
+        end
+        local line = listView:AddLine(unpack(lineData))
+        line.rowData = row
+    end
+
+    listView.OnRowRightClick = function(_, _, line)
+        if not IsValid(line) or not line.rowData then return end
+        local rowData = line.rowData
+        local menu = DermaMenu()
+        menu:AddOption("Kick", function()
+            Derma_Query("Are you sure you want to kick this player?", "Confirm", "Yes", function()
+                net.Start("KickCharacter")
+                net.WriteInt(tonumber(rowData.id), 32)
+                net.SendToServer()
+            end, "No")
+        end)
+        menu:AddOption("View Character List", function()
+            LocalPlayer():ConCommand("say /charlist " .. rowData.steamID)
+        end)
+        menu:AddOption(L("copyRow"), function()
+            local rowString = ""
+            for key, value in pairs(rowData) do
+                value = tostring(value or L("na"))
+                rowString = rowString .. key:gsub("^%l", string.upper) .. ": " .. value .. " | "
+            end
+            rowString = rowString:sub(1, -4)
+            SetClipboardText(rowString)
+        end)
+        menu:Open()
+    end
+end
+
 net.Receive("CharacterInfo", function()
     local factionID = net.ReadString()
     local characterData = net.ReadTable()
     local character = LocalPlayer():getChar()
     local isLeader = LocalPlayer():IsSuperAdmin() or character:getData("factionOwner") or character:getData("factionAdmin") or character:hasFlags("V")
     if not isLeader then return end
-    if IsValid(characterPanel) then characterPanel:Remove() end
     local rows = {}
     for _, data in ipairs(characterData) do
         if data.faction == factionID and data.id ~= character:getID() then table.insert(rows, data) end
@@ -43,40 +103,44 @@ net.Receive("CharacterInfo", function()
         }
     }
 
-    local frame, list = lia.util.CreateTableUI("Character Information", columns, rows, {
-        {
-            name = "Kick",
-            net = "KickCharacter"
-        }
-    })
+    if IsValid(lia.gui.roster) then
+        OpenRosterUI(lia.gui.roster, columns, rows)
+    else
+        local frame, list = lia.util.CreateTableUI("Character Information", columns, rows, {
+            {
+                name = "Kick",
+                net = "KickCharacter"
+            }
+        })
 
-    if IsValid(list) then
-        list.OnRowRightClick = function(_, _, line)
-            if not IsValid(line) or not line.rowData then return end
-            local rowData = line.rowData
-            local menu = DermaMenu()
-            menu:AddOption("Kick", function()
-                Derma_Query("Are you sure you want to kick this player?", "Confirm", "Yes", function()
-                    net.Start("KickCharacter")
-                    net.WriteInt(tonumber(rowData.id), 32)
-                    net.SendToServer()
-                    if IsValid(frame) then frame:Remove() end
-                end, "No")
-            end)
+        if IsValid(list) then
+            list.OnRowRightClick = function(_, _, line)
+                if not IsValid(line) or not line.rowData then return end
+                local rowData = line.rowData
+                local menu = DermaMenu()
+                menu:AddOption("Kick", function()
+                    Derma_Query("Are you sure you want to kick this player?", "Confirm", "Yes", function()
+                        net.Start("KickCharacter")
+                        net.WriteInt(tonumber(rowData.id), 32)
+                        net.SendToServer()
+                        if IsValid(frame) then frame:Remove() end
+                    end, "No")
+                end)
 
-            menu:AddOption("View Character List", function() LocalPlayer():ConCommand("say /charlist " .. rowData.steamID) end)
-            menu:AddOption(L("copyRow"), function()
-                local rowString = ""
-                for key, value in pairs(rowData) do
-                    value = tostring(value or L("na"))
-                    rowString = rowString .. key:gsub("^%l", string.upper) .. ": " .. value .. " | "
-                end
+                menu:AddOption("View Character List", function() LocalPlayer():ConCommand("say /charlist " .. rowData.steamID) end)
+                menu:AddOption(L("copyRow"), function()
+                    local rowString = ""
+                    for key, value in pairs(rowData) do
+                        value = tostring(value or L("na"))
+                        rowString = rowString .. key:gsub("^%l", string.upper) .. ": " .. value .. " | "
+                    end
 
-                rowString = rowString:sub(1, -4)
-                SetClipboardText(rowString)
-            end)
+                    rowString = rowString:sub(1, -4)
+                    SetClipboardText(rowString)
+                end)
 
-            menu:Open()
+                menu:Open()
+            end
         end
     end
 end)


### PR DESCRIPTION
## Summary
- localize `roster` term across languages
- add F1 menu button for faction roster that opens panel in-menu

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880ef93184083279fe6d97641503509