### PR TITLE
Add Set Usergroup option in admin players tab

### DIFF
--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -342,6 +342,15 @@ else
             local m = DermaMenu()
             local opt = m:AddOption("View Character List", function() LocalPlayer():ConCommand("say /charlist " .. line.steamID) end)
             opt:SetIcon("icon16/user.png")
+            local ply = player.GetBySteamID(line.steamID) or player.GetBySteamID64(line.steamID64)
+            if IsValid(ply) and (LocalPlayer():IsSuperAdmin() or LocalPlayer():hasPrivilege("Staff Permissions - Manage UserGroups")) then
+                local grp = m:AddOption("Set Usergroup", function()
+                    net.Start("liaRequestPlayerGroup")
+                    net.WriteEntity(ply)
+                    net.SendToServer()
+                end)
+                grp:SetIcon("icon16/group_edit.png")
+            end
             m:Open()
         end
     end


### PR DESCRIPTION
## Summary
- allow admins to set a player's usergroup directly from the Players tab

## Testing
- `luacheck --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68818a06ac488327bdbc86ba6f448629