### PR TITLE
Fix admin group sync

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -382,3 +382,17 @@ concommand.Add("plysetgroup", function(ply, _, args)
         end
     end
 end)
+
+if SERVER then
+    hook.Add("PlayerInitialSpawn", "liaAdminSendGroups", function(client)
+        if lia.admin.isDisabled() then return end
+        net.Start("updateAdminGroups")
+        net.WriteTable(lia.admin.groups)
+        net.Send(client)
+    end)
+else
+    net.Receive("updateAdminGroups", function()
+        local data = net.ReadTable() or {}
+        lia.admin.groups = data
+    end)
+end


### PR DESCRIPTION
## Summary
- send admin group table to each joining player
- update local copy when receiving `updateAdminGroups`

## Testing
- `git status --short`
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6881795499908327a8ca9e8370122aba