### PR TITLE
Add permanent kill message and flagged ragdolls

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -54,7 +54,11 @@ function GM:PlayerDeath(client, inflictor, attacker)
     local playerKill = IsValid(attacker) and attacker:IsPlayer() and attacker ~= client
     local selfKill = attacker == client
     local worldKill = not IsValid(attacker) or attacker:GetClass() == "worldspawn"
-    if (playerKill or pkWorld and selfKill or pkWorld and worldKill) and hook.Run("PlayerShouldPermaKill", client, inflictor, attacker) then character:ban() end
+    if (playerKill or pkWorld and selfKill or pkWorld and worldKill) and hook.Run("PlayerShouldPermaKill", client, inflictor, attacker) then
+        net.Start("PKMessage")
+        net.Send(client)
+        character:ban()
+    end
 end
 
 function GM:PlayerShouldPermaKill(client)
@@ -353,7 +357,15 @@ end
 
 function GM:DoPlayerDeath(client, attacker)
     client:AddDeaths(1)
-    if hook.Run("ShouldSpawnClientRagdoll", client) ~= false then client:createRagdoll(false, true) end
+    local isPK = hook.Run("PlayerShouldPermaKill", client, nil, attacker)
+    local rag
+    if hook.Run("ShouldSpawnClientRagdoll", client) ~= false then
+        rag = client:createRagdoll(false, true)
+        if isPK then
+            rag.liaIsPK = true
+            hook.Run("OnCreatePKRagdoll", client, rag)
+        end
+    end
     if IsValid(attacker) and attacker:IsPlayer() then
         if client == attacker then
             attacker:AddFrags(-1)
@@ -1018,7 +1030,7 @@ concommand.Add("list_entities", function(client)
     end
 end)
 
-local networkStrings = {"RosterRequest", "actBar", "AdminModeSwapCharacter", "AnimationStatus", "ArgumentsRequest", "attrib", "BinaryQuestionRequest", "blindFade", "blindTarget", "ButtonRequest", "cfgList", "cfgSet", "charInfo", "charKick", "charSet", "charVar", "CheckHack", "CheckSeed", "classUpdate", "cmd", "cMsg", "CreateTableUI", "DisplayCharList", "doorMenu", "doorPerm", "gVar", "invAct", "invData", "invQuantity", "KickCharacter", "lia_managesitrooms_action", "liaCharacterData", "liaCharacterInvList", "liaCharChoose", "liaCharCreate", "liaCharDelete", "liaCharFetchNames", "liaCharList", "liaCmdArgPrompt", "liaData", "liaDataSync", "liaGroupsAdd", "liaGroupsData", "liaGroupsRemove", "liaGroupsRequest", "liaInventoryAdd", "liaInventoryData", "liaInventoryDelete", "liaInventoryInit", "liaInventoryRemove", "liaItemDelete", "liaItemInspect", "liaItemInstance", "liaNotify", "liaNotifyL", "liaPACPartAdd", "liaPACPartRemove", "liaPACPartReset", "liaPACSync", "liaStorageExit", "liaStorageOpen", "liaStorageTransfer", "liaStorageUnlock", "liaTeleportToEntity", "liaTransferItem", "managesitrooms", "msg", "nDel", "NetStreamDS", "nLcl", "nVar", "OpenInvMenu", "OptionsRequest", "playerLoadedChar", "postPlayerLoadedChar", "prePlayerLoadedChar", "RegenChat", "removeF1", "request_respawn", "RequestDropdown", "rgnDone", "send_logs", "send_logs_request", "seqSet", "ServerChatAddText", "setWaypoint", "setWaypointWithLogo", "SpawnMenuGiveItem", "SpawnMenuSpawnItem", "StringRequest", "TicketSystem", "TicketSystemClaim", "TicketSystemClose", "TransferMoneyFromP2P", "trunkInitStorage", "updateAdminGroups", "VendorAllowClass", "VendorAllowFaction", "VendorEdit", "VendorExit", "VendorMaxStock", "VendorMode", "VendorMoney", "VendorOpen", "VendorPrice", "VendorStock", "VendorSync", "VendorTrade", "VerifyCheats", "VerifyCheatsResponse", "ViewClaims", "WorkshopDownloader_Info", "WorkshopDownloader_Request", "WorkshopDownloader_Start", "liaDBTables", "liaRequestTableData", "liaDBTableData", "liaDBTableDataChunk", "liaDBTableDataDone"}
+local networkStrings = {"RosterRequest", "actBar", "AdminModeSwapCharacter", "AnimationStatus", "ArgumentsRequest", "attrib", "BinaryQuestionRequest", "blindFade", "blindTarget", "ButtonRequest", "cfgList", "cfgSet", "charInfo", "charKick", "charSet", "charVar", "CheckHack", "CheckSeed", "classUpdate", "cmd", "cMsg", "CreateTableUI", "DisplayCharList", "doorMenu", "doorPerm", "gVar", "invAct", "invData", "invQuantity", "KickCharacter", "lia_managesitrooms_action", "liaCharacterData", "liaCharacterInvList", "liaCharChoose", "liaCharCreate", "liaCharDelete", "liaCharFetchNames", "liaCharList", "liaCmdArgPrompt", "liaData", "liaDataSync", "liaGroupsAdd", "liaGroupsData", "liaGroupsRemove", "liaGroupsRequest", "liaInventoryAdd", "liaInventoryData", "liaInventoryDelete", "liaInventoryInit", "liaInventoryRemove", "liaItemDelete", "liaItemInspect", "liaItemInstance", "liaNotify", "liaNotifyL", "liaPACPartAdd", "liaPACPartRemove", "liaPACPartReset", "liaPACSync", "liaStorageExit", "liaStorageOpen", "liaStorageTransfer", "liaStorageUnlock", "liaTeleportToEntity", "liaTransferItem", "managesitrooms", "msg", "nDel", "NetStreamDS", "nLcl", "nVar", "OpenInvMenu", "OptionsRequest", "playerLoadedChar", "postPlayerLoadedChar", "prePlayerLoadedChar", "RegenChat", "removeF1", "request_respawn", "RequestDropdown", "rgnDone", "send_logs", "send_logs_request", "seqSet", "ServerChatAddText", "setWaypoint", "setWaypointWithLogo", "SpawnMenuGiveItem", "SpawnMenuSpawnItem", "StringRequest", "TicketSystem", "TicketSystemClaim", "TicketSystemClose", "TransferMoneyFromP2P", "trunkInitStorage", "updateAdminGroups", "VendorAllowClass", "VendorAllowFaction", "VendorEdit", "VendorExit", "VendorMaxStock", "VendorMode", "VendorMoney", "VendorOpen", "VendorPrice", "VendorStock", "VendorSync", "VendorTrade", "VerifyCheats", "VerifyCheatsResponse", "ViewClaims", "WorkshopDownloader_Info", "WorkshopDownloader_Request", "WorkshopDownloader_Start", "liaDBTables", "liaRequestTableData", "liaDBTableData", "liaDBTableDataChunk", "liaDBTableDataDone", "PKMessage"}
 for _, netString in ipairs(networkStrings) do
     util.AddNetworkString(netString)
 end

--- a/gamemode/core/netcalls/client.lua
+++ b/gamemode/core/netcalls/client.lua
@@ -645,6 +645,22 @@ net.Receive("charKick", function()
     hook.Run("KickedFromChar", id, isCurrentChar)
 end)
 
+local pkMessage = false
+net.Receive("PKMessage", function()
+    pkMessage = true
+end)
+
+hook.Add("HUDPaint", "liaPKMessage", function()
+    if not pkMessage then return end
+    local txt = L("pkMessage")
+    surface.SetFont("liaBigFont")
+    local w, h = surface.GetTextSize(txt)
+    local x, y = (ScrW() - w) / 2, ScrH() * 0.4
+    lia.util.drawText(txt, x + 2, y + 2, Color(0, 0, 0, 255), 0, 0, "liaBigFont")
+    lia.util.drawText(txt, x, y, color_white, 0, 0, "liaBigFont")
+    if input.IsKeyDown(KEY_SPACE) then pkMessage = false end
+end)
+
 net.Receive("prePlayerLoadedChar", function()
     local charID = net.ReadUInt(32)
     local currentID = net.ReadType()

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -433,6 +433,7 @@ LANGUAGE = {
     respawnKey = "Press %s to respawn",
     respawnIn = "You can respawn in %s",
     youHaveDied = "You have died",
+    pkMessage = "Your character has been permanently killed, press space to return to main menu",
     factionStaffName = "Staff on Duty",
     factionStaffDesc = "The Staff",
     cleaningFinished = "You cleaned up %s: %s entities removed.",


### PR DESCRIPTION
## Summary
- send PK notice on death
- flag death ragdolls and fire hook
- display PK message on client
- add translation key for the PK message

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881efc56ed083278b8b205329cd51a1