### PR TITLE
Add usergroup dropdown in admin scoreboard

### DIFF
--- a/gamemode/modules/administration/libraries/client.lua
+++ b/gamemode/modules/administration/libraries/client.lua
@@ -110,8 +110,20 @@
                 name = "Return",
                 image = "icon16/arrow_redo.png",
                 func = function() RunConsoleCommand("say", "!return " .. target:SteamID()) end
-            }
+            },
         }
+
+        if client:IsSuperAdmin() or client:hasPrivilege("Staff Permissions - Manage UserGroups") then
+            table.insert(orderedOptions, {
+                name = "Set Usergroup",
+                image = "icon16/group_edit.png",
+                func = function()
+                    net.Start("liaRequestPlayerGroup")
+                    net.WriteEntity(target)
+                    net.SendToServer()
+                end
+            })
+        end
 
         for _, option in ipairs(orderedOptions) do
             table.insert(options, option)

--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -101,6 +101,7 @@ if SERVER then
     util.AddNetworkString("liaPlayersRequest")
     util.AddNetworkString("liaPlayersDataChunk")
     util.AddNetworkString("liaPlayersDataDone")
+    util.AddNetworkString("liaRequestPlayerGroup")
     lia.admin.privileges = lia.admin.privileges or {}
     lia.admin.groups = lia.admin.groups or {}
     lia.admin.lastJoin = lia.admin.lastJoin or {}
@@ -219,6 +220,29 @@ if SERVER then
     net.Receive("liaPlayersRequest", function(_, p)
         if not allowed(p) then return end
         sendBigTable(p, payloadPlayers(), "liaPlayersDataChunk", "liaPlayersDataDone")
+    end)
+
+    net.Receive("liaRequestPlayerGroup", function(_, p)
+        if not allowed(p) then return end
+        local target = net.ReadEntity()
+        if not IsValid(target) or not target:IsPlayer() then return end
+
+        local groups = {}
+        for name in pairs(lia.admin.groups or {}) do
+            groups[#groups + 1] = name
+        end
+        table.sort(groups)
+
+        p:requestDropdown("Set Usergroup", "Choose a group", groups, function(sel)
+            if not IsValid(p) or not IsValid(target) then return end
+            if lia.admin.groups[sel] then
+                lia.admin.setPlayerGroup(target, sel)
+                p:notifyLocalized("plyGroupSet")
+                lia.log.add(p, "plySetGroup", target:Name(), sel)
+            else
+                p:notifyLocalized("groupNotExists")
+            end
+        end)
     end)
 
     net.Receive("liaGroupsAdd", function(_, p)


### PR DESCRIPTION
## Summary
- add `liaRequestPlayerGroup` net message on the server
- implement server handler to prompt admins with a dropdown and change groups
- add scoreboard option to request usergroup change when right-clicking a player

## Testing
- `apt-get update && apt-get install -y luajit` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688180c2e9ac8327a9e5f813fde02961