### PR TITLE
Update liaAdminRegisterTab signature

### DIFF
--- a/documentation/docs/hooks/gamemode_hooks.md
+++ b/documentation/docs/hooks/gamemode_hooks.md
@@ -10737,7 +10737,6 @@ Triggered when building the admin menu. Allows modules to add custom tabs.
 
 **Parameters**
 
-- `parent` (`Panel`): Parent panel for the property sheet.
 - `registry` (`table`): Table to fill with tab definitions.
 
 Each tab entry should use the tab name as the key and contain a table with optional `icon` and `onShouldShow` fields plus a `build` function that returns the panel to display.
@@ -10753,7 +10752,7 @@ Each tab entry should use the tab name as the key and contain a table with optio
 **Example Usage**
 
 ```lua
-hook.Add("liaAdminRegisterTab", "AddWarningsTab", function(parent, tabs)
+hook.Add("liaAdminRegisterTab", "AddWarningsTab", function(tabs)
     tabs["Warnings"] = {
         icon = "icon16/error.png",
         build = function(sheet)

--- a/gamemode/core/libraries/config.lua
+++ b/gamemode/core/libraries/config.lua
@@ -473,7 +473,7 @@ lia.config.add("DermaSkin", "Derma UI Skin", "Lilia Skin", function(_, newSkin) 
 })
 
 
-hook.Add("liaAdminRegisterTab", "liaConfigTab", function(_, tabs)
+hook.Add("liaAdminRegisterTab", "liaConfigTab", function(tabs)
     local ConfigFormatting = {
         Int = function(key, name, config, parent)
             local container = vgui.Create("DPanel", parent)

--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -819,7 +819,7 @@ else
         return canAccess() and LocalPlayer():hasPrivilege("Access Players Tab")
     end
 
-    hook.Add("liaAdminRegisterTab", "AdminTabUsergroups", function(_, tabs)
+    hook.Add("liaAdminRegisterTab", "AdminTabUsergroups", function(tabs)
         tabs["Usergroups"] = {
             icon = "icon16/group.png",
             onShouldShow = canAccessUsergroups,
@@ -834,7 +834,7 @@ else
         }
     end)
 
-    hook.Add("liaAdminRegisterTab", "AdminTabPlayers", function(_, tabs)
+    hook.Add("liaAdminRegisterTab", "AdminTabPlayers", function(tabs)
         tabs["Players"] = {
             icon = "icon16/user.png",
             onShouldShow = canAccessPlayers,
@@ -859,7 +859,7 @@ else
             sheet:Dock(FILL)
             sheet.Paint = function() end
             local reg = {}
-            hook.Run("liaAdminRegisterTab", parent, reg)
+            hook.Run("liaAdminRegisterTab", reg)
             for name, data in pairs(reg) do
                 local should = true
                 if isfunction(data.onShouldShow) then should = data.onShouldShow() ~= false end

--- a/gamemode/modules/administration/netcalls/client.lua
+++ b/gamemode/modules/administration/netcalls/client.lua
@@ -7,7 +7,7 @@
     hook.Run("InitializedConfig")
 end)
 
-hook.Add("liaAdminRegisterTab", "AdminTabDBBrowser", function(_, tabs)
+hook.Add("liaAdminRegisterTab", "AdminTabDBBrowser", function(tabs)
     local function canView()
         local ply = LocalPlayer()
         return IsValid(ply) and ply:hasPrivilege("Access DB Browser Tab") and ply:hasPrivilege("View DB Tables")

--- a/gamemode/modules/administration/submodules/logging/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/logging/libraries/client.lua
@@ -97,7 +97,7 @@ net.Receive("send_logs", function()
     if IsValid(receivedPanel) then OpenLogsUI(receivedPanel, categorizedLogs) end
 end)
 
-hook.Add("liaAdminRegisterTab", "AdminTabLogs", function(parent, tabs)
+hook.Add("liaAdminRegisterTab", "AdminTabLogs", function(tabs)
     local function canView()
         local ply = LocalPlayer()
         return IsValid(ply) and ply:hasPrivilege("Access Logs Tab") and ply:hasPrivilege("Can See Logs")

--- a/gamemode/modules/administration/submodules/permissions/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/client.lua
@@ -172,7 +172,7 @@ net.Receive("DisplayCharList", function()
     end
 end)
 
-hook.Add("liaAdminRegisterTab", "AdminTabCharList", function(_, tabs)
+hook.Add("liaAdminRegisterTab", "AdminTabCharList", function(tabs)
     local function canShow()
         local ply = LocalPlayer()
         return IsValid(ply) and ply:hasPrivilege("Access Character List Tab") and ply:hasPrivilege("List Characters")

--- a/gamemode/modules/administration/submodules/tickets/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/tickets/libraries/client.lua
@@ -140,7 +140,7 @@ function MODULE:TicketFrame(requester, message, claimed)
     timer.Create("ticketsystem-" .. requester:SteamID64(), 60, 1, function() if IsValid(frm) then frm:Remove() end end)
 end
 
-hook.Add("liaAdminRegisterTab", "AdminTabTicketsDB", function(_, tabs)
+hook.Add("liaAdminRegisterTab", "AdminTabTicketsDB", function(tabs)
     local function canView()
         local ply = LocalPlayer()
         return IsValid(ply) and ply:hasPrivilege("Access Tickets Tab") and ply:hasPrivilege("View DB Tables")

--- a/gamemode/modules/administration/submodules/warns/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/warns/libraries/client.lua
@@ -1,4 +1,4 @@
-hook.Add("liaAdminRegisterTab", "AdminTabWarningsDB", function(_, tabs)
+hook.Add("liaAdminRegisterTab", "AdminTabWarningsDB", function(tabs)
     local function canView()
         local ply = LocalPlayer()
         return IsValid(ply) and ply:hasPrivilege("Access Warnings Tab") and ply:hasPrivilege("View DB Tables")

--- a/gamemode/modules/f1menu/libraries/client.lua
+++ b/gamemode/modules/f1menu/libraries/client.lua
@@ -134,7 +134,7 @@ function MODULE:CreateInformationButtons(pages)
     end
 end
 
-hook.Add("liaAdminRegisterTab", "AdminEntitiesTab", function(_, tabs)
+hook.Add("liaAdminRegisterTab", "AdminEntitiesTab", function(tabs)
     local function canView()
         return LocalPlayer():hasPrivilege("Staff Permission — Access Entity List")
     end

--- a/gamemode/modules/teams/libraries/client.lua
+++ b/gamemode/modules/teams/libraries/client.lua
@@ -150,7 +150,7 @@ end
         end
     end
 
-    hook.Add("liaAdminRegisterTab", "AdminTabFactions", function(parent, tabs)
+    hook.Add("liaAdminRegisterTab", "AdminTabFactions", function(tabs)
         local function canAccess()
             local ply = LocalPlayer()
             if not IsValid(ply) then return false end


### PR DESCRIPTION
## Summary
- remove `parent` arg from `liaAdminRegisterTab`
- update modules to use new signature
- adjust admin menu registration call
- document updated hook usage

## Testing
- `luajit -v` *(fails: command not found)*
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68823c1d4de48327875f9c4d83b5842b