### PR TITLE
Remove admin stick privilege display

### DIFF
--- a/gamemode/modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua
+++ b/gamemode/modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua
@@ -41,15 +41,15 @@ function SWEP:DrawHUD()
 
         if target:IsPlayer() then
             local group = target:GetUserGroup()
-            local privTbl = lia.admin and lia.admin.groups and lia.admin.groups[group] or {}
-            local privNames = {}
-            for priv in pairs(privTbl) do
-                privNames[#privNames + 1] = priv
-            end
-
-            table.sort(privNames)
-            local privStr = table.concat(privNames, ", ")
-            information = {L("nicknameLabel", target:Nick()), L("steamNameLabel", target.SteamName and target:SteamName() or target:Name()), L("steamIDLabel", target:SteamID()), L("steamID64Label", target:SteamID64()), L("healthLabel", target:Health()), L("armorLabel", target:Armor()), L("usergroupLabel", group), L("usergroupPrivilegesLabel", privStr)}
+            information = {
+                L("nicknameLabel", target:Nick()),
+                L("steamNameLabel", target.SteamName and target:SteamName() or target:Name()),
+                L("steamIDLabel", target:SteamID()),
+                L("steamID64Label", target:SteamID64()),
+                L("healthLabel", target:Health()),
+                L("armorLabel", target:Armor()),
+                L("usergroupLabel", group)
+            }
             if target:getChar() then
                 local char = target:getChar()
                 local faction = lia.faction.indices[target:Team()]


### PR DESCRIPTION
## Summary
- remove privilege listing from admin stick HUD

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68818cee4c348327a2dd7dcc20796ea6