### PR TITLE
Fix admin usergroup sync

### DIFF
--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -682,3 +682,13 @@ hook.Add("CAMI.OnPrivilegeUnregistered", "liaSyncAdminPrivilegeRemove", function
 
     if SERVER then lia.admin.save(true) end
 end)
+
+hook.Add("CAMI.PlayerUsergroupChanged", "liaSyncAdminPlayerGroup", function(ply, old, new)
+    if lia.admin.isDisabled() or not IsValid(ply) then return end
+    lia.db.query(string.format(
+        "UPDATE lia_players SET _userGroup = '%s' WHERE _steamID = %s",
+        lia.db.escape(new),
+        ply:SteamID64()
+    ))
+end)
+


### PR DESCRIPTION
## Summary
- sync lia.admin player groups when other admin mods change CAMI usergroups

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688155cc7d008327840878565519a0b7