### PR TITLE
Add banned as character variable

### DIFF
--- a/gamemode/core/derma/mainmenu/character.lua
+++ b/gamemode/core/derma/mainmenu/character.lua
@@ -487,7 +487,7 @@ function PANEL:createSelectedCharacterInfoPanel(character)
     local selectText = L("selectCharacter")
     if clientChar and character:getID() == clientChar:getID() then
         selectText = L("alreadyUsingCharacter")
-    elseif character:getData("banned") then
+    elseif character:getBanned() then
         selectText = L("bannedCharacter")
     end
 
@@ -495,7 +495,7 @@ function PANEL:createSelectedCharacterInfoPanel(character)
     self.selectBtn:SetSize(bw, bh)
     self.selectBtn:SetPos(cx, fy + fh + pad)
     self.selectBtn:SetText(selectText)
-    if clientChar and character:getID() == clientChar:getID() or character:getData("banned") then
+    if clientChar and character:getID() == clientChar:getID() or character:getBanned() then
         self.selectBtn:SetEnabled(false)
         self.selectBtn:SetTextColor(Color(255, 255, 255))
     end

--- a/gamemode/core/libraries/character.lua
+++ b/gamemode/core/libraries/character.lua
@@ -432,6 +432,13 @@ lia.char.registerVar("lastPos", {
     noDisplay = true
 })
 
+lia.char.registerVar("banned", {
+    field = "_banned",
+    fieldType = "text",
+    isLocal = true,
+    noDisplay = true
+})
+
 function lia.char.getCharData(charID, key)
     local charIDsafe = tonumber(charID)
     if not charIDsafe then return end

--- a/gamemode/core/meta/character.lua
+++ b/gamemode/core/meta/character.lua
@@ -471,7 +471,7 @@ if SERVER then
     function characterMeta:ban(time)
         time = tonumber(time)
         if time then time = os.time() + math.max(math.ceil(time), 60) end
-        self:setData("banned", time or true)
+        self:setBanned(time or true)
         self:save()
         self:kick()
         hook.Run("OnCharPermakilled", self, time or nil)

--- a/gamemode/modules/administration/submodules/permissions/commands.lua
+++ b/gamemode/modules/administration/submodules/permissions/commands.lua
@@ -43,7 +43,7 @@ lia.command.add("charunbanoffline", {
         if not charID then return client:notify("Invalid character ID.") end
         local charData = lia.char.getCharData(charID)
         if not charData then return client:notify("Character not found.") end
-        lia.char.setCharData(charID, "banned", nil)
+        lia.db.updateTable({_banned = nil}, nil, nil, "_id = " .. charID)
         lia.char.setCharData(charID, "charBanInfo", nil)
         client:notify("Offline character ID " .. charID .. " has been unbanned.")
         lia.log.add(client, "charUnbanOffline", charID)
@@ -60,7 +60,7 @@ lia.command.add("charbanoffline", {
         if not charID then return client:notify("Invalid character ID.") end
         local charData = lia.char.getCharData(charID)
         if not charData then return client:notify("Character not found.") end
-        lia.char.setCharData(charID, "banned", true)
+        lia.db.updateTable({_banned = true}, nil, nil, "_id = " .. charID)
         lia.char.setCharData(charID, "charBanInfo", {
             name = client:Nick(),
             steamID = client:SteamID(),
@@ -110,6 +110,7 @@ lia.command.add("charlist", {
             for _, row in ipairs(data) do
                 local stored = lia.char.loaded[row._id]
                 local info = stored and stored:getData() or lia.char.getCharData(row._id) or {}
+                local isBanned = stored and stored:getBanned() or row._banned
                 local allVars = {}
                 for varName, varInfo in pairs(lia.char.vars) do
                     local value
@@ -160,7 +161,7 @@ lia.command.add("charlist", {
                     Name = row._name,
                     Desc = row._desc,
                     Faction = row._faction,
-                    Banned = info.banned and "Yes" or "No",
+                    Banned = isBanned and "Yes" or "No",
                     BanningAdminName = info.charBanInfo and info.charBanInfo.name or "",
                     BanningAdminSteamID = info.charBanInfo and info.charBanInfo.steamID or "",
                     BanningAdminRank = info.charBanInfo and info.charBanInfo.rank or "",
@@ -704,8 +705,8 @@ lia.command.add("charunban", {
         end
 
         if charFound then
-            if charFound:getData("banned") then
-                charFound:setData("banned", nil)
+            if charFound:getBanned() then
+                charFound:setBanned(nil)
                 charFound:setData("permakilled", nil)
                 charFound:setData("charBanInfo", nil)
                 client:notifyLocalized("charUnBan", client:Name(), charFound:getName())
@@ -717,17 +718,17 @@ lia.command.add("charunban", {
 
         client.liaNextSearch = CurTime() + 15
         local sqlCondition = id and "_id = " .. id or "_name LIKE \"%" .. lia.db.escape(queryArg) .. "%\""
-        lia.db.query("SELECT _id, _name FROM lia_characters WHERE " .. sqlCondition .. " LIMIT 1", function(data)
+        lia.db.query("SELECT _id, _name, _banned FROM lia_characters WHERE " .. sqlCondition .. " LIMIT 1", function(data)
             if data and data[1] then
                 local charID = tonumber(data[1]._id)
-                local charData = lia.char.getCharData(charID)
+                local isBanned = data[1]._banned
                 client.liaNextSearch = 0
-                if not (charData and charData.banned) then
+                if not isBanned then
                     client:notifyLocalized("charNotBanned")
                     return
                 end
 
-                lia.char.setCharData(charID, "banned", nil)
+                lia.db.updateTable({_banned = nil}, nil, nil, "_id = " .. charID)
                 lia.char.setCharData(charID, "charBanInfo", nil)
                 client:notifyLocalized("charUnBan", client:Name(), data[1]._name)
                 lia.log.add(client, "charUnban", data[1]._name, charID)
@@ -852,7 +853,7 @@ lia.command.add("charban", {
 
         local character = target:getChar()
         if character then
-            character:setData("banned", true)
+            character:setBanned(true)
             character:setData("charBanInfo", {
                 name = client.steamName and client:steamName() or client:Name(),
                 steamID = client:SteamID(),

--- a/gamemode/modules/mainmenu/libraries/server.lua
+++ b/gamemode/modules/mainmenu/libraries/server.lua
@@ -32,13 +32,13 @@
 end
 
 function MODULE:CanPlayerUseChar(_, character)
-    local banned = character:getData("banned")
+    local banned = character:getBanned()
     if banned and isnumber(banned) and banned > os.time() then return false, L("bannedCharacter") end
     return true
 end
 
 function MODULE:CanPlayerSwitchChar(client, character, newCharacter)
-    local banned = character:getData("banned")
+    local banned = character:getBanned()
     if character:getID() == newCharacter:getID() then return false, L("alreadyUsingCharacter") end
     if banned and isnumber(banned) and banned > os.time() then return false, L("bannedCharacter") end
     if not client:Alive() then return false, L("youAreDead") end


### PR DESCRIPTION
## Summary
- register `banned` as a persistent character variable
- update admin commands to store bans via new char var

## Testing
- ❌ `luacheck gamemode --no-color` *(luacheck not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688170cc6b548327a2651870e44ad687