### PR TITLE
Fix lia.faction.register index output

### DIFF
--- a/gamemode/core/libraries/factions.lua
+++ b/gamemode/core/libraries/factions.lua
@@ -95,6 +95,7 @@ function lia.faction.register(uniqueID, data)
     team.SetUp(FACTION.index, FACTION.name or L("unknown"), FACTION.color or Color(125, 125, 125))
     lia.faction.indices[FACTION.index] = FACTION
     lia.faction.teams[uniqueID] = FACTION
+    data.index = FACTION.index
 
     return FACTION
 end

--- a/gamemode/modules/administration/factions/staff.lua
+++ b/gamemode/modules/administration/factions/staff.lua
@@ -1,7 +1,13 @@
-﻿FACTION.name = "factionStaffName"
+FACTION.name = "factionStaffName"
 FACTION.desc = "factionStaffDesc"
 FACTION.color = Color(255, 56, 252)
 FACTION.isDefault = false
-FACTION.models = {"models/Humans/Group02/male_07.mdl", "models/Humans/Group02/male_07.mdl", "models/Humans/Group02/male_07.mdl", "models/Humans/Group02/male_07.mdl", "models/Humans/Group02/male_07.mdl"}
+FACTION.models = {
+    "models/Humans/Group02/male_07.mdl",
+    "models/Humans/Group02/male_07.mdl",
+    "models/Humans/Group02/male_07.mdl",
+    "models/Humans/Group02/male_07.mdl",
+    "models/Humans/Group02/male_07.mdl"
+}
 FACTION.weapons = {"weapon_physgun", "gmod_tool"}
 FACTION_STAFF = FACTION.index


### PR DESCRIPTION
## Summary
- ensure `lia.faction.register` writes the assigned team index back to the passed table
- clean up `staff.lua` faction definition formatting

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882d25e25608327a8fc8496fdc28800