### PR TITLE
Add lia.admin.print function

### DIFF
--- a/documentation/docs/libraries/lia.admin.md
+++ b/documentation/docs/libraries/lia.admin.md
@@ -311,3 +311,31 @@ Executes a basic admin action by sending the appropriate chat command.
 * *boolean | nil*: `true` if a matching command executed, otherwise `nil`.
 
 ---
+
+### lia.admin.print
+
+**Purpose**
+
+Logs an admin related message with a coloured section tag.
+
+**Parameters**
+
+* `section` (*string*): Context tag for the message.
+
+* `msg` (*string*): Text to print.
+
+**Realm**
+
+`Shared`
+
+**Returns**
+
+* *nil*: This function does not return a value.
+
+**Example Usage**
+
+```lua
+lia.admin.print("Ban", "Player banned successfully")
+```
+
+---

--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -9,6 +9,12 @@ local DEFAULT_GROUPS = {
     superadmin = true,
 }
 
+function lia.admin.print(section, msg)
+    MsgC(Color(83, 143, 239), "[Lilia] ", "[Admin] ")
+    MsgC(Color(0, 255, 0), "[" .. section .. "] ")
+    MsgC(Color(255, 255, 255), tostring(msg), "\n")
+end
+
 function lia.admin.isDisabled()
     local sysDisabled = hook.Run("ShouldLiliaAdminLoad") == false
     local cmdDisabled = hook.Run("ShouldLiliaAdminCommandsLoad") == false
@@ -60,7 +66,7 @@ function lia.admin.load()
         end
 
         if created then lia.admin.save(true) end
-        lia.bootstrap("Administration", L("adminSystemLoaded"))
+        lia.admin.print("Bootstrap", L("adminSystemLoaded"))
     end
 
     lia.db.selectOne({"_data"}, "admingroups"):next(function(res)
@@ -188,7 +194,9 @@ if SERVER then
         if lia.admin.isDisabled() then return end
         if not steamid then Error("[Lilia Administration] lia.admin.removeBan: no steam id specified!") end
         lia.admin.banList[steamid] = nil
-        lia.db.query(Format("DELETE FROM lia_bans WHERE _steamID = '%s'", lia.db.escape(steamid)), function() MsgC(Color(0, 200, 0), "[Lilia Administration] Ban removed.\n") end)
+        lia.db.query(Format("DELETE FROM lia_bans WHERE _steamID = '%s'", lia.db.escape(steamid)), function()
+            lia.admin.print("Ban", "Ban removed.")
+        end)
     end
 
     function lia.admin.isBanned(steamid)
@@ -340,10 +348,10 @@ concommand.Add("plysetgroup", function(ply, _, args)
             if lia.admin.groups[args[2]] then
                 lia.admin.setPlayerGroup(target, args[2])
             else
-                MsgC(Color(200, 20, 20), "[Lilia Administration] Error: usergroup not found.\n")
+                lia.admin.print("Error", "Usergroup not found.")
             end
         else
-            MsgC(Color(200, 20, 20), "[Lilia Administration] Error: specified player not found.\n")
+            lia.admin.print("Error", "Specified player not found.")
         end
     end
 end)

--- a/gamemode/modules/administration/submodules/permissions/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/server.lua
@@ -315,10 +315,10 @@ local function handleDatabaseWipe(commandName)
 
         if resetCalled < RealTime() then
             resetCalled = RealTime() + 3
-            MsgC(Color(255, 0, 0), "[Lilia] " .. L("databaseWipeConfirm", commandName) .. "\n")
+            lia.admin.print("Warning", L("databaseWipeConfirm", commandName))
         else
             resetCalled = 0
-            MsgC(Color(255, 0, 0), "[Lilia] " .. L("databaseWipeProgress") .. "\n")
+            lia.admin.print("Warning", L("databaseWipeProgress"))
             hook.Run("OnWipeTables")
             lia.db.wipeTables(lia.db.loadTables)
             game.ConsoleCommand("changelevel " .. game.GetMap() .. "\n")


### PR DESCRIPTION
## Summary
- add a new `lia.admin.print` logging helper similar to `lia.bootstrap`
- log admin system bootstrap with the new helper
- use `lia.admin.print` for wipe warnings, ban removal messages, and error prints
- document `lia.admin.print`

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688133ebc1388327bca7d771bf4da9f9