### PR TITLE
Ensure admin tabs use consistent panel parenting

### DIFF
--- a/gamemode/modules/administration/netcalls/client.lua
+++ b/gamemode/modules/administration/netcalls/client.lua
@@ -13,10 +13,12 @@ hook.Add("liaAdminRegisterTab", "AdminTabDBBrowser", function(parent, tabs)
     tabs["DB Browser"] = {
         icon = "icon16/database.png",
         build = function(sheet)
+            local pnl = vgui.Create("DPanel", sheet)
+            pnl:DockPadding(10, 10, 10, 10)
+            pnl.Paint = function() end
+            lia.gui.dbBrowser = pnl
             net.Start("liaRequestDBTables")
             net.SendToServer()
-            local pnl = vgui.Create("DPanel", sheet)
-            pnl.Paint = function() end
             return pnl
         end
     }

--- a/gamemode/modules/administration/submodules/permissions/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/client.lua
@@ -180,6 +180,7 @@ hook.Add("liaAdminRegisterTab", "AdminTabCharList", function(parent, tabs)
         build = function(sheet)
             local pnl = vgui.Create("DPanel", sheet)
             pnl:DockPadding(10, 10, 10, 10)
+            lia.gui.charList = pnl
             local entry = pnl:Add("DTextEntry")
             entry:Dock(TOP)
             entry:SetTall(25)

--- a/gamemode/modules/administration/submodules/tickets/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/tickets/libraries/client.lua
@@ -147,6 +147,7 @@ hook.Add("liaAdminRegisterTab", "AdminTabTicketsDB", function(parent, tabs)
         build = function(sheet)
             local pnl = vgui.Create("DPanel", sheet)
             pnl:DockPadding(10, 10, 10, 10)
+            lia.gui.tickets = pnl
             net.Start("liaRequestTableData")
             net.WriteString("lia_ticketclaims")
             net.SendToServer()

--- a/gamemode/modules/administration/submodules/warns/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/warns/libraries/client.lua
@@ -6,6 +6,7 @@ hook.Add("liaAdminRegisterTab", "AdminTabWarningsDB", function(parent, tabs)
         build = function(sheet)
             local pnl = vgui.Create("DPanel", sheet)
             pnl:DockPadding(10, 10, 10, 10)
+            lia.gui.warnings = pnl
             net.Start("liaRequestTableData")
             net.WriteString("lia_warnings")
             net.SendToServer()


### PR DESCRIPTION
## Summary
- parent DB Browser panel with `DPropertySheet` and track in `lia.gui`
- track panel references for Warnings, Tickets, and Character List tabs

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881964e7f008327903ba60db25bab45