### PR TITLE
Add character list property sheets

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -1044,3 +1044,4 @@ local networkStrings = {"actBar", "AdminModeSwapCharacter", "AnimationStatus", "
 for _, netString in ipairs(networkStrings) do
     util.AddNetworkString(netString)
 end
+util.AddNetworkString("liaRequestAllCharList")

--- a/gamemode/core/netcalls/server.lua
+++ b/gamemode/core/netcalls/server.lua
@@ -270,6 +270,84 @@ net.Receive("liaRequestCharList", function(_, client)
     end)
 end)
 
+net.Receive("liaRequestAllCharList", function(_, client)
+    if not client:hasPrivilege("List Characters") then return end
+    lia.db.query("SELECT * FROM lia_characters", function(data)
+        if not data or #data == 0 then
+            client:notifyLocalized("noCharactersFound")
+            return
+        end
+
+        local sendData = {}
+        for _, row in ipairs(data) do
+            local stored = lia.char.loaded[row._id]
+            local info = stored and stored:getData() or lia.char.getCharData(row._id) or {}
+            local isBanned = stored and stored:getBanned() or row._banned
+            local allVars = {}
+            for varName, varInfo in pairs(lia.char.vars) do
+                local value
+                if stored then
+                    if varName == "data" then
+                        value = stored:getData()
+                    elseif varName == "var" then
+                        value = stored:getVar()
+                    else
+                        local getter = stored["get" .. varName:sub(1,1):upper() .. varName:sub(2)]
+                        if isfunction(getter) then
+                            value = getter(stored)
+                        else
+                            value = stored.vars and stored.vars[varName]
+                        end
+                    end
+                else
+                    if varName == "data" then
+                        value = info
+                    elseif varInfo.field and row[varInfo.field] ~= nil then
+                        local raw = row[varInfo.field]
+                        if isnumber(varInfo.default) then
+                            value = tonumber(raw) or varInfo.default
+                        elseif isbool(varInfo.default) then
+                            value = tobool(raw)
+                        elseif istable(varInfo.default) then
+                            value = util.JSONToTable(raw or "{}")
+                        else
+                            value = raw
+                        end
+                    else
+                        value = varInfo.default
+                    end
+                end
+
+                allVars[varName] = value
+            end
+
+            local lastUsedText = stored and L("onlineNow") or row._lastJoinTime
+            local entry = {
+                ID = row._id,
+                Name = row._name,
+                Desc = row._desc,
+                Faction = row._faction,
+                Banned = isBanned and "Yes" or "No",
+                BanningAdminName = info.charBanInfo and info.charBanInfo.name or "",
+                BanningAdminSteamID = info.charBanInfo and info.charBanInfo.steamID or "",
+                BanningAdminRank = info.charBanInfo and info.charBanInfo.rank or "",
+                Money = row._money,
+                LastUsed = lastUsedText,
+                allVars = allVars
+            }
+
+            entry.extraDetails = {}
+            hook.Run("CharListExtraDetails", client, entry, stored)
+            table.insert(sendData, entry)
+        end
+
+        net.Start("DisplayCharList")
+        net.WriteTable(sendData)
+        net.WriteString("all")
+        net.Send(client)
+    end)
+end)
+
 net.Receive("lia_managesitrooms_action", function(_, client)
     if not client:hasPrivilege("Manage SitRooms") then return end
     local action = net.ReadUInt(2)


### PR DESCRIPTION
## Summary
- show character list for admins in tabs per online player plus a database tab
- add network string and handler for listing all characters at once

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688327aa72f08327aa706135d98cefb7