### PR TITLE
Enable charlist command for offline steam IDs

### DIFF
--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -1036,15 +1036,21 @@ lia.command.add("charlist", {
     },
     onRun = function(client, arguments)
         local identifier = arguments[1]
-        local target
+        local steam64
         if identifier then
-            target = lia.util.findPlayer(client, identifier)
-            if not IsValid(target) then return end
+            if identifier:match("^%d+$") and #identifier >= 17 then
+                steam64 = identifier
+            elseif identifier:match("^STEAM_%d+:%d+:%d+$") then
+                steam64 = util.SteamIDTo64(identifier)
+            else
+                local target = lia.util.findPlayer(client, identifier)
+                if not IsValid(target) then return end
+                steam64 = target:SteamID64()
+            end
         else
-            target = client
+            steam64 = client:SteamID64()
         end
 
-        local steam64 = target:SteamID64()
         lia.db.query("SELECT * FROM lia_characters WHERE steamID = " .. lia.db.convertDataType(steam64), function(data)
             if not data or #data == 0 then
                 client:notifyLocalized("noCharactersFound")


### PR DESCRIPTION
## Summary
- support using SteamID or SteamID64 for `charlist`

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688363b7edb48327962267dc2686aea0