### PR TITLE
Fix door persistence

### DIFF
--- a/gamemode/modules/doors/libraries/server.lua
+++ b/gamemode/modules/doors/libraries/server.lua
@@ -76,6 +76,15 @@ function MODULE:SaveData()
             }
         end
     end
+
+    local count = #rows
+    if count > 0 then
+        return lia.db.bulkUpsert("doors", rows):next(function()
+            lia.information(L("doorSaveData", count))
+        end)
+    else
+        lia.information(L("doorSaveData", 0))
+    end
 end
 
 function MODULE:InitPostEntity()


### PR DESCRIPTION
## Summary
- ensure door SaveData persists to `lia_doors` table

## Testing
- `luacheck gamemode/modules/doors/libraries/server.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68819b3e7f90832795cab8537ba40504