### PR TITLE
Display user group privileges

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -1003,6 +1003,7 @@ LANGUAGE = {
     healthLabel = "Health: %s",
     armorLabel = "Armor: %s",
     usergroupLabel = "Usergroup: %s",
+    usergroupPrivilegesLabel = "Privileges: %s",
     characterFactionLabel = "Character Faction: %s",
     noLoadedCharacter = "No Loaded Character",
     originLabel = "origin = (%s, %s, %s)",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -1002,6 +1002,7 @@ LANGUAGE = {
     healthLabel = "Santé : %s",
     armorLabel = "Armure : %s",
     usergroupLabel = "Groupe : %s",
+    usergroupPrivilegesLabel = "Privilèges : %s",
     characterFactionLabel = "Faction : %s",
     noLoadedCharacter = "Aucun personnage chargé",
     originLabel = "origin = (%s, %s, %s)",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -1002,6 +1002,7 @@ LANGUAGE = {
     healthLabel = "Salute: %s",
     armorLabel = "Armatura: %s",
     usergroupLabel = "Usergroup: %s",
+    usergroupPrivilegesLabel = "Privilegi: %s",
     characterFactionLabel = "Fazione Personaggio: %s",
     noLoadedCharacter = "Nessun Personaggio Caricato",
     originLabel = "origin = (%s, %s, %s)",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -1002,6 +1002,7 @@ LANGUAGE = {
     healthLabel = "Vida: %s",
     armorLabel = "Armadura: %s",
     usergroupLabel = "Grupo: %s",
+    usergroupPrivilegesLabel = "Privilégios: %s",
     characterFactionLabel = "Facção: %s",
     noLoadedCharacter = "Sem personagem carregada",
     originLabel = "origem = (%s, %s, %s)",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -1002,6 +1002,7 @@ LANGUAGE = {
     healthLabel = "HP: %s",
     armorLabel = "Броня: %s",
     usergroupLabel = "Группа: %s",
+    usergroupPrivilegesLabel = "Привилегии: %s",
     characterFactionLabel = "Фракция персонажа: %s",
     noLoadedCharacter = "Нет загруженного персонажа",
     originLabel = "origin = (%s, %s, %s)",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -1002,6 +1002,7 @@ LANGUAGE = {
     healthLabel = "Salud: %s",
     armorLabel = "Armadura: %s",
     usergroupLabel = "Grupo: %s",
+    usergroupPrivilegesLabel = "Privilegios: %s",
     characterFactionLabel = "Facción: %s",
     noLoadedCharacter = "Sin personaje cargado",
     originLabel = "origen = (%s, %s, %s)",

--- a/gamemode/modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua
+++ b/gamemode/modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua
@@ -40,7 +40,24 @@ function SWEP:DrawHUD()
         end
 
         if target:IsPlayer() then
-            information = {L("nicknameLabel", target:Nick()), L("steamNameLabel", target.SteamName and target:SteamName() or target:Name()), L("steamIDLabel", target:SteamID()), L("steamID64Label", target:SteamID64()), L("healthLabel", target:Health()), L("armorLabel", target:Armor()), L("usergroupLabel", target:GetUserGroup())}
+            local group = target:GetUserGroup()
+            local privTbl = lia.admin and lia.admin.groups and lia.admin.groups[group] or {}
+            local privNames = {}
+            for priv in pairs(privTbl) do
+                privNames[#privNames + 1] = priv
+            end
+            table.sort(privNames)
+            local privStr = table.concat(privNames, ", ")
+            information = {
+                L("nicknameLabel", target:Nick()),
+                L("steamNameLabel", target.SteamName and target:SteamName() or target:Name()),
+                L("steamIDLabel", target:SteamID()),
+                L("steamID64Label", target:SteamID64()),
+                L("healthLabel", target:Health()),
+                L("armorLabel", target:Armor()),
+                L("usergroupLabel", group),
+                L("usergroupPrivilegesLabel", privStr)
+            }
             if target:getChar() then
                 local char = target:getChar()
                 local faction = lia.faction.indices[target:Team()]


### PR DESCRIPTION
## Summary
- localize a label for user group privileges
- show privilege list when using the admin stick

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688167930be08327857eae72b470c1aa