### PR TITLE
Notify staff about IP chat attempts

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -346,7 +346,12 @@ function GM:PlayerSay(client, message)
     local hasIPAddress = string.match(message, "%d+%.%d+%.%d+%.%d+(:%d*)?")
     message = parsedMessage
     if hasIPAddress then
-        lia.applyPunishment(client, L("ipInChat"), true, false)
+        for _, ply in player.Iterator() do
+            if ply:isStaffOnDuty() or ply:hasPrivilege("View IP Chat Attempts") then
+                ply:ChatPrint(L("ipAttemptStaff", client:Name(), hasIPAddress))
+            end
+        end
+        lia.log.add(client, "ipAttempt", hasIPAddress)
         return ""
     end
 

--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -672,6 +672,11 @@ local DefaultPrivileges = {
         Category = "Chatbox"
     },
     {
+        Name = "View IP Chat Attempts",
+        MinAccess = "admin",
+        Category = "Chatbox"
+    },
+    {
         Name = "Can Edit Vendors",
         MinAccess = "admin",
         Category = "Vendors"

--- a/gamemode/core/libraries/logger.lua
+++ b/gamemode/core/libraries/logger.lua
@@ -95,6 +95,10 @@ lia.log.types = {
         func = function(client, text) return string.format("Player '%s' ran command: %s.", client:Name(), text) end,
         category = "Chat"
     },
+    ["ipAttempt"] = {
+        func = function(client, ip) return string.format("Player '%s' attempted to say IP '%s' in chat.", client:Name(), ip) end,
+        category = "Chat"
+    },
     ["money"] = {
         func = function(client, amount) return string.format("Player '%s' changed money by: %s.", client:Name(), amount) end,
         category = "Money"

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -894,6 +894,7 @@ LANGUAGE = {
     caughtCheating = "Cheating detected. Staff have been notified.",
     cheaterWarningReason = "Cheating or exploiting",
     cheaterDetectedStaff = "%s (%s) was flagged for cheating.",
+    ipAttemptStaff = "%s attempted to post the IP %s in chat.",
     spawnDeletedByName = "Deleted %s spawn point(s) for faction: %s.",
     noSpawnsForFaction = "No spawn points exist for this faction.",
     spawner = "Spawner",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -892,6 +892,7 @@ LANGUAGE = {
     caughtCheating = "Triche détectée. Staff alerté.",
     cheaterWarningReason = "Triche ou exploit",
     cheaterDetectedStaff = "%s (%s) flag triche.",
+    ipAttemptStaff = "%s a tenté d'envoyer l'IP %s dans le chat.",
     spawnDeletedByName = "Spawns %s supprimés pour faction : %s.",
     noSpawnsForFaction = "Aucun spawn pour cette faction.",
     spawner = "Spawner",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -892,6 +892,7 @@ LANGUAGE = {
     caughtCheating = "Cheating rilevato. Lo staff è stato avvisato.",
     cheaterWarningReason = "Cheating o exploit",
     cheaterDetectedStaff = "%s (%s) è stato flaggato per cheating.",
+    ipAttemptStaff = "%s ha tentato di scrivere l'IP %s in chat.",
     spawnDeletedByName = "Eliminati %s punti spawn per la fazione: %s.",
     noSpawnsForFaction = "Non esistono punti spawn per questa fazione.",
     spawner = "Spawner",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -892,6 +892,7 @@ LANGUAGE = {
     caughtCheating = "Cheating detectado. Staff notificado.",
     cheaterWarningReason = "Cheating ou exploit",
     cheaterDetectedStaff = "%s (%s) sinalizado por cheating.",
+    ipAttemptStaff = "%s tentou postar o IP %s no chat.",
     spawnDeletedByName = "Pontos de spawn removidos: %s para facção %s.",
     noSpawnsForFaction = "Sem spawns para esta facção.",
     spawner = "Spawner",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -892,6 +892,7 @@ LANGUAGE = {
     caughtCheating = "Обнаружен чит. Админы уведомлены.",
     cheaterWarningReason = "Читерство/эксплойт",
     cheaterDetectedStaff = "%s (%s) отмечен как читер.",
+    ipAttemptStaff = "%s попытался отправить IP %s в чат.",
     spawnDeletedByName = "Удалено точек спавна: %s для %s.",
     noSpawnsForFaction = "Нет точек спавна для фракции.",
     spawner = "Спавнер",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -892,6 +892,7 @@ LANGUAGE = {
     caughtCheating = "Trampas detectadas. Staff notificado.",
     cheaterWarningReason = "Trampas o exploits",
     cheaterDetectedStaff = "%s (%s) marcado por trampas.",
+    ipAttemptStaff = "%s intentó publicar la IP %s en el chat.",
     spawnDeletedByName = "Puntos de spawn eliminados: %s para facción: %s.",
     noSpawnsForFaction = "Sin spawns para esa facción.",
     spawner = "Generador",


### PR DESCRIPTION
## Summary
- detect IP addresses in chat without punishing
- notify on-duty staff or privileged players via ChatPrint
- log IP attempts
- add privilege to view these notifications
- provide translations for new notification

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68849014a2808327a2567c9cdf2493f5