### PR TITLE
Sort admin tabs alphabetically

### DIFF
--- a/gamemode/modules/administration/tools/staff/client.lua
+++ b/gamemode/modules/administration/tools/staff/client.lua
@@ -526,7 +526,7 @@ function MODULE:CreateMenuButtons(tabs)
             end
         end
 
-        for name, data in pairs(reg) do
+        for name, data in SortedPairs(reg) do
             local should = true
             if isfunction(data.onShouldShow) then should = data.onShouldShow() ~= false end
             if should then


### PR DESCRIPTION
## Summary
- sort admin tab registration by name so the UI is alphabetical

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68836845df78832792a5ac2e32976eed