### PR TITLE
Hide default groups from player group picker

### DIFF
--- a/gamemode/modules/administration/tools/staff/client.lua
+++ b/gamemode/modules/administration/tools/staff/client.lua
@@ -118,7 +118,7 @@
             }
         }
 
-        if client:IsSuperAdmin() or client:hasPrivilege("Manage UserGroups") then
+        if (client:IsSuperAdmin() or client:hasPrivilege("Manage UserGroups")) and hasCustomGroups() then
             table.insert(orderedOptions, {
                 name = L("setUsergroup"),
                 image = "icon16/group_edit.png",
@@ -142,6 +142,13 @@ local DefaultGroups = {
     superadmin = true,
     developer = true
 }
+
+local function hasCustomGroups()
+    for name in pairs(lia.admin.groups or {}) do
+        if not DefaultGroups[name] then return true end
+    end
+    return false
+end
 
 local groupChunks, playerChunks, staffChunks = {}, {}, {}
 local PrivilegeCategories, PlayerList, StaffList, LastGroup = {}, {}, {}, nil
@@ -189,7 +196,7 @@ local function buildPlayersUI(parent)
         local opt = m:AddOption(L("viewCharacterList"), function() LocalPlayer():ConCommand("say /charlist " .. line.steamID) end)
         opt:SetIcon("icon16/user.png")
         local ply = player.GetBySteamID(line.steamID) or player.GetBySteamID64(line.steamID64)
-        if IsValid(ply) and (LocalPlayer():IsSuperAdmin() or LocalPlayer():hasPrivilege("Manage UserGroups")) then
+        if IsValid(ply) and (LocalPlayer():IsSuperAdmin() or LocalPlayer():hasPrivilege("Manage UserGroups")) and hasCustomGroups() then
             local grp = m:AddOption(L("setUsergroup"), function()
                 net.Start("liaRequestPlayerGroup")
                 net.WriteEntity(ply)

--- a/gamemode/modules/administration/tools/staff/server.lua
+++ b/gamemode/modules/administration/tools/staff/server.lua
@@ -242,8 +242,12 @@ net.Receive("liaRequestPlayerGroup", function(_, p)
     if not IsValid(target) or not target:IsPlayer() then return end
     local groups = {}
     for name in pairs(lia.admin.groups or {}) do
-        groups[#groups + 1] = name
+        if not DefaultGroups[name] then
+            groups[#groups + 1] = name
+        end
     end
+
+    if #groups == 0 then return end
 
     table.sort(groups)
     p:requestDropdown(L("setUsergroup"), L("chooseGroup"), groups, function(sel)


### PR DESCRIPTION
## Summary
- add `hasCustomGroups` helper
- only show **Set Usergroup** menu when non-default groups exist
- filter default groups from server dropdown

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688470e4b8588327a5c9e35023a3a0b9