### PR TITLE
Ignore bots for lia.admin

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -197,7 +197,7 @@ if SERVER then
     end
 
     function lia.admin.setPlayerGroup(ply, usergroup)
-        if lia.admin.isDisabled() then return end
+        if lia.admin.isDisabled() or ply:IsBot() then return end
         local old = ply:GetUserGroup()
         ply:SetUserGroup(usergroup)
         if CAMI and CAMI.SignalUserGroupChanged then
@@ -338,7 +338,7 @@ function lia.admin.execCommand(cmd, victim, dur, reason)
 end
 
 hook.Add("PlayerAuthed", "lia_SetUserGroup", function(ply, steamID)
-    if lia.admin.isDisabled() then return end
+    if lia.admin.isDisabled() or ply:IsBot() then return end
     local steam64 = util.SteamIDTo64(steamID)
     if CAMI and CAMI.GetUsergroup and CAMI.GetUsergroup(ply:GetUserGroup()) and ply:GetUserGroup() ~= "user" then
         lia.db.query(Format("UPDATE lia_players SET _userGroup = '%s' WHERE _steamID = %s", lia.db.escape(ply:GetUserGroup()), steam64))

--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -18,6 +18,7 @@ do
 end
 
 function playerMeta:hasPrivilege(privilegeName)
+    if self:IsBot() then return false end
     local group = self:GetUserGroup()
     local perms = lia.admin.groups[group]
     if not perms then return false end
@@ -566,6 +567,7 @@ if SERVER then
     end
 
     function playerMeta:banPlayer(reason, duration)
+        if self:IsBot() then return end
         lia.admin.addBan(self:SteamID64(), reason, duration)
         self:Kick(L("banMessage", self, duration or 0, reason or L("genericReason", self)))
     end

--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -159,6 +159,7 @@ if SERVER then
         local bans = getBanList()
         local plys = {}
         for _, v in ipairs(player.GetAll()) do
+            if v:IsBot() then continue end
             plys[#plys + 1] = {
                 name = v:Nick(),
                 id = v:SteamID(),
@@ -203,7 +204,10 @@ if SERVER then
     end
 
     syncPrivileges()
-    hook.Add("PlayerInitialSpawn", "liaAdminTrackJoin", function(p) lia.admin.lastJoin[p:SteamID()] = os.time() end)
+    hook.Add("PlayerInitialSpawn", "liaAdminTrackJoin", function(p)
+        if p:IsBot() then return end
+        lia.admin.lastJoin[p:SteamID()] = os.time()
+    end)
     net.Receive("liaGroupsRequest", function(_, p)
         if not allowed(p) then return end
         syncPrivileges()


### PR DESCRIPTION
## Summary
- avoid running admin actions on bots
- skip bots when building admin player lists

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68816566aea0832799fbadf2dc112384