### PR TITLE
Add row copy options for admin DListViews

### DIFF
--- a/gamemode/core/netcalls/client.lua
+++ b/gamemode/core/netcalls/client.lua
@@ -932,9 +932,21 @@ local function populateTable(panel, columns, rows)
     end
 
     function list:OnRowRightClick(_, _, line)
+        if not IsValid(line) or not line.rowData then return end
+        local rowData = line.rowData
+        local menu = DermaMenu()
+        menu:AddOption(L("copyRow"), function()
+            local rowString = ""
+            for key, value in pairs(rowData) do
+                rowString = rowString .. tostring(key) .. ": " .. tostring(value) .. " | "
+            end
+            rowString = rowString:sub(1, -4)
+            SetClipboardText(rowString)
+        end):SetIcon("icon16/page_copy.png")
         if LocalPlayer():hasPrivilege("See Decoded Tables") then
-            openRowInfo(line.rowData)
+            menu:AddOption(L("open"), function() openRowInfo(rowData) end):SetIcon("icon16/application_view_list.png")
         end
+        menu:Open()
     end
 end
 
@@ -990,9 +1002,21 @@ local function handleTableData(id)
     local _, list = lia.util.CreateTableUI(tbl, columns, rows)
     if IsValid(list) then
         function list:OnRowRightClick(_, _, line)
+            if not IsValid(line) or not line.rowData then return end
+            local rowData = line.rowData
+            local menu = DermaMenu()
+            menu:AddOption(L("copyRow"), function()
+                local rowString = ""
+                for key, value in pairs(rowData) do
+                    rowString = rowString .. tostring(key) .. ": " .. tostring(value) .. " | "
+                end
+                rowString = rowString:sub(1, -4)
+                SetClipboardText(rowString)
+            end):SetIcon("icon16/page_copy.png")
             if LocalPlayer():hasPrivilege("See Decoded Tables") then
-                openRowInfo(line.rowData)
+                menu:AddOption(L("open"), function() openRowInfo(rowData) end):SetIcon("icon16/application_view_list.png")
             end
+            menu:Open()
         end
     end
 end

--- a/gamemode/modules/administration/tools/logging/client.lua
+++ b/gamemode/modules/administration/tools/logging/client.lua
@@ -46,6 +46,16 @@ local function createLogPage(parent, logs)
 
     populate(logs)
 
+    list.OnRowRightClick = function(_, _, line)
+        if not IsValid(line) then return end
+        local text = "[" .. line:GetColumnText(1) .. "] " .. line:GetColumnText(2)
+        local id = line:GetColumnText(3)
+        if id and id ~= "" then
+            text = text .. " [" .. id .. "]"
+        end
+        SetClipboardText(text)
+    end
+
     search.OnChange = function()
         local query = string.lower(search:GetValue())
         local filtered = {}

--- a/gamemode/modules/administration/tools/permissions/client.lua
+++ b/gamemode/modules/administration/tools/permissions/client.lua
@@ -195,20 +195,29 @@ net.Receive("DisplayCharList", function()
             end
 
             listView.OnRowRightClick = function(_, _, ln)
-                if ln and ln.CharID and (LocalPlayer():hasPrivilege("Commands - Unban Offline") or LocalPlayer():hasPrivilege("Commands - Ban Offline")) then
-                    local dMenu = DermaMenu()
+                if not IsValid(ln) then return end
+                local menu = DermaMenu()
+                if ln.rowData then
+                    menu:AddOption(L("copyRow"), function()
+                        local rowString = ""
+                        for key, value in pairs(ln.rowData) do
+                            rowString = rowString .. tostring(key) .. ": " .. tostring(value) .. " | "
+                        end
+                        rowString = rowString:sub(1, -4)
+                        SetClipboardText(rowString)
+                    end):SetIcon("icon16/page_copy.png")
+                end
+                if ln.CharID and (LocalPlayer():hasPrivilege("Commands - Unban Offline") or LocalPlayer():hasPrivilege("Commands - Ban Offline")) then
                     if LocalPlayer():hasPrivilege("Commands - Unban Offline") then
-                        local opt1 = dMenu:AddOption(L("banCharacter"), function() LocalPlayer():ConCommand([[say "/charbanoffline ]] .. ln.CharID .. [["]]) end)
+                        local opt1 = menu:AddOption(L("banCharacter"), function() LocalPlayer():ConCommand([[say "/charbanoffline ]] .. ln.CharID .. [["]]) end)
                         opt1:SetIcon("icon16/cancel.png")
                     end
-
                     if LocalPlayer():hasPrivilege("Commands - Ban Offline") then
-                        local opt2 = dMenu:AddOption(L("unbanCharacter"), function() LocalPlayer():ConCommand([[say "/charunbanoffline ]] .. ln.CharID .. [["]]) end)
+                        local opt2 = menu:AddOption(L("unbanCharacter"), function() LocalPlayer():ConCommand([[say "/charunbanoffline ]] .. ln.CharID .. [["]]) end)
                         opt2:SetIcon("icon16/accept.png")
                     end
-
-                    dMenu:Open()
                 end
+                menu:Open()
             end
         end
     else
@@ -237,20 +246,29 @@ net.Receive("DisplayCharList", function()
             end
 
             listView.OnRowRightClick = function(_, _, ln)
-                if ln and ln.CharID and (LocalPlayer():hasPrivilege("Commands - Unban Offline") or LocalPlayer():hasPrivilege("Commands - Ban Offline")) then
-                    local dMenu = DermaMenu()
+                if not IsValid(ln) then return end
+                local menu = DermaMenu()
+                if ln.rowData then
+                    menu:AddOption(L("copyRow"), function()
+                        local rowString = ""
+                        for key, value in pairs(ln.rowData) do
+                            rowString = rowString .. tostring(key) .. ": " .. tostring(value) .. " | "
+                        end
+                        rowString = rowString:sub(1, -4)
+                        SetClipboardText(rowString)
+                    end):SetIcon("icon16/page_copy.png")
+                end
+                if ln.CharID and (LocalPlayer():hasPrivilege("Commands - Unban Offline") or LocalPlayer():hasPrivilege("Commands - Ban Offline")) then
                     if LocalPlayer():hasPrivilege("Commands - Unban Offline") then
-                        local opt1 = dMenu:AddOption(L("banCharacter"), function() LocalPlayer():ConCommand([[say "/charbanoffline ]] .. ln.CharID .. [["]]) end)
+                        local opt1 = menu:AddOption(L("banCharacter"), function() LocalPlayer():ConCommand([[say "/charbanoffline ]] .. ln.CharID .. [["]]) end)
                         opt1:SetIcon("icon16/cancel.png")
                     end
-
                     if LocalPlayer():hasPrivilege("Commands - Ban Offline") then
-                        local opt2 = dMenu:AddOption(L("unbanCharacter"), function() LocalPlayer():ConCommand([[say "/charunbanoffline ]] .. ln.CharID .. [["]]) end)
+                        local opt2 = menu:AddOption(L("unbanCharacter"), function() LocalPlayer():ConCommand([[say "/charunbanoffline ]] .. ln.CharID .. [["]]) end)
                         opt2:SetIcon("icon16/accept.png")
                     end
-
-                    dMenu:Open()
                 end
+                menu:Open()
             end
         end
     end


### PR DESCRIPTION
## Summary
- enable copying table rows in admin DB browser
- allow row copying in character list
- add row copy via right click for log viewer

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688363befce08327b199c49a08cef729