### PR TITLE
Register staff faction

### DIFF
--- a/gamemode/core/libraries/factions.lua
+++ b/gamemode/core/libraries/factions.lua
@@ -268,3 +268,19 @@ if CLIENT then
         return false
     end
 end
+
+-- Register the staff faction when the library loads so it is always available.
+FACTION_STAFF = lia.faction.register("staff", {
+    name = "factionStaffName",
+    desc = "factionStaffDesc",
+    color = Color(255, 56, 252),
+    isDefault = false,
+    models = {
+        "models/Humans/Group02/male_07.mdl",
+        "models/Humans/Group02/male_07.mdl",
+        "models/Humans/Group02/male_07.mdl",
+        "models/Humans/Group02/male_07.mdl",
+        "models/Humans/Group02/male_07.mdl"
+    },
+    weapons = {"weapon_physgun", "gmod_tool"}
+}).index


### PR DESCRIPTION
## Summary
- register staff faction automatically using `lia.faction.register`

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882cef8db288327b4e203614adf3014