### PR TITLE
Move flags to player data

### DIFF
--- a/documentation/docs/hooks/gamemode_hooks.md
+++ b/documentation/docs/hooks/gamemode_hooks.md
@@ -3472,9 +3472,9 @@ Similar to OnCharVarChanged but for local-only variables. Called after the table
 
 ```lua
 -- Prints a message when OnCharLocalVarChanged is triggered
-hook.Add("OnCharLocalVarChanged", "WatchFlags", function(char, k, old, new)
-    if k == "flags" then
-        print("Flags changed")
+hook.Add("OnCharLocalVarChanged", "WatchCustomVar", function(char, k, old, new)
+    if k == "someVar" then
+        print("Value updated")
     end
 end)
 ```

--- a/documentation/docs/meta/character.md
+++ b/documentation/docs/meta/character.md
@@ -196,7 +196,9 @@ end
 
 **Purpose**
 
-Retrieves the string of permission flags for this character.
+Retrieves the string of permission flags for this character. Internally this
+delegates to the owning player's `getFlags` method, which stores the string in
+their persistent data table under the key `"flags"`.
 
 **Parameters**
 
@@ -915,7 +917,9 @@ char:removeBoost("powerGloves", "str")
 
 **Purpose**
 
-Replaces the character's flag string with the provided value.
+Replaces the character's flag string with the provided value. This delegates to
+the player's `setFlags` method, storing the value in their persistent data via
+`setLiliaData("flags", ...)`.
 
 **Parameters**
 
@@ -942,7 +946,9 @@ char:setFlags("")
 
 **Purpose**
 
-Adds the specified flag characters to the character.
+Adds the specified flag characters to the character. Internally this calls the
+owning player's `giveFlags` method which updates the `"flags"` entry in their
+persistent data table.
 
 **Parameters**
 
@@ -969,7 +975,8 @@ char:giveFlags("A")
 
 **Purpose**
 
-Removes the given flag characters from the character.
+Removes the given flag characters from the character. This uses the player's
+`takeFlags` method to update the persistent `"flags"` data entry.
 
 **Parameters**
 

--- a/documentation/docs/meta/player.md
+++ b/documentation/docs/meta/player.md
@@ -1704,6 +1704,141 @@ player:setLiliaData("settings", {foo = true})
 
 ---
 
+### getFlags
+
+**Purpose**
+
+Retrieves the string of permission flags for this player. The string is stored
+in the player's persistent data under the key `"flags"`.
+
+**Parameters**
+
+* None
+
+**Realm**
+
+`Shared`
+
+**Returns**
+
+* `string`: Concatenated flag characters.
+
+**Example Usage**
+
+```lua
+if player:hasFlags("A") then
+    print("Admin user")
+end
+```
+
+---
+
+### hasFlags
+
+**Purpose**
+
+Checks if the player possesses any of the specified flags.
+
+**Parameters**
+
+* `flags` (`string`): Flag characters to check.
+
+**Realm**
+
+`Shared`
+
+**Returns**
+
+* `boolean`: `true` if at least one flag is present.
+
+**Example Usage**
+
+```lua
+if player:hasFlags("Z") then
+    print("Can invite others")
+end
+```
+
+---
+
+### setFlags
+
+**Purpose**
+
+Replaces the player's flag string with the provided value.
+
+**Parameters**
+
+* `flags` (`string`): New flag characters to assign.
+
+**Realm**
+
+`Server`
+
+**Returns**
+
+* `nil`: This function does not return a value.
+
+**Example Usage**
+
+```lua
+player:setFlags("AB")
+```
+
+---
+
+### giveFlags
+
+**Purpose**
+
+Adds the specified flag characters to the player.
+
+**Parameters**
+
+* `flags` (`string`): Flags to grant.
+
+**Realm**
+
+`Server`
+
+**Returns**
+
+* `nil`: This function does not return a value.
+
+**Example Usage**
+
+```lua
+player:giveFlags("A")
+```
+
+---
+
+### takeFlags
+
+**Purpose**
+
+Removes the given flag characters from the player.
+
+**Parameters**
+
+* `flags` (`string`): Flags to revoke.
+
+**Realm**
+
+`Server`
+
+**Returns**
+
+* `nil`: This function does not return a value.
+
+**Example Usage**
+
+```lua
+player:takeFlags("A")
+```
+
+---
+
 ### setWaypoint
 
 **Purpose**

--- a/gamemode/core/meta/character.lua
+++ b/gamemode/core/meta/character.lua
@@ -53,14 +53,19 @@ function characterMeta:hasMoney(amount)
 end
 
 function characterMeta:getFlags()
-    return self:getData("f", "")
+    local ply = self:getPlayer()
+    if IsValid(ply) then
+        return ply:getFlags()
+    end
+    return ""
 end
 
 function characterMeta:hasFlags(flags)
-    for i = 1, #flags do
-        if self:getFlags():find(flags:sub(i, i), 1, true) then return true end
+    local ply = self:getPlayer()
+    if IsValid(ply) then
+        return ply:hasFlags(flags)
     end
-    return hook.Run("CharHasFlags", self, flags) or false
+    return false
 end
 
 function characterMeta:getItemWeapon(requireEquip)
@@ -340,34 +345,24 @@ if SERVER then
     end
 
     function characterMeta:setFlags(flags)
-        self:setData("f", flags)
+        local ply = self:getPlayer()
+        if IsValid(ply) then
+            ply:setFlags(flags)
+        end
     end
 
     function characterMeta:giveFlags(flags)
-        local addedFlags = ""
-        for i = 1, #flags do
-            local flag = flags:sub(i, i)
-            local info = lia.flag.list[flag]
-            if info then
-                if not self:hasFlags(flag) then addedFlags = addedFlags .. flag end
-                if info.callback then info.callback(self:getPlayer(), true) end
-            end
+        local ply = self:getPlayer()
+        if IsValid(ply) then
+            ply:giveFlags(flags)
         end
-
-        if addedFlags ~= "" then self:setFlags(self:getFlags() .. addedFlags) end
     end
 
     function characterMeta:takeFlags(flags)
-        local oldFlags = self:getFlags()
-        local newFlags = oldFlags
-        for i = 1, #flags do
-            local flag = flags:sub(i, i)
-            local info = lia.flag.list[flag]
-            if info and info.callback then info.callback(self:getPlayer(), false) end
-            newFlags = newFlags:gsub(flag, "")
+        local ply = self:getPlayer()
+        if IsValid(ply) then
+            ply:takeFlags(flags)
         end
-
-        if newFlags ~= oldFlags then self:setFlags(newFlags) end
     end
 
     function characterMeta:save(callback)

--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -308,6 +308,23 @@ function playerMeta:leaveSequence()
     self.liaSeqCallback = nil
 end
 
+function playerMeta:getFlags()
+    return self:getLiliaData("flags", "")
+end
+
+function playerMeta:hasFlags(flags)
+    for i = 1, #flags do
+        if self:getFlags():find(flags:sub(i, i), 1, true) then return true end
+    end
+
+    local char = self:getChar()
+    if char then
+        return hook.Run("CharHasFlags", char, flags) or false
+    end
+
+    return false
+end
+
 if SERVER then
     function playerMeta:restoreStamina(amount)
         local char = self:getChar()
@@ -470,6 +487,39 @@ if SERVER then
             net.WriteType(value)
             net.Send(self)
         end
+    end
+
+    function playerMeta:setFlags(flags)
+        self:setLiliaData("flags", flags)
+    end
+
+    function playerMeta:giveFlags(flags)
+        local addedFlags = ""
+        for i = 1, #flags do
+            local flag = flags:sub(i, i)
+            local info = lia.flag.list[flag]
+            if info then
+                if not self:hasFlags(flag) then addedFlags = addedFlags .. flag end
+                if info.callback then info.callback(self, true) end
+            end
+        end
+
+        if addedFlags ~= "" then
+            self:setFlags(self:getFlags() .. addedFlags)
+        end
+    end
+
+    function playerMeta:takeFlags(flags)
+        local oldFlags = self:getFlags()
+        local newFlags = oldFlags
+        for i = 1, #flags do
+            local flag = flags:sub(i, i)
+            local info = lia.flag.list[flag]
+            if info and info.callback then info.callback(self, false) end
+            newFlags = newFlags:gsub(flag, "")
+        end
+
+        if newFlags ~= oldFlags then self:setFlags(newFlags) end
     end
 
     function playerMeta:setWaypoint(name, vector)


### PR DESCRIPTION
## Summary
- store permission flags in each player's persistent `liaData` table instead of character data
- document new storage location for flags
- update hook example referencing char local vars
- add player methods for getting and managing flags
- refactor character flag functions to use player methods

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6881526a75f88327a87afe450756ed83