### PR TITLE
Add join date info to admin players list

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -751,6 +751,7 @@ LANGUAGE = {
     renameGroupTitle = "Rename Group",
     delete = "Delete",
     group = "Group",
+    joinedOn = "Joined On",
     lastJoin = "Last Join",
     banned = "Banned",
     hoursPlayed = "Hours Played",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -751,6 +751,7 @@ LANGUAGE = {
     renameGroupTitle = "Renommer le groupe",
     delete = "Supprimer",
     group = "Groupe",
+    joinedOn = "Première connexion",
     lastJoin = "Dernière connexion",
     banned = "Banni",
     hoursPlayed = "Heures jouées",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -751,6 +751,7 @@ LANGUAGE = {
     renameGroupTitle = "Rinomina Gruppo",
     delete = "Elimina",
     group = "Gruppo",
+    joinedOn = "Prima Connessione",
     lastJoin = "Ultimo Accesso",
     banned = "Bannato",
     hoursPlayed = "Ore Giocate",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -751,6 +751,7 @@ LANGUAGE = {
     renameGroupTitle = "Renomear Grupo",
     delete = "Apagar",
     group = "Grupo",
+    joinedOn = "Primeira Conexão",
     lastJoin = "Última Conexão",
     banned = "Banido",
     hoursPlayed = "Horas Jogadas",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -751,6 +751,7 @@ LANGUAGE = {
     renameGroupTitle = "Переименовать группу",
     delete = "Удалить",
     group = "Группа",
+    joinedOn = "Первый вход",
     lastJoin = "Последний вход",
     banned = "Забанен",
     hoursPlayed = "Часов сыграно",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -751,6 +751,7 @@ LANGUAGE = {
     renameGroupTitle = "Renombrar grupo",
     delete = "Eliminar",
     group = "Grupo",
+    joinedOn = "Primera conexión",
     lastJoin = "Última conexión",
     banned = "Baneado",
     hoursPlayed = "Horas jugadas",

--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -131,7 +131,8 @@ if SERVER then
                 id = v:SteamID(),
                 id64 = v:SteamID64(),
                 group = v:GetUserGroup(),
-                lastJoin = lia.admin.lastJoin[v:SteamID()] or os.time(),
+                firstJoin = v.firstJoin or os.time(),
+                lastJoin = v.lastJoin or os.time(),
                 banned = bans[v:SteamID()] or false
             }
 
@@ -144,6 +145,7 @@ if SERVER then
                 id = id,
                 id64 = util.SteamIDTo64(id),
                 group = "",
+                firstJoin = 0,
                 lastJoin = 0,
                 banned = true
             }
@@ -302,11 +304,19 @@ else
         list:AddColumn(L("name"))
         list:AddColumn(L("steamID"))
         list:AddColumn(L("group"))
+        list:AddColumn(L("joinedOn"))
         list:AddColumn(L("lastJoin"))
         list:AddColumn(L("banned"))
         for _, v in ipairs(PlayerList) do
             local bannedText = v.banned == nil and "no" or v.banned and "Yes" or "No"
-            local row = list:AddLine(v.name, v.id, v.group, v.lastJoin > 0 and os.date("%Y-%m-%d %H:%M:%S", v.lastJoin) or "", bannedText)
+            local row = list:AddLine(
+                v.name,
+                v.id,
+                v.group,
+                v.firstJoin > 0 and os.date("%Y-%m-%d %H:%M:%S", v.firstJoin) or "",
+                v.lastJoin > 0 and os.date("%Y-%m-%d %H:%M:%S", v.lastJoin) or "",
+                bannedText
+            )
             row.steamID = v.id
             row.steamID64 = v.id64
             if v.banned then row:SetBGColor(Color(255, 120, 120)) end


### PR DESCRIPTION
## Summary
- include `firstJoin` and `lastJoin` data from players when sending the admin players list
- show the date a player first joined via new `Joined On` column
- translate `Joined On` string for all languages

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68830098ca408327a731a129d8f748ea