### PR TITLE
Define missing admin privilege

### DIFF
--- a/gamemode/modules/administration/submodules/permissions/module.lua
+++ b/gamemode/modules/administration/submodules/permissions/module.lua
@@ -160,6 +160,10 @@ MODULE.Privileges = {
         MinAccess = "admin"
     },
     {
+        Name = "Check Inventories",
+        MinAccess = "admin"
+    },
+    {
         Name = "Manage Items",
         MinAccess = "superadmin"
     },


### PR DESCRIPTION
## Summary
- ensure all privileges are explicitly registered
- add missing `Check Inventories` privilege to the permissions module

## Testing
- `luac` not available; attempted package install but was blocked

------
https://chatgpt.com/codex/tasks/task_e_6881fb5f385c83279f54efb162e28e81