### PR TITLE
Load admin groups dynamically from database

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -250,25 +250,27 @@ function GM:PlayerAuthed(client, steamid)
     end
 
     local steam64 = steamID64
-    local forcedGroup = lia.admin.steamAdmins[steam64]
-    if forcedGroup and lia.admin.groups[forcedGroup] then
-        lia.admin.setPlayerGroup(client, forcedGroup)
-        return
-    end
-
-    if CAMI and CAMI.GetUsergroup and CAMI.GetUsergroup(client:GetUserGroup()) and client:GetUserGroup() ~= "user" then
-        lia.db.query(Format("UPDATE lia_players SET userGroup = '%s' WHERE steamID = %s", lia.db.escape(client:GetUserGroup()), steam64))
-        return
-    end
-
-    lia.db.query(Format("SELECT userGroup FROM lia_players WHERE steamID = %s", steam64), function(data)
-        local group = istable(data) and data[1] and data[1].userGroup
-        if not group or group == "" then
-            group = "user"
-            lia.db.query(Format("UPDATE lia_players SET userGroup = '%s' WHERE steamID = %s", lia.db.escape(group), steam64))
+    lia.db.query(Format("SELECT userGroup FROM lia_admins WHERE steamID = %s", steam64), function(adminData)
+        local forcedGroup = istable(adminData) and adminData[1] and adminData[1].userGroup
+        if forcedGroup and lia.admin.groups[forcedGroup] then
+            lia.admin.setPlayerGroup(client, forcedGroup)
+            return
         end
 
-        client:SetUserGroup(group)
+        if CAMI and CAMI.GetUsergroup and CAMI.GetUsergroup(client:GetUserGroup()) and client:GetUserGroup() ~= "user" then
+            lia.db.query(Format("UPDATE lia_players SET userGroup = '%s' WHERE steamID = %s", lia.db.escape(client:GetUserGroup()), steam64))
+            return
+        end
+
+        lia.db.query(Format("SELECT userGroup FROM lia_players WHERE steamID = %s", steam64), function(data)
+            local group = istable(data) and data[1] and data[1].userGroup
+            if not group or group == "" then
+                group = "user"
+                lia.db.query(Format("UPDATE lia_players SET userGroup = '%s' WHERE steamID = %s", lia.db.escape(group), steam64))
+            end
+
+            client:SetUserGroup(group)
+        end)
     end)
 end
 

--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -1043,7 +1043,12 @@ if SERVER then
             usergroup = "superadmin"
         end
 
-        lia.admin.steamAdmins[steam64] = usergroup
+        lia.db.insertOrIgnore({
+            steamID = steam64,
+            userGroup = usergroup
+        }, "admins"):next(function()
+            lia.db.updateTable({userGroup = usergroup}, nil, "admins", "steamID = " .. lia.db.convertDataType(steam64))
+        end)
     end
 
     function lia.admin.addBan(steamid, reason, duration)

--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -267,6 +267,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS `lia_privileges`;
     DROP TABLE IF EXISTS `lia_saveditems`;
     DROP TABLE IF EXISTS `lia_persistence`;
+    DROP TABLE IF EXISTS `lia_admins`;
 ]])
             local done = 0
             for i = 1, #queries do
@@ -298,6 +299,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS lia_saveditems;
     DROP TABLE IF EXISTS lia_persistence;
     DROP TABLE IF EXISTS lia_chardata;
+    DROP TABLE IF EXISTS lia_admins;
 ]], realCallback)
     end
 end
@@ -460,6 +462,11 @@ function lia.db.loadTables()
                 category TEXT
             );
 
+            CREATE TABLE IF NOT EXISTS lia_admins (
+                steamID TEXT PRIMARY KEY,
+                userGroup TEXT
+            );
+
         ]], done)
     else
         local queries = string.Explode(";", [[
@@ -613,6 +620,12 @@ function lia.db.loadTables()
                 `minAccess` VARCHAR(32) NOT NULL,
                 `category` VARCHAR(64) NOT NULL,
                 PRIMARY KEY (`name`)
+            );
+
+            CREATE TABLE IF NOT EXISTS `lia_admins` (
+                `steamID` VARCHAR(20) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `userGroup` VARCHAR(32) NOT NULL COLLATE 'utf8mb4_general_ci',
+                PRIMARY KEY (`steamID`)
             );
         ]])
         local i = 1


### PR DESCRIPTION
## Summary
- create `lia_admins` table for persisting admin SteamIDs
- update admin registration to write to `lia_admins`
- pull admin group from the database on player auth

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688492318a848327877c7337689a9b6e