### PR TITLE
Prevent duplicate faction registration

### DIFF
--- a/gamemode/core/libraries/factions.lua
+++ b/gamemode/core/libraries/factions.lua
@@ -56,12 +56,12 @@ function lia.faction.register(name, data)
     data = data or {}
     local sanitized = string.Trim(string.lower(name):gsub("[^%w]+", "_"), "_")
     local uniqueID = sanitized
+    if lia.faction.teams[uniqueID] then return lia.faction.teams[uniqueID] end
     local suffix = 1
     while lia.faction.teams[uniqueID] do
         suffix = suffix + 1
         uniqueID = sanitized .. suffix
     end
-    if lia.faction.teams[uniqueID] then return lia.faction.teams[uniqueID] end
     local index = table.Count(lia.faction.teams) + 1
     local FACTION = table.Copy(data)
     FACTION.index = data.index or index
@@ -264,3 +264,4 @@ FACTION_STAFF = lia.faction.register("factionStaffName", {
     models = {…},
     weapons = {"weapon_physgun", "gmod_tool"},
 }).index
+


### PR DESCRIPTION
## Summary
- skip new faction creation if a faction with the same unique ID already exists
- revert staff on-duty registration to rely on the universal check

## Testing
- `luacheck --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688327e9da808327bb3ab604d799ad3b