### PR TITLE
Fix admin tab background

### DIFF
--- a/gamemode/modules/administration/tools/logging/client.lua
+++ b/gamemode/modules/administration/tools/logging/client.lua
@@ -79,7 +79,9 @@ local function OpenLogsUI(panel, categorizedLogs)
     panel:Clear()
     local ps = panel:Add("DPropertySheet")
     ps:Dock(FILL)
-    ps.Paint = function() end
+    ps.Paint = function(p, w, h)
+        derma.SkinHook("Paint", "PropertySheet", p, w, h)
+    end
 
     for category, logs in pairs(categorizedLogs) do
         local page = createLogPage(ps, logs)

--- a/gamemode/modules/administration/tools/utils/client.lua
+++ b/gamemode/modules/administration/tools/utils/client.lua
@@ -413,7 +413,9 @@ local function buildGroupsUI(panel, cami, perms)
     for _, g in ipairs(keys) do
         local pnl = vgui.Create("DPanel", sheet)
         pnl:Dock(FILL)
-        pnl.Paint = function() end
+        pnl.Paint = function(p, w, h)
+            derma.SkinHook("Paint", "Panel", p, w, h)
+        end
         renderGroupInfo(pnl, g, cami, perms)
         local item = sheet:AddSheet(g, pnl)
         if g == LastGroup then firstTab = item.Tab end
@@ -515,7 +517,9 @@ function MODULE:CreateMenuButtons(tabs)
         parent:Clear()
         local sheet = vgui.Create("DPropertySheet", parent)
         sheet:Dock(FILL)
-        sheet.Paint = function() end
+        sheet.Paint = function(p, w, h)
+            derma.SkinHook("Paint", "PropertySheet", p, w, h)
+        end
         local reg = {}
         hook.Run("liaAdminRegisterTab", reg)
         -- Allow other modules to supply admin sheets through the
@@ -533,7 +537,9 @@ function MODULE:CreateMenuButtons(tabs)
                         for _, page in ipairs(pages) do
                             local pnl = adminSheet:Add("DPanel")
                             pnl:Dock(FILL)
-                            pnl.Paint = function() end
+                            pnl.Paint = function(p, w, h)
+                                derma.SkinHook("Paint", "Panel", p, w, h)
+                            end
                             if page.drawFunc then page.drawFunc(pnl) end
                             adminSheet:AddSheet(page.name, pnl)
                         end


### PR DESCRIPTION
## Summary
- style admin tab property sheet to follow the gamemode skin
- ensure admin logging page uses the skin

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_688362651d9883279552fdc535c83e82