### PR TITLE
Fix prop blacklist enforcement with dupes

### DIFF
--- a/gamemode/core/libraries/compatibility/advdupe.lua
+++ b/gamemode/core/libraries/compatibility/advdupe.lua
@@ -12,11 +12,20 @@
     return true
 end
 
-hook.Add("PlayerSpawnProp", "liaAdvDupe", function(client)
+hook.Add("PlayerSpawnProp", "liaAdvDupe", function(client, model)
     local w = client:GetActiveWeapon()
     if IsValid(w) and w:GetClass() == "gmod_tool" then
         local t = w:GetToolObject()
-        if t and t.Entities then return true end
+        if t and t.Entities then
+            local list = lia.data.get("prop_blacklist", {})
+            if table.HasValue(list, model) and not client:hasPrivilege("Spawn Permissions - Can Spawn Blacklisted Props") then
+                lia.log.add(client, "spawnDenied", "prop", model)
+                client:notifyLocalized("blacklistedProp")
+                return false
+            end
+
+            return true
+        end
     end
 end)
 

--- a/gamemode/core/libraries/compatibility/advdupe2.lua
+++ b/gamemode/core/libraries/compatibility/advdupe2.lua
@@ -12,11 +12,20 @@
     return true
 end
 
-hook.Add("PlayerSpawnProp", "liaAdvDupe2", function(client)
+hook.Add("PlayerSpawnProp", "liaAdvDupe2", function(client, model)
     local weapon = client:GetActiveWeapon()
     if IsValid(weapon) and weapon:GetClass() == "gmod_tool" then
         local toolobj = weapon:GetToolObject()
-        if toolobj and (client.AdvDupe2 and client.AdvDupe2.Entities or client.CurrentDupe and client.CurrentDupe.Entities or toolobj.Entities) then return true end
+        if toolobj and (client.AdvDupe2 and client.AdvDupe2.Entities or client.CurrentDupe and client.CurrentDupe.Entities or toolobj.Entities) then
+            local list = lia.data.get("prop_blacklist", {})
+            if table.HasValue(list, model) and not client:hasPrivilege("Spawn Permissions - Can Spawn Blacklisted Props") then
+                lia.log.add(client, "spawnDenied", "prop", model)
+                client:notifyLocalized("blacklistedProp")
+                return false
+            end
+
+            return true
+        end
     end
 end)
 


### PR DESCRIPTION
## Summary
- update advdupe and advdupe2 compatibility hooks
- respect prop blacklist when spawning duped props

## Testing
- `apt-get update -y` *(fails: repository is not signed)*
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68818caab87c8327b19d1046256990a7