### PR TITLE
Remove chatbox DB usage

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -265,7 +265,6 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS `lia_bans`;
     DROP TABLE IF EXISTS `lia_doors`;
     DROP TABLE IF EXISTS `lia_spawns`;
-    DROP TABLE IF EXISTS `lia_chatbox`;
     DROP TABLE IF EXISTS `lia_admingroups`;
     DROP TABLE IF EXISTS `lia_sitrooms`;
     DROP TABLE IF EXISTS `lia_saveditems`;
@@ -300,7 +299,6 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS lia_bans;
     DROP TABLE IF EXISTS lia_doors;
     DROP TABLE IF EXISTS lia_spawns;
-    DROP TABLE IF EXISTS lia_chatbox;
     DROP TABLE IF EXISTS lia_admingroups;
     DROP TABLE IF EXISTS lia_sitrooms;
     DROP TABLE IF EXISTS lia_saveditems;
@@ -452,12 +450,6 @@ function lia.db.loadTables()
                 PRIMARY KEY (_schema, _map)
             );
 
-            CREATE TABLE IF NOT EXISTS lia_chatbox (
-                _schema TEXT,
-                _map TEXT,
-                _data TEXT,
-                PRIMARY KEY (_schema, _map)
-            );
 
             CREATE TABLE IF NOT EXISTS lia_sitrooms (
                 _folder TEXT,
@@ -634,12 +626,6 @@ function lia.db.loadTables()
                 PRIMARY KEY (`_schema`, `_map`)
             );
 
-            CREATE TABLE IF NOT EXISTS `lia_chatbox` (
-                `_schema` TEXT NULL,
-                `_map` TEXT NULL,
-                `_data` TEXT NULL,
-                PRIMARY KEY (`_schema`, `_map`)
-            );
 
             CREATE TABLE IF NOT EXISTS `lia_sitrooms` (
                 `_folder` TEXT NULL,

--- a/gamemode/modules/chatbox/commands.lua
+++ b/gamemode/modules/chatbox/commands.lua
@@ -1,5 +1,4 @@
 ﻿local MODULE = MODULE
-MODULE.OOCBans = MODULE.OOCBans or {}
 lia.command.add("banooc", {
     adminOnly = true,
     privilege = "Ban OOC",
@@ -18,9 +17,8 @@ lia.command.add("banooc", {
             return
         end
 
-        local id = target:SteamID64()
-        if not table.HasValue(MODULE.OOCBans, id) then table.insert(MODULE.OOCBans, id) end
-        MODULE:SaveData()
+        target:setLiliaData("oocBan", true)
+        target:saveLiliaData()
         client:notifyLocalized("playerBannedFromOOC", target:Name())
         lia.log.add(client, "banOOC", target:Name(), target:SteamID64())
     end
@@ -44,9 +42,8 @@ lia.command.add("unbanooc", {
             return
         end
 
-        local id = target:SteamID64()
-        table.RemoveByValue(MODULE.OOCBans, id)
-        MODULE:SaveData()
+        target:setLiliaData("oocBan", false)
+        target:saveLiliaData()
         client:notifyLocalized("playerUnbannedFromOOC", target:Name())
         lia.log.add(client, "unbanOOC", target:Name(), target:SteamID64())
     end

--- a/gamemode/modules/chatbox/libraries/server.lua
+++ b/gamemode/modules/chatbox/libraries/server.lua
@@ -1,39 +1,3 @@
-﻿local TABLE = "chatbox"
-local function buildCondition(folder, map)
-    return "_schema = " .. lia.db.convertDataType(folder) .. " AND _map = " .. lia.db.convertDataType(map)
-end
-
-function MODULE:SaveData()
-    local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-    local map = game.GetMap()
-    lia.db.upsert({
-        _schema = folder,
-        _map = map,
-        _data = lia.data.serialize({
-            bans = self.OOCBans
-        })
-    }, TABLE)
-end
-
-function MODULE:LoadData()
-    local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-    local map = game.GetMap()
-    local condition = buildCondition(folder, map)
-    lia.db.selectOne({"_data"}, TABLE, condition):next(function(res)
-        local data = res and lia.data.deserialize(res._data) or {}
-        self.OOCBans = {}
-        if istable(data) and istable(data.bans) then
-            if data.bans[1] then
-                self.OOCBans = data.bans
-            else
-                for id, banned in pairs(data.bans) do
-                    if banned then table.insert(self.OOCBans, id) end
-                end
-            end
-        end
-    end)
-end
-
 function MODULE:InitializedModules()
     SetGlobalBool("oocblocked", false)
 end

--- a/gamemode/modules/chatbox/libraries/shared.lua
+++ b/gamemode/modules/chatbox/libraries/shared.lua
@@ -252,7 +252,7 @@ lia.chat.register("ooc", {
             return false
         end
 
-        if table.HasValue(MODULE.OOCBans, speaker:SteamID64()) then
+        if speaker:getLiliaData("oocBan", false) then
             speaker:notifyLocalized("oocBanned")
             return false
         end


### PR DESCRIPTION
## Summary
- store OOC bans in player data rather than keeping a global list
- drop unused database save/load code

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68817da8029c83278ff6f07077d006e9