### PR TITLE
Fix admin claims timestamp parsing

### DIFF
--- a/gamemode/core/libraries/time.lua
+++ b/gamemode/core/libraries/time.lua
@@ -11,16 +11,21 @@ function lia.time.TimeSince(strTime)
     if isnumber(strTime) then
         timestamp = strTime
     elseif isstring(strTime) then
-        local year, month, day = lia.time.ParseTime(strTime)
-        if not (year and month and day) then return L("invalidDate") end
-        timestamp = os.time{
-            year = year,
-            month = month,
-            day = day,
-            hour = 0,
-            min = 0,
-            sec = 0
-        }
+        local num = tonumber(strTime)
+        if num then
+            timestamp = num
+        else
+            local year, month, day = lia.time.ParseTime(strTime)
+            if not (year and month and day) then return L("invalidDate") end
+            timestamp = os.time{
+                year = year,
+                month = month,
+                day = day,
+                hour = 0,
+                min = 0,
+                sec = 0
+            }
+        end
     else
         return L("invalidInput")
     end

--- a/gamemode/modules/administration/submodules/tickets/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/tickets/libraries/server.lua
@@ -3,6 +3,8 @@
     for _, row in ipairs(rows or {}) do
         local adminID = row._admin
         if adminID ~= "Unassigned" then adminID = tostring(adminID):match("(%d+)$") or adminID end
+        local timestamp = tonumber(row._timestamp) or 0
+
         caseclaims[adminID] = caseclaims[adminID] or {
             name = adminID,
             claims = 0,
@@ -12,7 +14,7 @@
 
         local info = caseclaims[adminID]
         info.claims = tonumber(info.claims) + 1
-        if tonumber(row._timestamp) > tonumber(info.lastclaim) then info.lastclaim = row._timestamp end
+        if timestamp > tonumber(info.lastclaim) then info.lastclaim = timestamp end
         local reqPly = player.GetBySteamID64(row._requester)
         info.claimedFor[row._requester] = IsValid(reqPly) and reqPly:Nick() or row._requester
     end


### PR DESCRIPTION
## Summary
- handle numeric timestamp strings in `lia.time.TimeSince`
- ensure claim timestamps are numeric when building admin claim tables

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688198fd30408327abcb248901405bec