### PR TITLE
Replace inventory slot material with derma painting

### DIFF
--- a/gamemode/modules/inventory/derma/cl_grid_inventory_panel.lua
+++ b/gamemode/modules/inventory/derma/cl_grid_inventory_panel.lua
@@ -1,5 +1,18 @@
-﻿local InvSlotMat = Material("invslotfree.png", "smooth noclamp")
 local PANEL = {}
+
+local function paintSlot(x, y, w, h, skin)
+    skin = skin or derma.GetSkinTable()
+    if skin and skin.DrawGenericBackground then
+        skin:DrawGenericBackground(x, y, w, h)
+    else
+        surface.SetDrawColor(45, 45, 45, 240)
+        surface.DrawRect(x, y, w, h)
+        surface.SetDrawColor(0, 0, 0, 180)
+        surface.DrawOutlinedRect(x, y, w, h)
+        surface.SetDrawColor(100, 100, 100, 25)
+        surface.DrawOutlinedRect(x + 1, y + 1, w - 2, h - 2)
+    end
+end
 function PANEL:Init()
     self:SetPaintBackground(false)
     self.icons = {}
@@ -129,9 +142,7 @@ function PANEL:drawHeldItemRectangle()
     local x = math.Round((mx - w * 0.5) / size)
     local y = math.Round((my - h * 0.5) / size)
     if x < 0 or y < 0 or x + item:getWidth() > self.gridW or y + item:getHeight() > self.gridH then return end
-    surface.SetDrawColor(255, 255, 255)
-    surface.SetMaterial(InvSlotMat)
-    surface.DrawTexturedRect(x * size, y * size, w, h)
+    paintSlot(x * size, y * size, w, h, self:GetSkin())
 end
 
 function PANEL:computeHeldPanel()
@@ -143,11 +154,10 @@ end
 
 function PANEL:Paint()
     local size = self.size
+    local skin = self:GetSkin()
     for y = 0, self.gridH - 1 do
         for x = 0, self.gridW - 1 do
-            surface.SetDrawColor(255, 255, 255)
-            surface.SetMaterial(InvSlotMat)
-            surface.DrawTexturedRect(x * (size + 2), y * (size + 2), size, size)
+            paintSlot(x * (size + 2), y * (size + 2), size, size, skin)
         end
     end
 


### PR DESCRIPTION
## Summary
- remove `InvSlotMat` and add `paintSlot` helper
- use Derma skin to paint inventory slots and held item highlight

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688491f237f08327a540344d3fcc77aa