### PR TITLE
Fix sitroom command syntax

### DIFF
--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -84,10 +84,10 @@ lia.command.add("managesitrooms", {
         for name, pos in pairs(rooms) do
             rooms[name] = lia.data.decodeVector(pos)
         end
-            net.Start("managesitrooms")
-            net.WriteTable(rooms)
-            net.Send(client)
-        end
+
+        net.Start("managesitrooms")
+        net.WriteTable(rooms)
+        net.Send(client)
     end
 })
 
@@ -156,7 +156,6 @@ lia.command.add("sendtositroom", {
                 target:notifyLocalized("sitroomArrive")
                 lia.log.add(client, "sendToSitRoom", target:Nick(), selection)
             end)
-        end
     end
 })
 


### PR DESCRIPTION
## Summary
- fix syntax errors in sitroom commands by removing extraneous `end` statements

## Testing
- `lua` interpreter unavailable due to environment limitations

------
https://chatgpt.com/codex/tasks/task_e_68849185251883278cc486ab38311fa6