### PR TITLE
Add admin tab privileges

### DIFF
--- a/gamemode/core/libraries/config.lua
+++ b/gamemode/core/libraries/config.lua
@@ -472,6 +472,7 @@ lia.config.add("DermaSkin", "Derma UI Skin", "Lilia Skin", function(_, newSkin) 
     options = CLIENT and getDermaSkins() or {"Lilia Skin"}
 })
 
+
 hook.Add("liaAdminRegisterTab", "liaConfigTab", function(parent, tabs)
     local ConfigFormatting = {
         Int = function(key, name, config, parent)
@@ -890,7 +891,7 @@ hook.Add("liaAdminRegisterTab", "liaConfigTab", function(parent, tabs)
         populate("")
     end
 
-    if hook.Run("CanPlayerModifyConfig", LocalPlayer()) ~= false then
+    if hook.Run("CanPlayerModifyConfig", LocalPlayer()) ~= false and LocalPlayer():hasPrivilege("Admin Tab - Config") then
         tabs["Config"] = {
             icon = "icon16/wrench.png",
             build = function(sheet)

--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -20,7 +20,23 @@ MODULE.Privileges = {
         MinAccess = "superadmin"
     },
     {
+        Name = "Admin Tab - Config",
+        MinAccess = "superadmin",
+    },
+    {
         Name = "Staff Permissions - Manage UserGroups",
+        MinAccess = "superadmin"
+    },
+    {
+        Name = "Staff Permissions - Access Usergroups Tab",
+        MinAccess = "superadmin"
+    },
+    {
+        Name = "Staff Permissions - Access Players Tab",
+        MinAccess = "superadmin"
+    },
+    {
+        Name = "Staff Permissions - Access DB Browser Tab",
         MinAccess = "superadmin"
     }
 }
@@ -667,10 +683,18 @@ else
         return IsValid(LocalPlayer()) and LocalPlayer():IsSuperAdmin() and LocalPlayer():hasPrivilege("Staff Permissions - Manage UserGroups")
     end
 
+    local function canAccessUsergroups()
+        return canAccess() and LocalPlayer():hasPrivilege("Staff Permissions - Access Usergroups Tab")
+    end
+
+    local function canAccessPlayers()
+        return canAccess() and LocalPlayer():hasPrivilege("Staff Permissions - Access Players Tab")
+    end
+
     hook.Add("liaAdminRegisterTab", "AdminTabUsergroups", function(parent, tabs)
         tabs["Usergroups"] = {
             icon = "icon16/group.png",
-            onShouldShow = canAccess,
+            onShouldShow = canAccessUsergroups,
             build = function(sheet)
                 local pnl = vgui.Create("DPanel", sheet)
                 pnl:DockPadding(10, 10, 10, 10)
@@ -685,7 +709,7 @@ else
     hook.Add("liaAdminRegisterTab", "AdminTabPlayers", function(parent, tabs)
         tabs["Players"] = {
             icon = "icon16/user.png",
-            onShouldShow = canAccess,
+            onShouldShow = canAccessPlayers,
             build = function(sheet)
                 local pnl = vgui.Create("DPanel", sheet)
                 pnl:DockPadding(10, 10, 10, 10)

--- a/gamemode/modules/administration/netcalls/client.lua
+++ b/gamemode/modules/administration/netcalls/client.lua
@@ -10,7 +10,7 @@ end)
 hook.Add("liaAdminRegisterTab", "AdminTabDBBrowser", function(parent, tabs)
     local function canView()
         local ply = LocalPlayer()
-        return IsValid(ply) and ply:hasPrivilege("View DB Tables")
+        return IsValid(ply) and ply:hasPrivilege("Staff Permissions - Access DB Browser Tab") and ply:hasPrivilege("View DB Tables")
     end
 
     tabs["DB Browser"] = {

--- a/gamemode/modules/administration/submodules/logging/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/logging/libraries/client.lua
@@ -100,7 +100,7 @@ end)
 hook.Add("liaAdminRegisterTab", "AdminTabLogs", function(parent, tabs)
     local function canView()
         local ply = LocalPlayer()
-        return IsValid(ply) and ply:hasPrivilege("Staff Permissions - Can See Logs")
+        return IsValid(ply) and ply:hasPrivilege("Staff Permissions - Access Logs Tab") and ply:hasPrivilege("Staff Permissions - Can See Logs")
     end
 
     tabs[L("logs")] = {

--- a/gamemode/modules/administration/submodules/logging/module.lua
+++ b/gamemode/modules/administration/submodules/logging/module.lua
@@ -4,6 +4,10 @@ MODULE.discord = "@liliaplayer"
 MODULE.desc = "Tracks administrative actions and server events, writing detailed logs that staff can review for oversight and auditing."
 MODULE.Privileges = {
     {
+        Name = "Staff Permissions - Access Logs Tab",
+        MinAccess = "superadmin"
+    },
+    {
         Name = "Staff Permissions - Can See Logs",
         MinAccess = "superadmin"
     }

--- a/gamemode/modules/administration/submodules/permissions/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/client.lua
@@ -175,7 +175,7 @@ end)
 hook.Add("liaAdminRegisterTab", "AdminTabCharList", function(parent, tabs)
     local function canShow()
         local ply = LocalPlayer()
-        return IsValid(ply) and ply:hasPrivilege("List Characters")
+        return IsValid(ply) and ply:hasPrivilege("Staff Permissions - Access Character List Tab") and ply:hasPrivilege("List Characters")
     end
 
     tabs["Character List"] = {

--- a/gamemode/modules/administration/submodules/permissions/module.lua
+++ b/gamemode/modules/administration/submodules/permissions/module.lua
@@ -4,6 +4,10 @@ MODULE.discord = "@liliaplayer"
 MODULE.desc = "Integrates with the CAMI system to provide fine-grained permission management for commands and modules across the framework."
 MODULE.Privileges = {
     {
+        Name = "Staff Permissions - Access Character List Tab",
+        MinAccess = "admin",
+    },
+    {
         Name = "Staff Permissions - Can Bypass Character Lock",
         MinAccess = "superadmin",
     },

--- a/gamemode/modules/administration/submodules/tickets/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/tickets/libraries/client.lua
@@ -142,7 +142,7 @@ end
 hook.Add("liaAdminRegisterTab", "AdminTabTicketsDB", function(parent, tabs)
     local function canView()
         local ply = LocalPlayer()
-        return IsValid(ply) and ply:hasPrivilege("View DB Tables")
+        return IsValid(ply) and ply:hasPrivilege("Staff Permissions - Access Tickets Tab") and ply:hasPrivilege("View DB Tables")
     end
 
     tabs["Tickets"] = {

--- a/gamemode/modules/administration/submodules/tickets/module.lua
+++ b/gamemode/modules/administration/submodules/tickets/module.lua
@@ -5,6 +5,10 @@ MODULE.discord = "@liliaplayer"
 MODULE.desc = "Introduces a ticket system where players can submit help requests that staff can view, respond to, and resolve in an organized manner."
 MODULE.Privileges = {
     {
+        Name = "Staff Permissions - Access Tickets Tab",
+        MinAccess = "superadmin",
+    },
+    {
         Name = "Staff Permissions - Always See Tickets",
         MinAccess = "superadmin"
     },

--- a/gamemode/modules/administration/submodules/warns/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/warns/libraries/client.lua
@@ -1,7 +1,7 @@
 hook.Add("liaAdminRegisterTab", "AdminTabWarningsDB", function(parent, tabs)
     local function canView()
         local ply = LocalPlayer()
-        return IsValid(ply) and ply:hasPrivilege("View DB Tables")
+        return IsValid(ply) and ply:hasPrivilege("Staff Permissions - Access Warnings Tab") and ply:hasPrivilege("View DB Tables")
     end
 
     tabs["Warnings"] = {

--- a/gamemode/modules/administration/submodules/warns/module.lua
+++ b/gamemode/modules/administration/submodules/warns/module.lua
@@ -2,3 +2,9 @@
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.desc = "Adds a warning system complete with logs and a management menu so staff can issue, track, and remove player warnings."
+MODULE.Privileges = {
+    {
+        Name = "Staff Permissions - Access Warnings Tab",
+        MinAccess = "superadmin",
+    }
+}

--- a/gamemode/modules/teams/libraries/shared.lua
+++ b/gamemode/modules/teams/libraries/shared.lua
@@ -237,7 +237,7 @@ else
             if not IsValid(ply) then return false end
             local char = ply:getChar()
             if not char then return false end
-            return ply:IsSuperAdmin() or char:hasFlags("V")
+            return (ply:IsSuperAdmin() or char:hasFlags("V")) and ply:hasPrivilege("Staff Permissions - Access Factions Tab")
         end
 
         tabs["Factions"] = {

--- a/gamemode/modules/teams/module.lua
+++ b/gamemode/modules/teams/module.lua
@@ -2,3 +2,9 @@
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.desc = "Handles the creation of factions and character classes, controlling default permissions and spawn settings for each."
+MODULE.Privileges = {
+    {
+        Name = "Staff Permissions - Access Factions Tab",
+        MinAccess = "superadmin",
+    }
+}


### PR DESCRIPTION
## Summary
- add missing admin privileges per tab
- require new privileges when showing admin tabs
- move Config tab privilege to administration module

## Testing
- `apt-get update` *(fails: repository not signed)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881a004d1a8832796b0f466a84f70f0