### PR TITLE
Refactor warnings table

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -414,10 +414,12 @@ function lia.db.loadTables()
             CREATE TABLE IF NOT EXISTS lia_warnings (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 charID INTEGER,
-                steamID TEXT,
                 timestamp DATETIME,
+                playerName TEXT,
+                playerSteam TEXT,
                 reason TEXT,
-                admin TEXT
+                adminName TEXT,
+                adminSteam TEXT
             );
 
             CREATE TABLE IF NOT EXISTS lia_doors (
@@ -594,10 +596,12 @@ function lia.db.loadTables()
             CREATE TABLE IF NOT EXISTS `lia_warnings` (
                 `id` INT(12) NOT NULL AUTO_INCREMENT,
                 `charID` INT(12) NULL DEFAULT NULL,
-                `steamID` VARCHAR(64) NULL DEFAULT NULL COLLATE 'utf8mb4_general_ci',
                 `timestamp` DATETIME NOT NULL,
+                `playerName` TEXT NULL COLLATE 'utf8mb4_general_ci',
+                `playerSteam` VARCHAR(64) NULL DEFAULT NULL COLLATE 'utf8mb4_general_ci',
                 `reason` TEXT NULL COLLATE 'utf8mb4_general_ci',
-                `admin` TEXT NULL COLLATE 'utf8mb4_general_ci',
+                `adminName` TEXT NULL COLLATE 'utf8mb4_general_ci',
+                `adminSteam` VARCHAR(64) NULL DEFAULT NULL COLLATE 'utf8mb4_general_ci',
                 PRIMARY KEY (`id`)
             );
 

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -870,7 +870,15 @@ lia.command.add("warn", {
 
         local timestamp = os.date("%Y-%m-%d %H:%M:%S")
         local adminStr = client:Nick() .. " (" .. client:SteamID() .. ")"
-        MODULE:AddWarning(target:getChar():getID(), target:SteamID64(), timestamp, reason, adminStr)
+        MODULE:AddWarning(
+            target:getChar():getID(),
+            timestamp,
+            target:Nick(),
+            target:SteamID64(),
+            reason,
+            client:Nick(),
+            client:SteamID()
+        )
         lia.db.count("warnings", "charID = " .. lia.db.convertDataType(target:getChar():getID())):next(function(count)
             target:notifyLocalized("playerWarned", adminStr, reason)
             client:notifyLocalized("warningIssued", target:Nick())
@@ -909,8 +917,11 @@ lia.command.add("viewwarns", {
                 table.insert(warningList, {
                     index = index,
                     timestamp = warn.timestamp or L("na"),
+                    playerName = warn.playerName or target:Nick(),
+                    playerSteam = warn.playerSteam or target:SteamID64(),
                     reason = warn.reason or L("na"),
-                    admin = warn.admin or L("na")
+                    adminName = warn.adminName or L("na"),
+                    adminSteam = warn.adminSteam or L("na")
                 })
             end
 
@@ -924,12 +935,24 @@ lia.command.add("viewwarns", {
                     field = "timestamp"
                 },
                 {
+                    name = L("name"),
+                    field = "playerName"
+                },
+                {
+                    name = L("steamID"),
+                    field = "playerSteam"
+                },
+                {
                     name = L("reason"),
                     field = "reason"
                 },
                 {
-                    name = L("admin"),
-                    field = "admin"
+                    name = L("administrator"),
+                    field = "adminName"
+                },
+                {
+                    name = L("steamID"),
+                    field = "adminSteam"
                 }
             }, warningList, {
                 {

--- a/gamemode/modules/administration/tools/staff/server.lua
+++ b/gamemode/modules/administration/tools/staff/server.lua
@@ -166,7 +166,7 @@ local function payloadStaff()
             local d = deferred.new()
             table.insert(promises, d)
             lia.db.count("ticketclaims", "admin LIKE '%" .. ply:SteamID64() .. "%'"):next(function(tickets)
-                return lia.db.count("warnings", "admin LIKE '%" .. ply:SteamID() .. "%'"):next(function(warns)
+                return lia.db.count("warnings", "adminSteam = " .. lia.db.convertDataType(ply:SteamID())):next(function(warns)
                     staff[#staff + 1] = {
                         name = ply:Nick(),
                         id = ply:SteamID(),

--- a/gamemode/modules/administration/tools/warns/server.lua
+++ b/gamemode/modules/administration/tools/warns/server.lua
@@ -1,16 +1,26 @@
 ﻿local MODULE = MODULE
 function MODULE:GetWarnings(charID)
     local condition = "charID = " .. lia.db.convertDataType(charID)
-    return lia.db.select({"id", "timestamp", "reason", "admin"}, "warnings", condition):next(function(res) return res.results or {} end)
+    return lia.db.select({
+        "id",
+        "timestamp",
+        "playerName",
+        "playerSteam",
+        "reason",
+        "adminName",
+        "adminSteam"
+    }, "warnings", condition):next(function(res) return res.results or {} end)
 end
 
-function MODULE:AddWarning(charID, steamID, timestamp, reason, admin)
+function MODULE:AddWarning(charID, timestamp, playerName, playerSteam, reason, adminName, adminSteam)
     lia.db.insertTable({
         charID = charID,
-        steamID = steamID,
         timestamp = timestamp,
+        playerName = playerName,
+        playerSteam = playerSteam,
         reason = reason,
-        admin = admin
+        adminName = adminName,
+        adminSteam = adminSteam
     }, nil, "warnings")
 end
 

--- a/gamemode/modules/protection/commands.lua
+++ b/gamemode/modules/protection/commands.lua
@@ -20,11 +20,19 @@
             client:notifyLocalized("cheaterMarked", target:Name())
             target:notifyLocalized("cheaterMarkedByAdmin")
             local timestamp = os.date("%Y-%m-%d %H:%M:%S")
-            local adminStr = client:Nick() .. " (" .. client:SteamID() .. ")"
             local warnsModule = lia.module.list["warns"]
             if warnsModule and warnsModule.AddWarning then
-                warnsModule:AddWarning(target:getChar():getID(), target:SteamID64(), timestamp, L("cheaterWarningReason"), adminStr)
+                warnsModule:AddWarning(
+                    target:getChar():getID(),
+                    timestamp,
+                    target:Nick(),
+                    target:SteamID64(),
+                    L("cheaterWarningReason"),
+                    client:Nick(),
+                    client:SteamID()
+                )
                 lia.db.count("warnings", "charID = " .. lia.db.convertDataType(target:getChar():getID())):next(function(count)
+                    local adminStr = client:Nick() .. " (" .. client:SteamID() .. ")"
                     target:notifyLocalized("playerWarned", adminStr, L("cheaterWarningReason"))
                     client:notifyLocalized("warningIssued", target:Nick())
                     hook.Run("WarningIssued", client, target, L("cheaterWarningReason"), count)


### PR DESCRIPTION
## Summary
- expand warnings database schema to store player/admin names and SteamIDs alongside timestamps
- adjust warning creation and retrieval to handle new fields
- update admin commands and protection module to use the updated schema
- show extended warning details in the view warnings table
- count warnings per staff member using the new adminSteam column

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68838af350b88327b7014a08f8d31f75