### PR TITLE
Fix AddSheet error when entity list is empty

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -963,6 +963,7 @@ LANGUAGE = {
     pressInstructions = "Press A/D to rotate | W/S to move camera vertically | Press SPACE to exit",
     entities = "Entities",
     totalPlayerEntities = "Total Player Entities: %s",
+    noEntitiesFound = "No entities to display.",
     modulesCount = "Modules Count: %s",
     ["Bring"] = "Bring",
     ["Goto"] = "Goto",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -962,6 +962,7 @@ LANGUAGE = {
     pressInstructions = "A/D pour tourner | W/S vertical | ESPACE quitter",
     entities = "Entités",
     totalPlayerEntities = "Entités du joueur : %s",
+    noEntitiesFound = "Aucune entité à afficher.",
     modulesCount = "Modules : %s",
     ["Bring"] = "Bring",
     ["Goto"] = "Goto",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -962,6 +962,7 @@ LANGUAGE = {
     pressInstructions = "Premi A/D per ruotare | W/S per muovere la camera verticalmente | Premi SPACE per uscire",
     entities = "Entità",
     totalPlayerEntities = "Entità Totali Giocatore: %s",
+    noEntitiesFound = "Nessuna entità da mostrare.",
     modulesCount = "Conteggio Moduli: %s",
     ["Bring"] = "Bring",
     ["Goto"] = "Goto",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -962,6 +962,7 @@ LANGUAGE = {
     pressInstructions = "Pressiona A/D rodar | W/S subir câmara | SPACE sair",
     entities = "Entidades",
     totalPlayerEntities = "Entidades do Jogador: %s",
+    noEntitiesFound = "Sem entidades para mostrar.",
     modulesCount = "Total de Módulos: %s",
     ["Bring"] = "Trazer",
     ["Goto"] = "Ir",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -962,6 +962,7 @@ LANGUAGE = {
     pressInstructions = "A/D вращение | W/S камера | SPACE выход",
     entities = "Сущности",
     totalPlayerEntities = "Объектов игрока: %s",
+    noEntitiesFound = "Нет сущностей для отображения.",
     modulesCount = "Модулей: %s",
     ["Bring"] = "Притянуть",
     ["Goto"] = "Перейти",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -962,6 +962,7 @@ LANGUAGE = {
     pressInstructions = "A/D girar | W/S cámara | SPACE salir",
     entities = "Entidades",
     totalPlayerEntities = "Entidades del jugador: %s",
+    noEntitiesFound = "No hay entidades para mostrar.",
     modulesCount = "Módulos: %s",
     ["Bring"] = "Traer",
     ["Goto"] = "Ir a",

--- a/gamemode/modules/f1menu/libraries/client.lua
+++ b/gamemode/modules/f1menu/libraries/client.lua
@@ -184,7 +184,18 @@ hook.Add("liaAdminRegisterTab", "AdminEntitiesTab", function(parent, tabs)
                 end
             end
 
-            if table.IsEmpty(entitiesByCreator) then return end
+            if table.IsEmpty(entitiesByCreator) then
+                local emptyPanel = vgui.Create("DPanel", sheet)
+                emptyPanel:Dock(FILL)
+                emptyPanel.Paint = function() end
+                local label = emptyPanel:Add("DLabel")
+                label:Dock(FILL)
+                label:SetContentAlignment(5)
+                label:SetText(L("noEntitiesFound") or "No entities to display.")
+                label:SetFont("liaMediumFont")
+                label:SetTextColor(color_white)
+                return emptyPanel
+            end
             local function startSpectateView(ent, originalThirdPerson)
                 local yaw = client:EyeAngles().yaw
                 local camZOffset = 50


### PR DESCRIPTION
## Summary
- prevent `DPropertySheet:AddSheet` error when there are no entities
- add `noEntitiesFound` translations for all languages

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68818b32b8308327a2411157750cf41a