### PR TITLE
Implement conditional admin sheet display

### DIFF
--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -668,9 +668,9 @@ else
     end
 
     hook.Add("liaAdminRegisterTab", "AdminTabUsergroups", function(parent, tabs)
-        if not canAccess() then return end
         tabs["Usergroups"] = {
             icon = "icon16/group.png",
+            onShouldShow = canAccess,
             build = function(sheet)
                 local pnl = vgui.Create("DPanel", sheet)
                 pnl:DockPadding(10, 10, 10, 10)
@@ -683,9 +683,9 @@ else
     end)
 
     hook.Add("liaAdminRegisterTab", "AdminTabPlayers", function(parent, tabs)
-        if not canAccess() then return end
         tabs["Players"] = {
             icon = "icon16/user.png",
+            onShouldShow = canAccess,
             build = function(sheet)
                 local pnl = vgui.Create("DPanel", sheet)
                 pnl:DockPadding(10, 10, 10, 10)
@@ -708,8 +708,14 @@ else
             local reg = {}
             hook.Run("liaAdminRegisterTab", parent, reg)
             for name, data in pairs(reg) do
-                local pnl = data.build(sheet)
-                sheet:AddSheet(name, pnl, data.icon or "icon16/application.png")
+                local should = true
+                if isfunction(data.onShouldShow) then
+                    should = data.onShouldShow() ~= false
+                end
+                if should then
+                    local pnl = data.build(sheet)
+                    sheet:AddSheet(name, pnl, data.icon or "icon16/application.png")
+                end
             end
         end
     end

--- a/gamemode/modules/administration/netcalls/client.lua
+++ b/gamemode/modules/administration/netcalls/client.lua
@@ -8,10 +8,14 @@
 end)
 
 hook.Add("liaAdminRegisterTab", "AdminTabDBBrowser", function(parent, tabs)
-    local ply = LocalPlayer()
-    if not (IsValid(ply) and ply:hasPrivilege("View DB Tables")) then return end
+    local function canView()
+        local ply = LocalPlayer()
+        return IsValid(ply) and ply:hasPrivilege("View DB Tables")
+    end
+
     tabs["DB Browser"] = {
         icon = "icon16/database.png",
+        onShouldShow = canView,
         build = function(sheet)
             local pnl = vgui.Create("DPanel", sheet)
             pnl:DockPadding(10, 10, 10, 10)

--- a/gamemode/modules/administration/submodules/logging/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/logging/libraries/client.lua
@@ -98,10 +98,14 @@ net.Receive("send_logs", function()
 end)
 
 hook.Add("liaAdminRegisterTab", "AdminTabLogs", function(parent, tabs)
-    local ply = LocalPlayer()
-    if not (IsValid(ply) and ply:hasPrivilege("Staff Permissions - Can See Logs")) then return end
+    local function canView()
+        local ply = LocalPlayer()
+        return IsValid(ply) and ply:hasPrivilege("Staff Permissions - Can See Logs")
+    end
+
     tabs[L("logs")] = {
         icon = "icon16/application_view_detail.png",
+        onShouldShow = canView,
         build = function(sheet)
             local pnl = vgui.Create("DPanel", sheet)
             pnl:DockPadding(10, 10, 10, 10)

--- a/gamemode/modules/administration/submodules/permissions/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/client.lua
@@ -173,10 +173,14 @@ net.Receive("DisplayCharList", function()
 end)
 
 hook.Add("liaAdminRegisterTab", "AdminTabCharList", function(parent, tabs)
-    local ply = LocalPlayer()
-    if not (IsValid(ply) and ply:hasPrivilege("List Characters")) then return end
+    local function canShow()
+        local ply = LocalPlayer()
+        return IsValid(ply) and ply:hasPrivilege("List Characters")
+    end
+
     tabs["Character List"] = {
         icon = "icon16/user_gray.png",
+        onShouldShow = canShow,
         build = function(sheet)
             local pnl = vgui.Create("DPanel", sheet)
             pnl:DockPadding(10, 10, 10, 10)

--- a/gamemode/modules/administration/submodules/tickets/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/tickets/libraries/client.lua
@@ -140,10 +140,14 @@ function MODULE:TicketFrame(requester, message, claimed)
 end
 
 hook.Add("liaAdminRegisterTab", "AdminTabTicketsDB", function(parent, tabs)
-    local ply = LocalPlayer()
-    if not (IsValid(ply) and ply:hasPrivilege("View DB Tables")) then return end
+    local function canView()
+        local ply = LocalPlayer()
+        return IsValid(ply) and ply:hasPrivilege("View DB Tables")
+    end
+
     tabs["Tickets"] = {
         icon = "icon16/page_white_text.png",
+        onShouldShow = canView,
         build = function(sheet)
             local pnl = vgui.Create("DPanel", sheet)
             pnl:DockPadding(10, 10, 10, 10)

--- a/gamemode/modules/administration/submodules/warns/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/warns/libraries/client.lua
@@ -1,8 +1,12 @@
 hook.Add("liaAdminRegisterTab", "AdminTabWarningsDB", function(parent, tabs)
-    local ply = LocalPlayer()
-    if not (IsValid(ply) and ply:hasPrivilege("View DB Tables")) then return end
+    local function canView()
+        local ply = LocalPlayer()
+        return IsValid(ply) and ply:hasPrivilege("View DB Tables")
+    end
+
     tabs["Warnings"] = {
         icon = "icon16/error.png",
+        onShouldShow = canView,
         build = function(sheet)
             local pnl = vgui.Create("DPanel", sheet)
             pnl:DockPadding(10, 10, 10, 10)

--- a/gamemode/modules/f1menu/libraries/client.lua
+++ b/gamemode/modules/f1menu/libraries/client.lua
@@ -168,9 +168,13 @@ function MODULE:CreateInformationButtons(pages)
 end
 
 hook.Add("liaAdminRegisterTab", "AdminEntitiesTab", function(parent, tabs)
-    if not LocalPlayer():hasPrivilege("Staff Permission — Access Entity List") then return end
+    local function canView()
+        return LocalPlayer():hasPrivilege("Staff Permission — Access Entity List")
+    end
+
     tabs[L("entities")] = {
         icon = "icon16/bricks.png",
+        onShouldShow = canView,
         build = function(sheet)
             local panel = vgui.Create("DPanel", sheet)
             panel:DockPadding(10, 10, 10, 10)

--- a/gamemode/modules/teams/libraries/shared.lua
+++ b/gamemode/modules/teams/libraries/shared.lua
@@ -232,13 +232,17 @@ else
     end
 
     hook.Add("liaAdminRegisterTab", "AdminTabFactions", function(parent, tabs)
-        local ply = LocalPlayer()
-        if not IsValid(ply) then return end
-        local char = ply:getChar()
-        if not char then return end
-        if not (ply:IsSuperAdmin() or char:hasFlags("V")) then return end
+        local function canAccess()
+            local ply = LocalPlayer()
+            if not IsValid(ply) then return false end
+            local char = ply:getChar()
+            if not char then return false end
+            return ply:IsSuperAdmin() or char:hasFlags("V")
+        end
+
         tabs["Factions"] = {
             icon = "icon16/group.png",
+            onShouldShow = canAccess,
             build = function(sheet)
                 local pnl = vgui.Create("DPanel", sheet)
                 pnl:DockPadding(10, 10, 10, 10)


### PR DESCRIPTION
## Summary
- support an `onShouldShow` field when populating admin tabs
- only add admin sheets when `onShouldShow` allows it
- define `onShouldShow` for each admin tab hook

## Testing
- `git status --short`
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68819baf6cec832792f5290066e23107