### PR TITLE
Add documentation for lia.db.getTables

### DIFF
--- a/documentation/docs/libraries/lia.database.md
+++ b/documentation/docs/libraries/lia.database.md
@@ -809,6 +809,33 @@ local db = lia.db.getObject()
 
 ---
 
+### lia.db.getTables
+
+**Purpose**
+
+Retrieves a list of all tables that begin with `lia_` in the connected database.
+
+**Parameters**
+
+* *None*
+
+**Realm**
+
+`Server`
+
+**Returns**
+
+* *deferred*: Resolves to a table containing the table names.
+
+**Example Usage**
+
+```lua
+lia.db.getTables():next(function(tables)
+    PrintTable(tables)
+end)
+```
+
+---
 ### lia.db.tableExists
 
 **Purpose**


### PR DESCRIPTION
## Summary
- document `lia.db.getTables`

## Testing
- `grep -n "db.getTables" -n documentation/docs/libraries/lia.database.md`

------
https://chatgpt.com/codex/tasks/task_e_6880f6cd36508327bfe1079775002dfc