### PR TITLE
Fix SAM notification privilege

### DIFF
--- a/gamemode/core/libraries/compatibility/sam.lua
+++ b/gamemode/core/libraries/compatibility/sam.lua
@@ -213,6 +213,11 @@ lia.admin.registerPrivilege({
 })
 
 lia.admin.registerPrivilege({
+    Name = "Can See SAM Notifications",
+    MinAccess = "admin"
+})
+
+lia.admin.registerPrivilege({
     Name = "Can Bypass Staff Faction SAM Command whitelist",
     MinAccess = "superadmin"
 })


### PR DESCRIPTION
## Summary
- define `Can See SAM Notifications` privilege in the SAM compatibility library

## Testing
- `luacheck gamemode/core/libraries/compatibility/sam.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881f7d1be808327ab18d48d8373e88e