### PR TITLE
Add skin and bodygroups char vars

### DIFF
--- a/gamemode/core/derma/mainmenu/character.lua
+++ b/gamemode/core/derma/mainmenu/character.lua
@@ -529,8 +529,8 @@ function PANEL:updateModelEntity(character)
     local model = character.getModel and character:getModel() or LocalPlayer():GetModel()
     self.modelEntity = ClientsideModel(model, RENDERGROUP_OPAQUE)
     if not IsValid(self.modelEntity) then return end
-    self.modelEntity:SetSkin(character:getData("skin", 0))
-    local groups = character:getData("groups", {})
+    self.modelEntity:SetSkin(character:getSkin())
+    local groups = character:getBodygroups()
     for i = 0, self.modelEntity:GetNumBodyGroups() - 1 do
         local value = groups[i]
         if value == nil then value = groups[tostring(i)] end

--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -335,13 +335,13 @@ function GM:PostPlayerLoadout(client)
     if not character then return end
     client:Give("lia_hands")
     client:SetupHands()
-    for k, v in pairs(character:getData("groups", {})) do
+    for k, v in pairs(character:getBodygroups()) do
         local index = tonumber(k)
         local value = tonumber(v) or 0
         if index then client:SetBodygroup(index, value) end
     end
 
-    client:SetSkin(character:getData("skin", 0))
+    client:SetSkin(character:getSkin())
     client:setNetVar("VoiceType", "Talking")
 end
 

--- a/gamemode/core/meta/character.lua
+++ b/gamemode/core/meta/character.lua
@@ -433,13 +433,13 @@ if SERVER then
 
             client:SetTeam(self:getFaction())
             client:setNetVar("char", self:getID())
-            for k, v in pairs(self:getData("groups", {})) do
+            for k, v in pairs(self:getBodygroups()) do
                 local index = tonumber(k)
                 local value = tonumber(v) or 0
                 if index then client:SetBodygroup(index, value) end
             end
 
-            client:SetSkin(self:getData("skin", 0))
+            client:SetSkin(self:getSkin())
             hook.Run("SetupPlayerModel", client, self)
             if not noNetworking then
                 for _, v in ipairs(self:getInv(true)) do

--- a/gamemode/items/base/outfit.lua
+++ b/gamemode/items/base/outfit.lua
@@ -28,7 +28,7 @@ function ITEM:removeOutfit(client)
     if hook.Run("CanOutfitChangeModel", self) ~= false then
         character:setModel(self:getData("oldMdl", character:getModel()))
         self:setData("oldMdl", nil)
-        client:SetSkin(self:getData("oldSkin", character:getData("skin", 0)))
+        client:SetSkin(self:getData("oldSkin", character:getSkin()))
         self:setData("oldSkin", nil)
         local oldGroups = character:getData("oldGroups", {})
         for k in pairs(self.bodyGroups or {}) do
@@ -36,10 +36,10 @@ function ITEM:removeOutfit(client)
             if index > -1 then
                 client:SetBodygroup(index, oldGroups[index] or 0)
                 oldGroups[index] = nil
-                local groups = character:getData("groups", {})
+                local groups = character:getBodygroups()
                 if groups[index] then
                     groups[index] = nil
-                    character:setData("groups", groups)
+                    character:setBodygroups(groups)
                 end
             end
         end
@@ -115,7 +115,7 @@ ITEM.functions.Equip = {
 
             if isnumber(item.newSkin) then
                 item:setData("oldSkin", item.player:GetSkin())
-                character:setData("skin", item.newSkin)
+                character:setSkin(item.newSkin)
                 item.player:SetSkin(item.newSkin)
             end
 
@@ -132,13 +132,13 @@ ITEM.functions.Equip = {
 
                 character:setData("oldGroups", oldGroups)
                 item:setData("oldGroups", oldGroups)
-                local newGroups = character:getData("groups", {})
+                local newGroups = character:getBodygroups()
                 for index, value in pairs(groups) do
                     newGroups[index] = value
                     item.player:SetBodygroup(index, value)
                 end
 
-                if table.Count(newGroups) > 0 then character:setData("groups", newGroups) end
+                if table.Count(newGroups) > 0 then character:setBodygroups(newGroups) end
             end
         end
 

--- a/gamemode/modules/administration/submodules/permissions/commands.lua
+++ b/gamemode/modules/administration/submodules/permissions/commands.lua
@@ -1150,9 +1150,9 @@ lia.command.add("charsetbodygroup", {
         local index = target:FindBodygroupByName(bodyGroup)
         if index > -1 then
             if value and value < 1 then value = nil end
-            local groups = target:getChar():getData("groups", {})
+            local groups = target:getChar():getBodygroups()
             groups[index] = value
-            target:getChar():setData("groups", groups)
+            target:getChar():setBodygroups(groups)
             target:SetBodygroup(index, value or 0)
             client:notifyLocalized("changeBodygroups", client:Name(), target:Name(), bodyGroup, value or 0)
         else
@@ -1181,7 +1181,7 @@ lia.command.add("charsetskin", {
             return
         end
 
-        target:getChar():setData("skin", skin)
+        target:getChar():setSkin(skin)
         target:SetSkin(skin or 0)
         client:notifyLocalized("changeSkin", client:Name(), target:Name(), skin or 0)
     end


### PR DESCRIPTION
## Summary
- store skin and bodygroup info as character variables
- update character creation to save these fields
- apply new getters/setters across hooks, UI and admin commands
- adjust outfit item behaviour to use the new variables

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688154253aac8327936c17a074d68d3d