### PR TITLE
Fix missing pkMessage translations

### DIFF
--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -433,6 +433,7 @@ LANGUAGE = {
     respawnKey = "Appuyez sur %s pour réapparaître",
     respawnIn = "Réapparition dans %s",
     youHaveDied = "Vous êtes mort",
+    pkMessage = "Votre personnage a été tué définitivement, appuyez sur espace pour revenir au menu principal",
     factionStaffName = "Staff en service",
     factionStaffDesc = "Le staff",
     cleaningFinished = "Nettoyage : %s entités supprimées.",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -433,6 +433,7 @@ LANGUAGE = {
     respawnKey = "Premi %s per respawnare",
     respawnIn = "Puoi respawnare in %s",
     youHaveDied = "Sei morto",
+    pkMessage = "Il tuo personaggio è stato ucciso permanentemente, premi spazio per tornare al menu principale",
     factionStaffName = "Staff in Servizio",
     factionStaffDesc = "Lo Staff",
     cleaningFinished = "Hai pulito %s: %s entità rimosse.",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -433,6 +433,7 @@ LANGUAGE = {
     respawnKey = "Carrega %s para renascer",
     respawnIn = "Podes renascer em %s",
     youHaveDied = "Morreste",
+    pkMessage = "O teu personagem foi permanentemente morto, carrega no espaço para voltar ao menu principal",
     factionStaffName = "Staff em serviço",
     factionStaffDesc = "O Staff",
     cleaningFinished = "Limpeza concluída: %s entidades removidas.",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -433,6 +433,7 @@ LANGUAGE = {
     respawnKey = "Нажмите %s для респавна",
     respawnIn = "Вы сможете возродиться через %s",
     youHaveDied = "Вы умерли",
+    pkMessage = "Ваш персонаж был окончательно убит, нажмите пробел чтобы вернуться в главное меню",
     factionStaffName = "Персонал",
     factionStaffDesc = "Штат",
     cleaningFinished = "Очистка %s завершена: удалено сущностей %s.",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -433,6 +433,7 @@ LANGUAGE = {
     respawnKey = "Pulsa %s para reaparecer",
     respawnIn = "Puedes reaparecer en %s",
     youHaveDied = "Has muerto",
+    pkMessage = "Tu personaje ha sido asesinado permanentemente, presiona espacio para volver al menú principal",
     factionStaffName = "Staff en servicio",
     factionStaffDesc = "El Staff",
     cleaningFinished = "Limpiaste %s: %s entidades.",


### PR DESCRIPTION
## Summary
- localize `pkMessage` in French, Italian, Portuguese, Russian, and Spanish language files

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881f7dc3d348327b69ec5e000028d5f