### PR TITLE
Fix sitroom commands

### DIFF
--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -50,7 +50,7 @@ lia.command.add("managesitrooms", {
             net.Start("managesitrooms")
             net.WriteTable(rooms)
             net.Send(client)
-        end)
+        end
     end
 })
 
@@ -119,7 +119,7 @@ lia.command.add("sendtositroom", {
                 target:notifyLocalized("sitroomArrive")
                 lia.log.add(client, "sendToSitRoom", target:Nick(), selection)
             end)
-        end)
+        end
     end
 })
 
@@ -141,7 +141,7 @@ lia.command.add("returnsitroom", {
             return
         end
 
-        local prev = target:GetNWVector("previousSitroomPos")
+        local prev = target:GetNW2Vector("previousSitroomPos")
         if not prev then
             client:notifyLocalized("noPreviousSitroomPos")
             return


### PR DESCRIPTION
## Summary
- fix syntax in `managesitrooms` and `sendtositroom` commands
- use `GetNW2Vector` for sitroom return

## Testing
- `luac -p gamemode/modules/administration/commands.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688484387d70832784109214f0de46ba