### PR TITLE
Add staff actions admin tab

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -417,6 +417,11 @@ local DefaultPrivileges = {
         Category = "Administration Utilities"
     },
     {
+        Name = "Access Staff Actions Tab",
+        MinAccess = "superadmin",
+        Category = "Administration Utilities"
+    },
+    {
         Name = "See Decoded Tables",
         MinAccess = "superadmin",
         Category = "Administration Utilities"

--- a/gamemode/core/netcalls/client.lua
+++ b/gamemode/core/netcalls/client.lua
@@ -975,9 +975,15 @@ local function handleTableData(id)
     local rows = payload.data or {}
     if not tbl then return end
     if #rows == 0 then
-        if tbl == "lia_staffactions" and lia.gui.warnings and IsValid(lia.gui.warnings) then
-            displayNoData(lia.gui.warnings, L("noWarningsFound") or "No warnings to display.")
-            return
+        if tbl == "lia_staffactions" then
+            if lia.gui.warnings and IsValid(lia.gui.warnings) then
+                displayNoData(lia.gui.warnings, L("noWarningsFound") or "No warnings to display.")
+                return
+            end
+            if lia.gui.staffActions and lia.gui.staffActions.sheet and IsValid(lia.gui.staffActions.sheet) then
+                displayNoData(lia.gui.staffActions.sheet, L("noStaffActionsFound") or "No staff actions to display.")
+                return
+            end
         end
         return
     end
@@ -1002,6 +1008,29 @@ local function handleTableData(id)
         end
 
         populateTable(lia.gui.warnings, columns, warns)
+        return
+    end
+
+    if tbl == "lia_staffactions" and lia.gui.staffActions and lia.gui.staffActions.sheet and IsValid(lia.gui.staffActions.sheet) then
+        local grouped = {}
+        for _, row in ipairs(rows) do
+            grouped[row.action] = grouped[row.action] or {}
+            table.insert(grouped[row.action], row)
+        end
+
+        for action, data in pairs(grouped) do
+            local panel = lia.gui.staffActions.panels[action]
+            if not IsValid(panel) then
+                panel = vgui.Create("DPanel", lia.gui.staffActions.sheet)
+                panel:Dock(FILL)
+                panel.Paint = function() end
+                lia.gui.staffActions.sheet:AddSheet(action, panel)
+                lia.gui.staffActions.panels[action] = panel
+            end
+
+            populateTable(panel, columns, data)
+        end
+
         return
     end
 end

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -1009,6 +1009,7 @@ LANGUAGE = {
     noEntitiesFound = "No entities to display.",
     noWarningsFound = "No warnings to display.",
     noTicketsFound = "No tickets to display.",
+    noStaffActionsFound = "No staff actions to display.",
     modulesCount = "Modules Count: %s",
     ["Bring"] = "Bring",
     ["Goto"] = "Goto",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -1007,6 +1007,7 @@ LANGUAGE = {
     noEntitiesFound = "Aucune entité à afficher.",
     noWarningsFound = "Aucun avertissement à afficher.",
     noTicketsFound = "Aucun ticket à afficher.",
+    noStaffActionsFound = "Aucune action du staff à afficher.",
     modulesCount = "Modules : %s",
     ["Bring"] = "Bring",
     ["Goto"] = "Goto",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -1007,6 +1007,7 @@ LANGUAGE = {
     noEntitiesFound = "Nessuna entità da mostrare.",
     noWarningsFound = "Nessun warning da mostrare.",
     noTicketsFound = "Nessun ticket da mostrare.",
+    noStaffActionsFound = "Nessuna azione staff da mostrare.",
     modulesCount = "Conteggio Moduli: %s",
     ["Bring"] = "Bring",
     ["Goto"] = "Goto",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -1007,6 +1007,7 @@ LANGUAGE = {
     noEntitiesFound = "Sem entidades para mostrar.",
     noWarningsFound = "Sem advertências para mostrar.",
     noTicketsFound = "Sem tickets para mostrar.",
+    noStaffActionsFound = "Sem ações de staff para mostrar.",
     modulesCount = "Total de Módulos: %s",
     ["Bring"] = "Trazer",
     ["Goto"] = "Ir",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -1007,6 +1007,7 @@ LANGUAGE = {
     noEntitiesFound = "Нет сущностей для отображения.",
     noWarningsFound = "Нет предупреждений для отображения.",
     noTicketsFound = "Нет тикетов для отображения.",
+    noStaffActionsFound = "Нет действий персонала для отображения.",
     modulesCount = "Модулей: %s",
     ["Bring"] = "Притянуть",
     ["Goto"] = "Перейти",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -1007,6 +1007,7 @@ LANGUAGE = {
     noEntitiesFound = "No hay entidades para mostrar.",
     noWarningsFound = "No hay advertencias para mostrar.",
     noTicketsFound = "No hay tickets para mostrar.",
+    noStaffActionsFound = "No hay acciones de staff para mostrar.",
     modulesCount = "Módulos: %s",
     ["Bring"] = "Traer",
     ["Goto"] = "Ir a",

--- a/gamemode/modules/administration/tools/staffactions/client.lua
+++ b/gamemode/modules/administration/tools/staffactions/client.lua
@@ -1,0 +1,29 @@
+hook.Add("liaAdminRegisterTab", "AdminTabStaffActions", function(tabs)
+    local function canView()
+        local ply = LocalPlayer()
+        return IsValid(ply) and ply:hasPrivilege("Access Staff Actions Tab") and ply:hasPrivilege("View DB Tables")
+    end
+
+    tabs["Staff Actions"] = {
+        icon = "icon16/book_open.png",
+        onShouldShow = canView,
+        build = function(sheet)
+            local pnl = vgui.Create("DPanel", sheet)
+            pnl:DockPadding(10, 10, 10, 10)
+
+            local ps = vgui.Create("DPropertySheet", pnl)
+            ps:Dock(FILL)
+
+            lia.gui.staffActions = {
+                sheet = ps,
+                panels = {}
+            }
+
+            net.Start("liaRequestTableData")
+            net.WriteString("lia_staffactions")
+            net.SendToServer()
+
+            return pnl
+        end
+    }
+end)


### PR DESCRIPTION
## Summary
- add new admin tab **Staff Actions** and request lia_staffactions
- display staff action logs by action in sub-tabs
- support 'Access Staff Actions Tab' privilege
- add translations for `noStaffActionsFound`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68848d290ea48327bbf807653776b6b7