### PR TITLE
Fix missing SAM privileges

### DIFF
--- a/gamemode/core/libraries/compatibility/sam.lua
+++ b/gamemode/core/libraries/compatibility/sam.lua
@@ -222,6 +222,21 @@ lia.admin.registerPrivilege({
     MinAccess = "superadmin"
 })
 
+lia.admin.registerPrivilege({
+    Name = "Clear Decals",
+    MinAccess = "admin"
+})
+
+lia.admin.registerPrivilege({
+    Name = "View Own Playtime",
+    MinAccess = "admin"
+})
+
+lia.admin.registerPrivilege({
+    Name = "View Playtime",
+    MinAccess = "admin"
+})
+
 lia.config.add("AdminOnlyNotification", "Admin Only Notifications", true, nil, {
     desc = "Restricts certain notifications to admins with specific permissions or those on duty.",
     category = "Staff",


### PR DESCRIPTION
## Summary
- register `Clear Decals`, `View Own Playtime`, and `View Playtime` privileges in the SAM compatibility library

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881fd58a60c8327bfe1e67ed1c9e06b