### PR TITLE
Propagate privileges to usergroups

### DIFF
--- a/documentation/docs/libraries/lia.admin.md
+++ b/documentation/docs/libraries/lia.admin.md
@@ -86,6 +86,10 @@ Registers a CAMI privilege for use with permission checks.
 
 * `privilege` (*table*): Table containing the privilege definition.
 
+When a privilege is registered it will automatically be assigned to all
+usergroups that inherit from the privilege's `MinAccess` level. Groups created
+via `lia.admin.createGroup` inherit from `user` by default.
+
 **Realm**
 
 `Shared`


### PR DESCRIPTION
## Summary
- automatically apply registered privileges based on usergroup inheritance
- new groups default to user inherited permissions
- document new behavior in `lia.admin.registerPrivilege`

## Testing
- `luacheck gamemode --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688152c8e1508327bc44d754391f84d5