### PR TITLE
Remove Last Character column and handle nil banned status

### DIFF
--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -330,10 +330,10 @@ else
         list:AddColumn("SteamID")
         list:AddColumn("Group")
         list:AddColumn("Last Join")
-        list:AddColumn("Last Character")
         list:AddColumn("Banned")
         for _, v in ipairs(PLAYER_LIST) do
-            local row = list:AddLine(v.name, v.id, v.group, v.lastJoin > 0 and os.date("%Y-%m-%d %H:%M:%S", v.lastJoin) or "", v.banned and "Yes" or "No")
+            local bannedText = v.banned == nil and "no" or (v.banned and "Yes" or "No")
+            local row = list:AddLine(v.name, v.id, v.group, v.lastJoin > 0 and os.date("%Y-%m-%d %H:%M:%S", v.lastJoin) or "", bannedText)
             row.steamID = v.id
             row.steamID64 = v.id64
             if v.banned then row:SetBGColor(Color(255, 120, 120)) end


### PR DESCRIPTION
## Summary
- remove the unused **Last Character** column from the admin player list
- default to showing `no` when a player's banned field is `nil`

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68819387b8508327b6cc48da2ec4be82