### PR TITLE
Display warnings and tickets in admin sheet

### DIFF
--- a/gamemode/core/netcalls/client.lua
+++ b/gamemode/core/netcalls/client.lua
@@ -948,6 +948,14 @@ local function handleTableData(id)
         return
     end
 
+    if tbl == "lia_warnings" and lia.gui.warnings and IsValid(lia.gui.warnings) then
+        populateTable(lia.gui.warnings, columns, rows)
+        return
+    elseif tbl == "lia_ticketclaims" and lia.gui.tickets and IsValid(lia.gui.tickets) then
+        populateTable(lia.gui.tickets, columns, rows)
+        return
+    end
+
     local _, list = lia.util.CreateTableUI(tbl, columns, rows)
     if IsValid(list) then
         function list:OnRowSelected(_, line)


### PR DESCRIPTION
## Summary
- show DB table results directly inside Admin tabs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68832d8b1428832785c2876f34700858