### PR TITLE
Implement cheater chat and door restrictions

### DIFF
--- a/gamemode/modules/protection/libraries/server.lua
+++ b/gamemode/modules/protection/libraries/server.lua
@@ -293,3 +293,23 @@ function MODULE:CanPlayerInteractItem(client, action)
         return false
     end
 end
+function MODULE:CanPlayerLock(client, door)
+    if lia.config.get("DisableCheaterActions", true) and client:getNetVar("cheater", false) then
+        LogCheaterAction(client, "lock door")
+        return false
+    end
+end
+
+function MODULE:CanPlayerUnlock(client, door)
+    if lia.config.get("DisableCheaterActions", true) and client:getNetVar("cheater", false) then
+        LogCheaterAction(client, "unlock door")
+        return false
+    end
+end
+
+function MODULE:PlayerMessageSend(client, chatType, message, anonymous)
+    if chatType == "ooc" and lia.config.get("DisableCheaterActions", true) and client:getNetVar("cheater", false) then
+        LogCheaterAction(client, "ooc message")
+        return "I have to cheat on GMOD!!!!"
+    end
+end


### PR DESCRIPTION
## Summary
- block door locking/unlocking for flagged cheaters
- force cheater OOC messages to a fixed phrase

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881a797dc2c8327be41508c815a3153