### PR TITLE
Fix charlist banned flag

### DIFF
--- a/gamemode/core/netcalls/server.lua
+++ b/gamemode/core/netcalls/server.lua
@@ -205,6 +205,12 @@ net.Receive("liaRequestCharList", function(_, client)
             local stored = lia.char.loaded[row.id]
             local info = stored and stored:getData() or lia.char.getCharData(row.id) or {}
             local isBanned = stored and stored:getBanned() or row.banned
+            if isstring(isBanned) then
+                local lower = isBanned:lower()
+                if lower == "false" or lower == "nil" or isBanned == "NULL" then
+                    isBanned = false
+                end
+            end
             isBanned = tobool(isBanned)
             local allVars = {}
             for varName, varInfo in pairs(lia.char.vars) do
@@ -284,6 +290,12 @@ net.Receive("liaRequestAllCharList", function(_, client)
             local stored = lia.char.loaded[row.id]
             local info = stored and stored:getData() or lia.char.getCharData(row.id) or {}
             local isBanned = stored and stored:getBanned() or row.banned
+            if isstring(isBanned) then
+                local lower = isBanned:lower()
+                if lower == "false" or lower == "nil" or isBanned == "NULL" then
+                    isBanned = false
+                end
+            end
             isBanned = tobool(isBanned)
             local allVars = {}
             for varName, varInfo in pairs(lia.char.vars) do

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -1056,6 +1056,12 @@ lia.command.add("charlist", {
                 local stored = lia.char.loaded[row.id]
                 local info = stored and stored:getData() or lia.char.getCharData(row.id) or {}
                 local isBanned = stored and stored:getBanned() or row.banned
+                if isstring(isBanned) then
+                    local lower = isBanned:lower()
+                    if lower == "false" or lower == "nil" or isBanned == "NULL" then
+                        isBanned = false
+                    end
+                end
                 isBanned = tobool(isBanned)
                 local allVars = {}
                 for varName, varInfo in pairs(lia.char.vars) do


### PR DESCRIPTION
## Summary
- fix banned status detection for characters when string values are used

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883606a59d88327b86b1ece224de686