### PR TITLE
Overhaul lia.administration log tag

### DIFF
--- a/documentation/docs/libraries/lia.admin.md
+++ b/documentation/docs/libraries/lia.admin.md
@@ -325,7 +325,7 @@ Executes a basic admin action by sending the appropriate chat command.
 
 **Purpose**
 
-Logs an admin related message with a coloured section tag.
+Logs an administration related message with a coloured section tag.
 
 **Parameters**
 
@@ -345,6 +345,8 @@ Logs an admin related message with a coloured section tag.
 
 ```lua
 lia.administration("Ban", "Player banned successfully")
+-- console output:
+-- [Lilia] [Administration] [Ban] Player banned successfully
 ```
 
 ---

--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -684,7 +684,7 @@ local function registerDefaultPrivileges()
 end
 
 function lia.administration(section, msg)
-    MsgC(Color(83, 143, 239), "[Lilia] ", "[Admin] ")
+    MsgC(Color(83, 143, 239), "[Lilia] ", "[Administration] ")
     MsgC(Color(0, 255, 0), "[" .. section .. "] ")
     MsgC(Color(255, 255, 255), tostring(msg), "\n")
 end


### PR DESCRIPTION
## Summary
- update the lia.administration function to print `[Administration]`
- adjust the documentation with an updated example

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6882f4fa6450832793d78e8d2df97ac4