### PR TITLE
Fix class fallback and improve roster

### DIFF
--- a/gamemode/modules/teams/libraries/server.lua
+++ b/gamemode/modules/teams/libraries/server.lua
@@ -180,10 +180,22 @@ end
 
 function MODULE:ClassOnLoadout(client)
     local character = client:getChar()
-    local class = lia.class.list[character:getClass()]
+    if not character then return end
+
+    local classIndex = character:getClass()
+    local class = lia.class.list[classIndex]
+
+    if not class or class.faction ~= client:Team() then
+        character:kickClass()
+        class = lia.class.list[character:getClass()]
+    end
+
     if not class then return end
+
     applyAttributes(client, class)
-    if class.model then client:SetModel(class.model) end
+    if class.model then
+        client:SetModel(class.model)
+    end
 end
 
 function MODULE:ClassPostLoadout(client)

--- a/gamemode/modules/teams/libraries/shared.lua
+++ b/gamemode/modules/teams/libraries/shared.lua
@@ -118,6 +118,15 @@ else
         line.rowData = r
     end
 
+    local function makeClassList(parent)
+        local list = parent:Add("DListView")
+        list:Dock(FILL)
+        list:SetMultiSelect(false)
+        list:AddColumn("Class")
+        list:AddColumn("Members")
+        return list
+    end
+
     local function populate()
         if not built then return end
         if IsValid(lists.faction) then
@@ -129,8 +138,13 @@ else
 
         if IsValid(lists.class) then
             lists.class:Clear()
+            local counts = {}
             for _, r in ipairs(rosterRows) do
-                addRow(lists.class, r)
+                local c = r.class or L("na")
+                counts[c] = (counts[c] or 0) + 1
+            end
+            for className, count in pairs(counts) do
+                lists.class:AddLine(className, count)
             end
         end
     end
@@ -197,9 +211,10 @@ else
         pf:Dock(FILL)
         lists.faction = makeList(pf)
         sheet:AddSheet("Faction", pf, "icon16/group.png")
+
         local pc = vgui.Create("DPanel", sheet)
         pc:Dock(FILL)
-        lists.class = makeList(pc)
+        lists.class = makeClassList(pc)
         sheet:AddSheet("Class", pc, "icon16/user.png")
         built = true
         populate()


### PR DESCRIPTION
## Summary
- ensure players default to a valid class when their saved class no longer exists
- show class counts in the roster panel

## Testing
- `echo no tests`

------
https://chatgpt.com/codex/tasks/task_e_68815783bb34832787ebbfd4001ad6b2