### PR TITLE
Remove duplicate rename strings

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -20,7 +20,6 @@ LANGUAGE = {
     renameSitroomTitle = "Rename Sitroom",
     teleport = "Teleport",
     reposition = "Reposition",
-    rename = "Rename",
     noAccess = "No Access",
     mecloseDesc = "Displays a close-range emote action.",
     actionsDesc = "Displays a general action.",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -20,7 +20,6 @@ LANGUAGE = {
     renameSitroomTitle = "Renommer la Sitroom",
     teleport = "Téléporter",
     reposition = "Repositionner",
-    rename = "Renommer",
     noAccess = "Aucun accès",
     mecloseDesc = "Affiche une action d’émote à courte portée.",
     actionsDesc = "Affiche une action générale.",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -20,7 +20,6 @@ LANGUAGE = {
     renameSitroomTitle = "Rinomina Sitroom",
     teleport = "Teletrasporta",
     reposition = "Riposiziona",
-    rename = "Rinomina",
     noAccess = "Nessun Accesso",
     mecloseDesc = "Mostra un'azione/emote a corto raggio.",
     actionsDesc = "Mostra un'azione generale.",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -20,7 +20,6 @@ LANGUAGE = {
     renameSitroomTitle = "Renomear Sitroom",
     teleport = "Teleportar",
     reposition = "Reposicionar",
-    rename = "Renomear",
     noAccess = "Sem acesso",
     mecloseDesc = "Mostra uma acção de emote de curta distância.",
     actionsDesc = "Mostra uma acção geral.",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -20,7 +20,6 @@ LANGUAGE = {
     renameSitroomTitle = "Переименовать атмосферу",
     teleport = "Телепорт",
     reposition = "Переместить",
-    rename = "Переименовать",
     noAccess = "Нет доступа",
     mecloseDesc = "Показывает действие‑эмоут в ближнем радиусе.",
     actionsDesc = "Показывает общее действие.",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -20,7 +20,6 @@ LANGUAGE = {
     renameSitroomTitle = "Renombrar Sala",
     teleport = "Teletransportar",
     reposition = "Reubicar",
-    rename = "Renombrar",
     noAccess = "Sin acceso",
     mecloseDesc = "Muestra una acción de rol cercana.",
     actionsDesc = "Muestra una acción general.",


### PR DESCRIPTION
## Summary
- remove unused `rename` localization entries

## Testing
- `apt-get update` *(fails: repository not signed)*
- `luacheck gamemode/languages/english.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68823c26bcd48327b9a0fc47ac36d52f