### PR TITLE
Integrate vendors with persistence

### DIFF
--- a/gamemode/core/libraries/data.lua
+++ b/gamemode/core/libraries/data.lua
@@ -247,15 +247,7 @@ function lia.data.savePersistence(entities)
     local condition = buildCondition(folder, map)
     local dynamic = {}
     local dynamicList = {}
-    local vendors = {}
-    local others = {}
     for _, ent in ipairs(entities) do
-        if ent.class == "lia_vendor" then
-            vendors[#vendors + 1] = ent
-        else
-            others[#others + 1] = ent
-        end
-
         for k in pairs(ent) do
             if not defaultCols[k] and not dynamic[k] then
                 dynamic[k] = true
@@ -273,25 +265,14 @@ function lia.data.savePersistence(entities)
         cols[#cols + 1] = c
     end
 
-    ensurePersistenceColumns(cols):next(function() return lia.db.delete("vendors", condition) end):next(function()
-        if #vendors > 0 then
-            local vrows = {}
-            for _, ent in ipairs(vendors) do
-                vrows[#vrows + 1] = {
-                    gamemode = folder,
-                    map = map,
-                    class = ent.class,
-                    pos = lia.data.serialize(ent.pos),
-                    angles = lia.data.serialize(ent.angles),
-                    model = ent.model,
-                    data = lia.data.serialize(ent.data)
-                }
-            end
-            return lia.db.bulkInsert("vendors", vrows)
-        end
-    end):next(function() return lia.db.delete("persistence", condition) end):next(function()
+    ensurePersistenceColumns(cols):next(function()
+        -- Clean up legacy vendor table if present
+        return lia.db.delete("vendors", condition)
+    end):next(function()
+        return lia.db.delete("persistence", condition)
+    end):next(function()
         local rows = {}
-        for _, ent in ipairs(others) do
+        for _, ent in ipairs(entities) do
             local row = {
                 gamemode = folder,
                 map = map,
@@ -316,36 +297,26 @@ function lia.data.loadPersistenceData(callback)
     local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
     local map = game.GetMap()
     local condition = buildCondition(folder, map)
-    ensurePersistenceColumns(baseCols):next(function() return lia.db.select("*", "vendors", condition) end):next(function(vres)
-        local vendors = vres.results or {}
-        return lia.db.select("*", "persistence", condition):next(function(res)
-            local rows = res.results or {}
-            local entities = {}
-            for _, row in ipairs(vendors) do
-                local ent = lia.data.deserialize(row.data) or {}
-                ent.class = row.class or "lia_vendor"
-                ent.pos = lia.data.decodeVector(row.pos)
-                ent.angles = lia.data.decodeAngle(row.angles)
-                ent.model = row.model
-                entities[#entities + 1] = ent
+    ensurePersistenceColumns(baseCols):next(function()
+        return lia.db.select("*", "persistence", condition)
+    end):next(function(res)
+        local rows = res.results or {}
+        local entities = {}
+        for _, row in ipairs(rows) do
+            local ent = {}
+            for k, v in pairs(row) do
+                if not defaultCols[k] and k ~= "id" and k ~= "gamemode" and k ~= "map" then ent[k] = lia.data.deserialize(v) end
             end
 
-            for _, row in ipairs(rows) do
-                local ent = {}
-                for k, v in pairs(row) do
-                    if not defaultCols[k] and k ~= "id" and k ~= "gamemode" and k ~= "map" then ent[k] = lia.data.deserialize(v) end
-                end
+            ent.class = row.class
+            ent.pos = lia.data.decodeVector(row.pos)
+            ent.angles = lia.data.decodeAngle(row.angles)
+            ent.model = row.model
+            entities[#entities + 1] = ent
+        end
 
-                ent.class = row.class
-                ent.pos = lia.data.decodeVector(row.pos)
-                ent.angles = lia.data.decodeAngle(row.angles)
-                ent.model = row.model
-                entities[#entities + 1] = ent
-            end
-
-            lia.data.persistCache = entities
-            if callback then callback(entities) end
-        end)
+        lia.data.persistCache = entities
+        if callback then callback(entities) end
     end)
 end
 

--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -270,7 +270,6 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS `lia_sitrooms`;
     DROP TABLE IF EXISTS `lia_saveditems`;
     DROP TABLE IF EXISTS `lia_persistence`;
-    DROP TABLE IF EXISTS `lia_vendors`;
     DROP TABLE IF EXISTS `lia_warnings`;
 ]])
             local done = 0
@@ -305,7 +304,6 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS lia_sitrooms;
     DROP TABLE IF EXISTS lia_saveditems;
     DROP TABLE IF EXISTS lia_persistence;
-    DROP TABLE IF EXISTS lia_vendors;
     DROP TABLE IF EXISTS lia_warnings;
     DROP TABLE IF EXISTS lia_chardata;
 ]], realCallback)
@@ -480,16 +478,6 @@ function lia.db.loadTables()
                 model TEXT
             );
 
-            CREATE TABLE IF NOT EXISTS lia_vendors (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                gamemode TEXT,
-                map TEXT,
-                class TEXT,
-                pos TEXT,
-                angles TEXT,
-                model TEXT,
-                data TEXT
-            );
 
             CREATE TABLE IF NOT EXISTS lia_saveditems (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -675,17 +663,6 @@ function lia.db.loadTables()
                 PRIMARY KEY (`id`)
             );
 
-            CREATE TABLE IF NOT EXISTS `lia_vendors` (
-                `id` INT(12) NOT NULL AUTO_INCREMENT,
-                `gamemode` TEXT NULL,
-                `map` TEXT NULL,
-                `class` TEXT NULL,
-                `pos` TEXT NULL,
-                `angles` TEXT NULL,
-                `model` TEXT NULL,
-                `data` TEXT NULL,
-                PRIMARY KEY (`id`)
-            );
 
             CREATE TABLE IF NOT EXISTS `lia_saveditems` (
                 `id` INT(12) NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
## Summary
- store vendor data in `lia_persistence` instead of a separate table
- drop the unused `lia_vendors` table

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68847522e07c83278d5fb4f80960b35d