### PR TITLE
Add admin DB tabs for tickets and warnings

### DIFF
--- a/gamemode/modules/administration/submodules/tickets/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/tickets/libraries/client.lua
@@ -138,3 +138,20 @@ function MODULE:TicketFrame(requester, message, claimed)
     table.insert(TicketFrames, frm)
     timer.Create("ticketsystem-" .. requester:SteamID64(), 60, 1, function() if IsValid(frm) then frm:Remove() end end)
 end
+
+hook.Add("liaAdminRegisterTab", "AdminTabTicketsDB", function(parent, tabs)
+    local ply = LocalPlayer()
+    if not (IsValid(ply) and ply:hasPrivilege("View DB Tables")) then return end
+    tabs["Tickets"] = {
+        icon = "icon16/page_white_text.png",
+        build = function(sheet)
+            local pnl = vgui.Create("DPanel", sheet)
+            pnl:DockPadding(10, 10, 10, 10)
+            net.Start("liaRequestTableData")
+            net.WriteString("lia_ticketclaims")
+            net.SendToServer()
+            return pnl
+        end
+    }
+end)
+

--- a/gamemode/modules/administration/submodules/warns/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/warns/libraries/client.lua
@@ -1,0 +1,15 @@
+hook.Add("liaAdminRegisterTab", "AdminTabWarningsDB", function(parent, tabs)
+    local ply = LocalPlayer()
+    if not (IsValid(ply) and ply:hasPrivilege("View DB Tables")) then return end
+    tabs["Warnings"] = {
+        icon = "icon16/error.png",
+        build = function(sheet)
+            local pnl = vgui.Create("DPanel", sheet)
+            pnl:DockPadding(10, 10, 10, 10)
+            net.Start("liaRequestTableData")
+            net.WriteString("lia_warnings")
+            net.SendToServer()
+            return pnl
+        end
+    }
+end)


### PR DESCRIPTION
## Summary
- allow viewing `lia_ticketclaims` and `lia_warnings` from the admin menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688187cbf06c8327bcd93983486fe6d4