### PR TITLE
Add missing privilege definitions

### DIFF
--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -38,6 +38,18 @@ MODULE.Privileges = {
     {
         Name = "Staff Permissions - Access DB Browser Tab",
         MinAccess = "superadmin"
+    },
+    {
+        Name = "View DB Tables",
+        MinAccess = "superadmin"
+    },
+    {
+        Name = "Manage SitRooms",
+        MinAccess = "superadmin"
+    },
+    {
+        Name = "List Characters",
+        MinAccess = "admin"
     }
 }
 


### PR DESCRIPTION
## Summary
- register missing privileges for database browsing, sitroom management, and character lists

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6881eb7d9e808327aee11262ed745768