### PR TITLE
Add hook for custom sheeted F1 tabs

### DIFF
--- a/documentation/docs/hooks/gamemode_hooks.md
+++ b/documentation/docs/hooks/gamemode_hooks.md
@@ -8654,6 +8654,41 @@ end)
 
 ---
 
+### CreateSheetedTabs
+
+**Purpose**
+
+Adds new F1 tabs that contain property sheet pages. Comparable to how the
+information and settings tabs are built.
+
+**Parameters**
+
+- `tabs` (`table`): Table to populate with sheet definitions. Keys are tab
+  names and values are arrays of page tables containing `name` and `drawFunc`
+  fields.
+
+**Realm**
+
+`Client`
+
+**Returns**
+
+- None
+
+**Example Usage**
+
+```lua
+-- Creates a Tutorials tab with two separate sheets
+hook.Add("CreateSheetedTabs", "AddTutorialsTab", function(tabs)
+    tabs["Tutorials"] = {
+        { name = "Basics", drawFunc = function(pnl) end },
+        { name = "Advanced", drawFunc = function(pnl) end }
+    }
+end)
+```
+
+---
+
 ### InitializedKeybinds
 
 **Purpose**

--- a/gamemode/modules/f1menu/libraries/client.lua
+++ b/gamemode/modules/f1menu/libraries/client.lua
@@ -397,6 +397,25 @@ function MODULE:CreateMenuButtons(tabs)
             sheet:AddSheet(page.name, panel)
         end
     end
+
+    local sheetTabs = {}
+    hook.Run("CreateSheetedTabs", sheetTabs)
+    for name, pages in pairs(sheetTabs) do
+        tabs[name] = function(panel)
+            local sheet = panel:Add("DPropertySheet")
+            sheet:Dock(FILL)
+            sheet:DockMargin(10, 10, 10, 10)
+            for _, page in ipairs(pages) do
+                local pnl = sheet:Add("DPanel")
+                pnl:Dock(FILL)
+                pnl.Paint = function() end
+                if page.drawFunc then
+                    page.drawFunc(pnl)
+                end
+                sheet:AddSheet(page.name, pnl)
+            end
+        end
+    end
 end
 
 function MODULE:CanDisplayCharInfo(name)


### PR DESCRIPTION
## Summary
- support creating sheeted tabs in the F1 menu via `CreateSheetedTabs` hook
- document the new hook in gamemode hooks guide

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68831d67b430832796a086f70b35dcc6