### PR TITLE
Add privilege categories

### DIFF
--- a/documentation/docs/definitions/module.md
+++ b/documentation/docs/definitions/module.md
@@ -21,7 +21,7 @@ A `MODULE` table defines a self-contained add-on for the Lilia framework. Each f
 | `discord` | `string` | `""` | Discord tag or support channel. |
 | `version` | `number` | `0` | Version number for compatibility checks. |
 | `desc` | `string` | `"No Description"` | Short description of module functionality. |
-| `Privileges` | `table` | `nil` | CAMI privileges defined or required by the module. |
+| `Privileges` | `table` | `nil` | CAMI privileges defined or required by the module. Each entry may also specify a `Category`. |
 | `WorkshopContent` | `table` | `nil` | Steam Workshop add-on IDs required. |
 | `enabled` | `boolean` or `function` | `true` | Controls whether the module loads. |
 | `Dependencies` | `table` | `nil` | Files or directories included before the module loads. |
@@ -183,7 +183,7 @@ CAMI privileges required or provided by the module.
 
 ```lua
 MODULE.Privileges = {
-    { Name = "Admin Chat", MinAccess = "admin" }
+    { Name = "Admin Chat", MinAccess = "admin", Category = "Chat" }
 }
 ```
 
@@ -434,7 +434,7 @@ MODULE.WorkshopContent = {
 }
 
 MODULE.Privileges = {
-    { Name = "My Feature - Use", MinAccess = "admin" }
+    { Name = "My Feature - Use", MinAccess = "admin", Category = "MyFeature" }
 }
 
 MODULE.Dependencies = {

--- a/documentation/docs/libraries/lia.admin.md
+++ b/documentation/docs/libraries/lia.admin.md
@@ -84,7 +84,10 @@ Registers a CAMI privilege for use with permission checks.
 
 **Parameters**
 
-* `privilege` (*table*): Table containing the privilege definition.
+* `privilege` (*table*): Table containing the privilege definition. Supported fields:
+  * `Name` (*string*): Identifier of the privilege.
+  * `MinAccess` (*string*): Minimum group that automatically receives the privilege.
+  * `Category` (*string*): Display category for the privilege.
 
 When a privilege is registered it will automatically be assigned to all
 usergroups that inherit from the privilege's `MinAccess` level. Groups created

--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -35,6 +35,7 @@ function lia.admin.load()
         end
 
         for name, priv in pairs(CAMI and CAMI.GetPrivileges and CAMI.GetPrivileges() or {}) do
+            priv.Category = priv.Category or "Misc"
             lia.admin.privileges[name] = priv
         end
 
@@ -116,6 +117,7 @@ end
 function lia.admin.registerPrivilege(privilege)
     if lia.admin.isDisabled() then return end
     if not privilege or not privilege.Name then return end
+    privilege.Category = privilege.Category or "Misc"
     lia.admin.privileges[privilege.Name] = privilege
     for groupName in pairs(lia.admin.groups) do
         local minAccess = privilege.MinAccess or "user"

--- a/gamemode/core/libraries/commands.lua
+++ b/gamemode/core/libraries/commands.lua
@@ -15,7 +15,8 @@ function lia.command.add(command, data)
         if not lia.admin.privileges[privilegeName] then
             lia.admin.registerPrivilege({
                 Name = privilegeName,
-                MinAccess = superAdminOnly and "superadmin" or "admin"
+                MinAccess = superAdminOnly and "superadmin" or "admin",
+                Category = "Commands"
             })
         end
     end

--- a/gamemode/core/libraries/compatibility/pac.lua
+++ b/gamemode/core/libraries/compatibility/pac.lua
@@ -240,7 +240,8 @@ lia.config.add("BlockPackURLoad", "Block Pack URL Load", true, nil, {
 
 lia.admin.registerPrivilege({
     Name = "Can Use PAC3",
-    MinAccess = "admin"
+    MinAccess = "admin",
+    Category = "PAC3"
 })
 
 lia.flag.add("P", "Access to PAC3.")

--- a/gamemode/core/libraries/compatibility/sam.lua
+++ b/gamemode/core/libraries/compatibility/sam.lua
@@ -209,32 +209,38 @@ lia.command.add("plygetplaytime", {
 
 lia.admin.registerPrivilege({
     Name = "Can See SAM Notifications Outside Staff Character",
-    MinAccess = "superadmin"
+    MinAccess = "superadmin",
+    Category = "SAM"
 })
 
 lia.admin.registerPrivilege({
     Name = "Can See SAM Notifications",
-    MinAccess = "admin"
+    MinAccess = "admin",
+    Category = "SAM"
 })
 
 lia.admin.registerPrivilege({
     Name = "Can Bypass Staff Faction SAM Command whitelist",
-    MinAccess = "superadmin"
+    MinAccess = "superadmin",
+    Category = "SAM"
 })
 
 lia.admin.registerPrivilege({
     Name = "Clear Decals",
-    MinAccess = "admin"
+    MinAccess = "admin",
+    Category = "SAM"
 })
 
 lia.admin.registerPrivilege({
     Name = "View Own Playtime",
-    MinAccess = "admin"
+    MinAccess = "admin",
+    Category = "SAM"
 })
 
 lia.admin.registerPrivilege({
     Name = "View Playtime",
-    MinAccess = "admin"
+    MinAccess = "admin",
+    Category = "SAM"
 })
 
 lia.config.add("AdminOnlyNotification", "Admin Only Notifications", true, nil, {

--- a/gamemode/core/libraries/compatibility/simfphys.lua
+++ b/gamemode/core/libraries/compatibility/simfphys.lua
@@ -71,7 +71,8 @@ lia.config.add("TimeToEnterVehicle", "Time To Enter Vehicle", 4, nil, {
 
 lia.admin.registerPrivilege({
     Name = "Can Edit Simfphys Cars",
-    MinAccess = "superadmin"
+    MinAccess = "superadmin",
+    Category = "Simfphys"
 })
 
 hook.Add("simfphysPhysicsCollide", "SIMFPHYS_simfphysPhysicsCollide", function() return true end)

--- a/gamemode/core/libraries/modularity.lua
+++ b/gamemode/core/libraries/modularity.lua
@@ -9,7 +9,8 @@ local function loadPermissions(Privileges)
         if not lia.admin.privileges[privilegeName] then
             lia.admin.registerPrivilege({
                 Name = privilegeName,
-                MinAccess = privilegeData.MinAccess or "admin"
+                MinAccess = privilegeData.MinAccess or "admin",
+                Category = privilegeData.Category or MODULE.name
             })
         end
     end

--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -896,7 +896,8 @@ hook.Add("CAMI.OnPrivilegeRegistered", "liaSyncAdminPrivilegeAdd", function(pv)
     if lia.admin.isDisabled() or not pv or not pv.Name then return end
     lia.admin.privileges[pv.Name] = {
         Name = pv.Name,
-        MinAccess = pv.MinAccess or "user"
+        MinAccess = pv.MinAccess or "user",
+        Category = pv.Category or "Misc"
     }
 
     for g in pairs(lia.admin.groups) do

--- a/gamemode/modules/administration/submodules/permissions/libraries/shared.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/shared.lua
@@ -10,7 +10,8 @@ function MODULE:InitializedModules()
                 if not lia.admin.privileges[privilege] then
                     lia.admin.registerPrivilege({
                         Name = privilege,
-                        MinAccess = "admin"
+                        MinAccess = "admin",
+                        Category = "Properties"
                     })
                 end
             end
@@ -24,7 +25,8 @@ function MODULE:InitializedModules()
                 if not lia.admin.privileges[privilege] then
                     lia.admin.registerPrivilege({
                         Name = privilege,
-                        MinAccess = defaultUserTools[string.lower(tool)] and "user" or "admin"
+                        MinAccess = defaultUserTools[string.lower(tool)] and "user" or "admin",
+                        Category = "Tools"
                     })
                 end
             end


### PR DESCRIPTION
## Summary
- support specifying a `Category` field when registering privileges
- propagate category data through admin modules and compatibility files
- document the new field and show usage in module definitions

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882392639c883279d2e1756607b5c43