### PR TITLE
Fix bodygrouper to use latest character variables

### DIFF
--- a/gamemode/modules/bodygrouper/netcalls/server.lua
+++ b/gamemode/modules/bodygrouper/netcalls/server.lua
@@ -49,12 +49,12 @@ net.Receive("BodygrouperMenu", function(_, client)
     local character = target:getChar()
     if not character then return end
     target:SetSkin(skn)
-    character:setData("skin", skn)
+    character:setSkin(skn)
     for k, v in pairs(groups) do
         target:SetBodygroup(k, v)
     end
 
-    character:setData("groups", groups)
+    character:setBodygroups(groups)
     hook.Run("PostBodygroupApply", client, target, skn, groups)
     if target == client then
         target:notifyLocalized("bodygroupChanged", "your")


### PR DESCRIPTION
## Summary
- bodygrouper now persists skin and bodygroups using character variables

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688170c074b48327a9310e80fd1f2828