### PR TITLE
Add setKeysNonOwnable helper

### DIFF
--- a/documentation/docs/meta/entity.md
+++ b/documentation/docs/meta/entity.md
@@ -276,11 +276,13 @@ car:keysUnLock()
 
 **Purpose**
 
-Marks a door as non-ownable so players cannot purchase it.
+Marks a door as non-ownable and prevents players from using keys on it.
 
 **Parameters**
 
 * `state` (`boolean`): Whether the door should be unownable.
+
+When enabled this sets the `noSell` and `noKeying` network variables on the door.
 
 **Realm**
 

--- a/documentation/docs/meta/entity.md
+++ b/documentation/docs/meta/entity.md
@@ -272,6 +272,33 @@ car:keysUnLock()
 
 ---
 
+### setKeysNonOwnable
+
+**Purpose**
+
+Marks a door as non-ownable so players cannot purchase it.
+
+**Parameters**
+
+* `state` (`boolean`): Whether the door should be unownable.
+
+**Realm**
+
+`Server`
+
+**Returns**
+
+* `nil`: This function does not return a value.
+
+**Example Usage**
+
+```lua
+-- Prevent players from buying this door permanently
+door:setKeysNonOwnable(true)
+```
+
+---
+
 ### getDoorOwner
 
 **Purpose**

--- a/gamemode/core/meta/entity.lua
+++ b/gamemode/core/meta/entity.lua
@@ -135,7 +135,9 @@ if SERVER then
     end
 
     function entityMeta:setKeysNonOwnable(state)
-        self:setNetVar("noSell", state and true or nil)
+        local flag = state and true or nil
+        self:setNetVar("noSell", flag)
+        self:setNetVar("noKeying", flag)
     end
 
     function entityMeta:isDoor()

--- a/gamemode/core/meta/entity.lua
+++ b/gamemode/core/meta/entity.lua
@@ -134,6 +134,10 @@ if SERVER then
         self:setNetVar("locked", state)
     end
 
+    function entityMeta:setKeysNonOwnable(state)
+        self:setNetVar("noSell", state and true or nil)
+    end
+
     function entityMeta:isDoor()
         if not IsValid(self) then return end
         local class = self:GetClass():lower()

--- a/gamemode/modules/doors/libraries/server.lua
+++ b/gamemode/modules/doors/libraries/server.lua
@@ -196,7 +196,7 @@ function MODULE:KeyLock(client, door, time)
     if hook.Run("CanPlayerLock", client, door) == false then return end
     local distance = client:GetPos():Distance(door:GetPos())
     local isProperEntity = door:isDoor() or door:IsVehicle() or door:isSimfphysCar()
-    if isProperEntity and not door:isLocked() and distance <= 256 and (door:checkDoorAccess(client) or door:GetCreator() == client or client:isStaffOnDuty()) then
+    if isProperEntity and not door:isLocked() and distance <= 256 and (door:checkDoorAccess(client) or door:GetCreator() == client or client:isStaffOnDuty()) and not door:getNetVar("noKeying") then
         client:setAction(L("locking"), time, function() end)
         client:doStaredAction(door, function() self:ToggleLock(client, door, true) end, time, function() client:stopAction() end)
         lia.log.add(client, "lockDoor", door)
@@ -208,7 +208,7 @@ function MODULE:KeyUnlock(client, door, time)
     if hook.Run("CanPlayerUnlock", client, door) == false then return end
     local distance = client:GetPos():Distance(door:GetPos())
     local isProperEntity = door:isDoor() or door:IsVehicle() or door:isSimfphysCar()
-    if isProperEntity and door:isLocked() and distance <= 256 and (door:checkDoorAccess(client) or door:GetCreator() == client or client:isStaffOnDuty()) then
+    if isProperEntity and door:isLocked() and distance <= 256 and (door:checkDoorAccess(client) or door:GetCreator() == client or client:isStaffOnDuty()) and not door:getNetVar("noKeying") then
         client:setAction(L("unlocking"), time, function() end)
         client:doStaredAction(door, function() self:ToggleLock(client, door, false) end, time, function() client:stopAction() end)
         lia.log.add(client, "unlockDoor", door)


### PR DESCRIPTION
## Summary
- add `setKeysNonOwnable` helper to door entity meta
- document new helper in entity API docs

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68846c03259c832784932845693de96f