### PR TITLE
Fix progress bar persisting on death

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -362,6 +362,7 @@ function GM:DoPlayerDeath(client, attacker)
         end
     end
 
+    client:stopAction()
     client:SetDSP(31, false)
 end
 


### PR DESCRIPTION
## Summary
- stop the player's action bar when they die so the "Entering Vehicle" bar disappears if killed while entering a car.

## Testing
- `luacheck --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688120b7fed88327a288f338d9d2e985