### PR TITLE
Add right-click decoded table view

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -377,6 +377,11 @@ local DefaultPrivileges = {
         Category = "Administration Utilities"
     },
     {
+        Name = "See Decoded Tables",
+        MinAccess = "superadmin",
+        Category = "Administration Utilities"
+    },
+    {
         Name = "Manage SitRooms",
         MinAccess = "superadmin",
         Category = "Administration Utilities"

--- a/gamemode/core/netcalls/client.lua
+++ b/gamemode/core/netcalls/client.lua
@@ -931,8 +931,10 @@ local function populateTable(panel, columns, rows)
         line.rowData = row
     end
 
-    function list:OnRowSelected(_, line)
-        openRowInfo(line.rowData)
+    function list:OnRowRightClick(_, _, line)
+        if LocalPlayer():hasPrivilege("See Decoded Tables") then
+            openRowInfo(line.rowData)
+        end
     end
 end
 
@@ -963,8 +965,10 @@ local function handleTableData(id)
 
     local _, list = lia.util.CreateTableUI(tbl, columns, rows)
     if IsValid(list) then
-        function list:OnRowSelected(_, line)
-            openRowInfo(line.rowData)
+        function list:OnRowRightClick(_, _, line)
+            if LocalPlayer():hasPrivilege("See Decoded Tables") then
+                openRowInfo(line.rowData)
+            end
         end
     end
 end


### PR DESCRIPTION
## Summary
- register a new admin privilege `See Decoded Tables`
- move DB row details to a privileged right-click action

## Testing
- `lua` not installed; unable to run Lua syntax checks

------
https://chatgpt.com/codex/tasks/task_e_688337b9f02883278437ea91357674b4