### PR TITLE
Fix missing roster localization

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -723,6 +723,7 @@ LANGUAGE = {
     plyIgniteDesc = "Set a player on fire.",
     plyExtinguishDesc = "Extinguish the specified player.",
     plyStripDesc = "Strip all weapons from a player.",
+    roster = "Roster",
     rosterDesc = "View a roster of your faction members.",
     factionManagementDesc = "Open the faction management menu.",
     adminMenuTitle = "Admin Menu",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -722,6 +722,7 @@ LANGUAGE = {
     plyIgniteDesc = "Enflamme un joueur.",
     plyExtinguishDesc = "Éteint un joueur.",
     plyStripDesc = "Retire toutes les armes.",
+    roster = "Roster",
     rosterDesc = "Affiche la liste de votre faction.",
     factionManagementDesc = "Ouvre la gestion de faction.",
     adminMenuTitle = "Menu admin",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -722,6 +722,7 @@ LANGUAGE = {
     plyIgniteDesc = "Dai fuoco a un giocatore.",
     plyExtinguishDesc = "Spegni il giocatore specificato.",
     plyStripDesc = "Rimuovi tutte le armi da un giocatore.",
+    roster = "Roster",
     rosterDesc = "Vedi il roster dei membri della tua fazione.",
     factionManagementDesc = "Apri il menu gestione fazione.",
     adminMenuTitle = "Menu Admin",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -722,6 +722,7 @@ LANGUAGE = {
     plyIgniteDesc = "Ateia fogo.",
     plyExtinguishDesc = "Extingue fogo.",
     plyStripDesc = "Remove armas.",
+    roster = "Roster",
     rosterDesc = "Vê roster da facção.",
     factionManagementDesc = "Abre gestão de facção.",
     adminMenuTitle = "Menu de Admin",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -722,6 +722,7 @@ LANGUAGE = {
     plyIgniteDesc = "Поджечь игрока.",
     plyExtinguishDesc = "Потушить игрока.",
     plyStripDesc = "Снять оружие.",
+    roster = "Roster",
     rosterDesc = "Просмотр состава фракции.",
     factionManagementDesc = "Меню управления фракцией.",
     adminMenuTitle = "Админ‑меню",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -722,6 +722,7 @@ LANGUAGE = {
     plyIgniteDesc = "Prender fuego.",
     plyExtinguishDesc = "Apagar fuego.",
     plyStripDesc = "Quitar armas.",
+    roster = "Roster",
     rosterDesc = "Ver roster.",
     factionManagementDesc = "Abrir gestión de facción.",
     adminMenuTitle = "Menú admin",


### PR DESCRIPTION
## Summary
- add missing `roster` string to all language files

## Testing
- `python3 - <<'PY'
import re, os
english_keys=set()
with open('gamemode/languages/english.lua') as f:
    data=f.read()
match=re.search(r'LANGUAGE\s*=\s*{(.*)}',data,re.S)
if match:
    for line in match.group(1).splitlines():
        m=re.match(r'\s*(?:\[\"([^\"]+)\"\]|([A-Za-z0-9_]+))\s*=',line)
        if m:
            english_keys.add(m.group(1) or m.group(2))
used=set()
for root,_,files in os.walk('gamemode'):
    for file in files:
        if file.endswith('.lua'):
            with open(os.path.join(root,file),errors='ignore') as g:
                code=g.read()
            for m in re.finditer(r'L\("([^\"]+)"\)',code):
                used.add(m.group(1))
missing=sorted(used-english_keys)
print('missing keys',missing)
PY

------
https://chatgpt.com/codex/tasks/task_e_68819ea2da9c832795d3de526c772551