### PR TITLE
Fix usergroup tab refresh

### DIFF
--- a/gamemode/modules/administration/tools/staff/client.lua
+++ b/gamemode/modules/administration/tools/staff/client.lua
@@ -494,6 +494,10 @@ end)
 net.Receive("liaGroupsNotice", function()
     local msg = net.ReadString()
     if IsValid(LocalPlayer()) and LocalPlayer().notify then LocalPlayer():notify(msg) end
+    if IsValid(lia.gui.usergroups) then
+        net.Start("liaGroupsRequest")
+        net.SendToServer()
+    end
 end)
 
 hook.Add("liaAdminRegisterTab", "AdminTabUsergroups", function(tabs)


### PR DESCRIPTION
## Summary
- refresh usergroup tab when groups are changed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688391f20b208327aebc0f15cd715592