### PR TITLE
Remove lia.admin.addStaffAction usage

### DIFF
--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -1,37 +1,5 @@
 ﻿local MODULE = MODULE
 
--- local helper to directly record staff actions
-local function logStaffAction(admin, action, victim, message, charID)
-    local targetName
-    local targetSteam
-    if IsValid(victim) and victim:IsPlayer() then
-        targetName = victim:Name()
-        targetSteam = victim:SteamID()
-    elseif isstring(victim) then
-        targetSteam = victim
-        local ply = player.GetBySteamID(victim) or player.GetBySteamID64(victim)
-        if IsValid(ply) then
-            targetName = ply:Name()
-        else
-            targetName = victim
-        end
-    else
-        targetName = tostring(victim)
-        targetSteam = tostring(victim)
-    end
-
-    lia.db.insertTable({
-        timestamp = os.date("%Y-%m-%d %H:%M:%S"),
-        targetName = targetName,
-        targetSteam = targetSteam,
-        adminSteam = IsValid(admin) and admin:SteamID() or "Console",
-        adminName = IsValid(admin) and admin:Name() or "Console",
-        adminGroup = IsValid(admin) and admin:GetUserGroup() or "Console",
-        action = action,
-        message = message,
-        charID = charID
-    }, nil, "staffactions")
-end
 lia.command.add("adminmode", {
     desc = "adminModeDesc",
     onRun = function(client)
@@ -234,7 +202,34 @@ lia.command.add("plykick", {
             target:Kick(L("kickMessage", target, arguments[2] or L("genericReason")))
             client:notifyLocalized("plyKicked")
             lia.log.add(client, "plyKick", target:Name())
-            logStaffAction(client, "kick", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "kick",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
         end
     end
 })
@@ -250,7 +245,34 @@ lia.command.add("plyban", {
             target:banPlayer(arguments[3] or L("genericReason"), arguments[2])
             client:notifyLocalized("plyBanned")
             lia.log.add(client, "plyBan", target:Name())
-            logStaffAction(client, "ban", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "ban",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
         end
     end
 })
@@ -266,7 +288,34 @@ lia.command.add("plykill", {
             target:Kill()
             client:notifyLocalized("plyKilled")
             lia.log.add(client, "plyKill", target:Name())
-            logStaffAction(client, "kill", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "kill",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
         end
     end
 })
@@ -315,7 +364,34 @@ lia.command.add("plyfreeze", {
             local dur = tonumber(arguments[2]) or 0
             if dur > 0 then timer.Simple(dur, function() if IsValid(target) then target:Freeze(false) end end) end
             lia.log.add(client, "plyFreeze", target:Name(), dur)
-            logStaffAction(client, "freeze", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "freeze",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
         end
     end
 })
@@ -330,7 +406,34 @@ lia.command.add("plyunfreeze", {
         if IsValid(target) then
             target:Freeze(false)
             lia.log.add(client, "plyUnfreeze", target:Name())
-            logStaffAction(client, "unfreeze", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "unfreeze",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
         end
     end
 })
@@ -345,7 +448,34 @@ lia.command.add("plyslay", {
         if IsValid(target) then
             target:Kill()
             lia.log.add(client, "plySlay", target:Name())
-            logStaffAction(client, "slay", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "slay",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
         end
     end
 })
@@ -360,7 +490,34 @@ lia.command.add("plyrespawn", {
         if IsValid(target) then
             target:Spawn()
             lia.log.add(client, "plyRespawn", target:Name())
-            logStaffAction(client, "respawn", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "respawn",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
         end
     end
 })
@@ -388,7 +545,34 @@ lia.command.add("plyblind", {
             end
 
             lia.log.add(client, "plyBlind", target:Name(), dur or 0)
-            logStaffAction(client, "blind", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "blind",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
         end
     end
 })
@@ -405,7 +589,34 @@ lia.command.add("plyunblind", {
             net.WriteBool(false)
             net.Send(target)
             lia.log.add(client, "plyUnblind", target:Name())
-            logStaffAction(client, "unblind", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "unblind",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
         end
     end
 })
@@ -469,7 +680,34 @@ lia.command.add("plygag", {
         if IsValid(target) then
             target:setNetVar("liaGagged", true)
             lia.log.add(client, "plyGag", target:Name())
-            logStaffAction(client, "gag", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "gag",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
             hook.Run("PlayerGagged", target, client)
         end
     end
@@ -485,7 +723,34 @@ lia.command.add("plyungag", {
         if IsValid(target) then
             target:setNetVar("liaGagged", false)
             lia.log.add(client, "plyUngag", target:Name())
-            logStaffAction(client, "ungag", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "ungag",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
             hook.Run("PlayerUngagged", target, client)
         end
     end
@@ -501,7 +766,34 @@ lia.command.add("plymute", {
         if IsValid(target) then
             target:setLiliaData("VoiceBan", true)
             lia.log.add(client, "plyMute", target:Name())
-            logStaffAction(client, "mute", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "mute",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
             hook.Run("PlayerMuted", target, client)
         end
     end
@@ -517,7 +809,34 @@ lia.command.add("plyunmute", {
         if IsValid(target) then
             target:setLiliaData("VoiceBan", false)
             lia.log.add(client, "plyUnmute", target:Name())
-            logStaffAction(client, "unmute", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "unmute",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
             hook.Run("PlayerUnmuted", target, client)
         end
     end
@@ -535,7 +854,34 @@ lia.command.add("plybring", {
             returnPositions[target] = target:GetPos()
             target:SetPos(client:GetPos() + client:GetForward() * 50)
             lia.log.add(client, "plyBring", target:Name())
-            logStaffAction(client, "bring", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "bring",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
         end
     end
 })
@@ -551,7 +897,34 @@ lia.command.add("plygoto", {
             returnPositions[client] = client:GetPos()
             client:SetPos(target:GetPos() + target:GetForward() * 50)
             lia.log.add(client, "plyGoto", target:Name())
-            logStaffAction(client, "goto", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "goto",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
         end
     end
 })
@@ -569,7 +942,34 @@ lia.command.add("plyreturn", {
             target:SetPos(pos)
             returnPositions[target] = nil
             lia.log.add(client, "plyReturn", target:Name())
-            logStaffAction(client, "return", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "return",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
         end
     end
 })
@@ -585,7 +985,34 @@ lia.command.add("plyjail", {
             target:Lock()
             target:Freeze(true)
             lia.log.add(client, "plyJail", target:Name())
-            logStaffAction(client, "jail", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "jail",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
         end
     end
 })
@@ -601,7 +1028,34 @@ lia.command.add("plyunjail", {
             target:UnLock()
             target:Freeze(false)
             lia.log.add(client, "plyUnjail", target:Name())
-            logStaffAction(client, "unjail", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "unjail",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
         end
     end
 })
@@ -616,7 +1070,34 @@ lia.command.add("plycloak", {
         if IsValid(target) then
             target:SetNoDraw(true)
             lia.log.add(client, "plyCloak", target:Name())
-            logStaffAction(client, "cloak", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "cloak",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
         end
     end
 })
@@ -631,7 +1112,34 @@ lia.command.add("plyuncloak", {
         if IsValid(target) then
             target:SetNoDraw(false)
             lia.log.add(client, "plyUncloak", target:Name())
-            logStaffAction(client, "uncloak", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "uncloak",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
         end
     end
 })
@@ -646,7 +1154,34 @@ lia.command.add("plygod", {
         if IsValid(target) then
             target:GodEnable()
             lia.log.add(client, "plyGod", target:Name())
-            logStaffAction(client, "god", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "god",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
         end
     end
 })
@@ -661,7 +1196,34 @@ lia.command.add("plyungod", {
         if IsValid(target) then
             target:GodDisable()
             lia.log.add(client, "plyUngod", target:Name())
-            logStaffAction(client, "ungod", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "ungod",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
         end
     end
 })
@@ -677,7 +1239,34 @@ lia.command.add("plyignite", {
             local dur = tonumber(arguments[2]) or 5
             target:Ignite(dur)
             lia.log.add(client, "plyIgnite", target:Name(), dur)
-            logStaffAction(client, "ignite", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "ignite",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
         end
     end
 })
@@ -692,7 +1281,34 @@ lia.command.add("plyextinguish", {
         if IsValid(target) then
             target:Extinguish()
             lia.log.add(client, "plyExtinguish", target:Name())
-            logStaffAction(client, "extinguish", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "extinguish",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
         end
     end
 })
@@ -707,7 +1323,34 @@ lia.command.add("plystrip", {
         if IsValid(target) then
             target:StripWeapons()
             lia.log.add(client, "plyStrip", target:Name())
-            logStaffAction(client, "strip", target)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "strip",
+                message = nil,
+                charID = nil
+            }, nil, "staffactions")
         end
     end
 })
@@ -749,7 +1392,34 @@ lia.command.add("warn", {
             client:notifyLocalized("warningIssued", target:Nick())
             hook.Run("WarningIssued", client, target, reason, count)
             lia.log.add(client, "warningIssued", target, reason, count)
-            logStaffAction(client, "warn", target, reason)
+            local targetName
+            local targetSteam
+            if IsValid(target) and target:IsPlayer() then
+                targetName = target:Name()
+                targetSteam = target:SteamID()
+            elseif isstring(target) then
+                targetSteam = target
+                local ply = player.GetBySteamID(target) or player.GetBySteamID64(target)
+                if IsValid(ply) then
+                    targetName = ply:Name()
+                else
+                    targetName = target
+                end
+            else
+                targetName = tostring(target)
+                targetSteam = tostring(target)
+            end
+            lia.db.insertTable({
+                timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                targetName = targetName,
+                targetSteam = targetSteam,
+                adminSteam = IsValid(client) and client:SteamID() or "Console",
+                adminName = IsValid(client) and client:Name() or "Console",
+                adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+                action = "warn",
+                message = reason,
+                charID = nil
+            }, nil, "staffactions")
         end)
     end
 })

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -1,4 +1,37 @@
 ﻿local MODULE = MODULE
+
+-- local helper to directly record staff actions
+local function logStaffAction(admin, action, victim, message, charID)
+    local targetName
+    local targetSteam
+    if IsValid(victim) and victim:IsPlayer() then
+        targetName = victim:Name()
+        targetSteam = victim:SteamID()
+    elseif isstring(victim) then
+        targetSteam = victim
+        local ply = player.GetBySteamID(victim) or player.GetBySteamID64(victim)
+        if IsValid(ply) then
+            targetName = ply:Name()
+        else
+            targetName = victim
+        end
+    else
+        targetName = tostring(victim)
+        targetSteam = tostring(victim)
+    end
+
+    lia.db.insertTable({
+        timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+        targetName = targetName,
+        targetSteam = targetSteam,
+        adminSteam = IsValid(admin) and admin:SteamID() or "Console",
+        adminName = IsValid(admin) and admin:Name() or "Console",
+        adminGroup = IsValid(admin) and admin:GetUserGroup() or "Console",
+        action = action,
+        message = message,
+        charID = charID
+    }, nil, "staffactions")
+end
 lia.command.add("adminmode", {
     desc = "adminModeDesc",
     onRun = function(client)
@@ -201,7 +234,7 @@ lia.command.add("plykick", {
             target:Kick(L("kickMessage", target, arguments[2] or L("genericReason")))
             client:notifyLocalized("plyKicked")
             lia.log.add(client, "plyKick", target:Name())
-            lia.admin.addStaffAction(client, "kick", target)
+            logStaffAction(client, "kick", target)
         end
     end
 })
@@ -217,7 +250,7 @@ lia.command.add("plyban", {
             target:banPlayer(arguments[3] or L("genericReason"), arguments[2])
             client:notifyLocalized("plyBanned")
             lia.log.add(client, "plyBan", target:Name())
-            lia.admin.addStaffAction(client, "ban", target)
+            logStaffAction(client, "ban", target)
         end
     end
 })
@@ -233,7 +266,7 @@ lia.command.add("plykill", {
             target:Kill()
             client:notifyLocalized("plyKilled")
             lia.log.add(client, "plyKill", target:Name())
-            lia.admin.addStaffAction(client, "kill", target)
+            logStaffAction(client, "kill", target)
         end
     end
 })
@@ -282,7 +315,7 @@ lia.command.add("plyfreeze", {
             local dur = tonumber(arguments[2]) or 0
             if dur > 0 then timer.Simple(dur, function() if IsValid(target) then target:Freeze(false) end end) end
             lia.log.add(client, "plyFreeze", target:Name(), dur)
-            lia.admin.addStaffAction(client, "freeze", target)
+            logStaffAction(client, "freeze", target)
         end
     end
 })
@@ -297,7 +330,7 @@ lia.command.add("plyunfreeze", {
         if IsValid(target) then
             target:Freeze(false)
             lia.log.add(client, "plyUnfreeze", target:Name())
-            lia.admin.addStaffAction(client, "unfreeze", target)
+            logStaffAction(client, "unfreeze", target)
         end
     end
 })
@@ -312,7 +345,7 @@ lia.command.add("plyslay", {
         if IsValid(target) then
             target:Kill()
             lia.log.add(client, "plySlay", target:Name())
-            lia.admin.addStaffAction(client, "slay", target)
+            logStaffAction(client, "slay", target)
         end
     end
 })
@@ -327,7 +360,7 @@ lia.command.add("plyrespawn", {
         if IsValid(target) then
             target:Spawn()
             lia.log.add(client, "plyRespawn", target:Name())
-            lia.admin.addStaffAction(client, "respawn", target)
+            logStaffAction(client, "respawn", target)
         end
     end
 })
@@ -355,7 +388,7 @@ lia.command.add("plyblind", {
             end
 
             lia.log.add(client, "plyBlind", target:Name(), dur or 0)
-            lia.admin.addStaffAction(client, "blind", target)
+            logStaffAction(client, "blind", target)
         end
     end
 })
@@ -372,7 +405,7 @@ lia.command.add("plyunblind", {
             net.WriteBool(false)
             net.Send(target)
             lia.log.add(client, "plyUnblind", target:Name())
-            lia.admin.addStaffAction(client, "unblind", target)
+            logStaffAction(client, "unblind", target)
         end
     end
 })
@@ -436,7 +469,7 @@ lia.command.add("plygag", {
         if IsValid(target) then
             target:setNetVar("liaGagged", true)
             lia.log.add(client, "plyGag", target:Name())
-            lia.admin.addStaffAction(client, "gag", target)
+            logStaffAction(client, "gag", target)
             hook.Run("PlayerGagged", target, client)
         end
     end
@@ -452,7 +485,7 @@ lia.command.add("plyungag", {
         if IsValid(target) then
             target:setNetVar("liaGagged", false)
             lia.log.add(client, "plyUngag", target:Name())
-            lia.admin.addStaffAction(client, "ungag", target)
+            logStaffAction(client, "ungag", target)
             hook.Run("PlayerUngagged", target, client)
         end
     end
@@ -468,7 +501,7 @@ lia.command.add("plymute", {
         if IsValid(target) then
             target:setLiliaData("VoiceBan", true)
             lia.log.add(client, "plyMute", target:Name())
-            lia.admin.addStaffAction(client, "mute", target)
+            logStaffAction(client, "mute", target)
             hook.Run("PlayerMuted", target, client)
         end
     end
@@ -484,7 +517,7 @@ lia.command.add("plyunmute", {
         if IsValid(target) then
             target:setLiliaData("VoiceBan", false)
             lia.log.add(client, "plyUnmute", target:Name())
-            lia.admin.addStaffAction(client, "unmute", target)
+            logStaffAction(client, "unmute", target)
             hook.Run("PlayerUnmuted", target, client)
         end
     end
@@ -502,7 +535,7 @@ lia.command.add("plybring", {
             returnPositions[target] = target:GetPos()
             target:SetPos(client:GetPos() + client:GetForward() * 50)
             lia.log.add(client, "plyBring", target:Name())
-            lia.admin.addStaffAction(client, "bring", target)
+            logStaffAction(client, "bring", target)
         end
     end
 })
@@ -518,7 +551,7 @@ lia.command.add("plygoto", {
             returnPositions[client] = client:GetPos()
             client:SetPos(target:GetPos() + target:GetForward() * 50)
             lia.log.add(client, "plyGoto", target:Name())
-            lia.admin.addStaffAction(client, "goto", target)
+            logStaffAction(client, "goto", target)
         end
     end
 })
@@ -536,7 +569,7 @@ lia.command.add("plyreturn", {
             target:SetPos(pos)
             returnPositions[target] = nil
             lia.log.add(client, "plyReturn", target:Name())
-            lia.admin.addStaffAction(client, "return", target)
+            logStaffAction(client, "return", target)
         end
     end
 })
@@ -552,7 +585,7 @@ lia.command.add("plyjail", {
             target:Lock()
             target:Freeze(true)
             lia.log.add(client, "plyJail", target:Name())
-            lia.admin.addStaffAction(client, "jail", target)
+            logStaffAction(client, "jail", target)
         end
     end
 })
@@ -568,7 +601,7 @@ lia.command.add("plyunjail", {
             target:UnLock()
             target:Freeze(false)
             lia.log.add(client, "plyUnjail", target:Name())
-            lia.admin.addStaffAction(client, "unjail", target)
+            logStaffAction(client, "unjail", target)
         end
     end
 })
@@ -583,7 +616,7 @@ lia.command.add("plycloak", {
         if IsValid(target) then
             target:SetNoDraw(true)
             lia.log.add(client, "plyCloak", target:Name())
-            lia.admin.addStaffAction(client, "cloak", target)
+            logStaffAction(client, "cloak", target)
         end
     end
 })
@@ -598,7 +631,7 @@ lia.command.add("plyuncloak", {
         if IsValid(target) then
             target:SetNoDraw(false)
             lia.log.add(client, "plyUncloak", target:Name())
-            lia.admin.addStaffAction(client, "uncloak", target)
+            logStaffAction(client, "uncloak", target)
         end
     end
 })
@@ -613,7 +646,7 @@ lia.command.add("plygod", {
         if IsValid(target) then
             target:GodEnable()
             lia.log.add(client, "plyGod", target:Name())
-            lia.admin.addStaffAction(client, "god", target)
+            logStaffAction(client, "god", target)
         end
     end
 })
@@ -628,7 +661,7 @@ lia.command.add("plyungod", {
         if IsValid(target) then
             target:GodDisable()
             lia.log.add(client, "plyUngod", target:Name())
-            lia.admin.addStaffAction(client, "ungod", target)
+            logStaffAction(client, "ungod", target)
         end
     end
 })
@@ -644,7 +677,7 @@ lia.command.add("plyignite", {
             local dur = tonumber(arguments[2]) or 5
             target:Ignite(dur)
             lia.log.add(client, "plyIgnite", target:Name(), dur)
-            lia.admin.addStaffAction(client, "ignite", target)
+            logStaffAction(client, "ignite", target)
         end
     end
 })
@@ -659,7 +692,7 @@ lia.command.add("plyextinguish", {
         if IsValid(target) then
             target:Extinguish()
             lia.log.add(client, "plyExtinguish", target:Name())
-            lia.admin.addStaffAction(client, "extinguish", target)
+            logStaffAction(client, "extinguish", target)
         end
     end
 })
@@ -674,7 +707,7 @@ lia.command.add("plystrip", {
         if IsValid(target) then
             target:StripWeapons()
             lia.log.add(client, "plyStrip", target:Name())
-            lia.admin.addStaffAction(client, "strip", target)
+            logStaffAction(client, "strip", target)
         end
     end
 })
@@ -716,7 +749,7 @@ lia.command.add("warn", {
             client:notifyLocalized("warningIssued", target:Nick())
             hook.Run("WarningIssued", client, target, reason, count)
             lia.log.add(client, "warningIssued", target, reason, count)
-            lia.admin.addStaffAction(client, "warn", target, reason)
+            logStaffAction(client, "warn", target, reason)
         end)
     end
 })

--- a/gamemode/modules/administration/tools/tickets/server.lua
+++ b/gamemode/modules/administration/tools/tickets/server.lua
@@ -1,37 +1,5 @@
 ﻿local MODULE = MODULE
 
--- local helper to record staff actions directly
-local function logStaffAction(admin, action, victim, message, charID)
-    local targetName
-    local targetSteam
-    if IsValid(victim) and victim:IsPlayer() then
-        targetName = victim:Name()
-        targetSteam = victim:SteamID()
-    elseif isstring(victim) then
-        targetSteam = victim
-        local ply = player.GetBySteamID(victim) or player.GetBySteamID64(victim)
-        if IsValid(ply) then
-            targetName = ply:Name()
-        else
-            targetName = victim
-        end
-    else
-        targetName = tostring(victim)
-        targetSteam = tostring(victim)
-    end
-
-    lia.db.insertTable({
-        timestamp = os.date("%Y-%m-%d %H:%M:%S"),
-        targetName = targetName,
-        targetSteam = targetSteam,
-        adminSteam = IsValid(admin) and admin:SteamID() or "Console",
-        adminName = IsValid(admin) and admin:Name() or "Console",
-        adminGroup = IsValid(admin) and admin:GetUserGroup() or "Console",
-        action = action,
-        message = message,
-        charID = charID
-    }, nil, "staffactions")
-end
 local function buildClaimTable(rows)
     local caseclaims = {}
     for _, row in ipairs(rows or {}) do
@@ -74,7 +42,34 @@ function MODULE:GetAllCaseClaims()
 end
 
 function MODULE:TicketSystemClaim(admin, requester)
-    logStaffAction(admin, "ticketClaim", requester)
+    local targetName
+    local targetSteam
+    if IsValid(requester) and requester:IsPlayer() then
+        targetName = requester:Name()
+        targetSteam = requester:SteamID()
+    elseif isstring(requester) then
+        targetSteam = requester
+        local ply = player.GetBySteamID(requester) or player.GetBySteamID64(requester)
+        if IsValid(ply) then
+            targetName = ply:Name()
+        else
+            targetName = requester
+        end
+    else
+        targetName = tostring(requester)
+        targetSteam = tostring(requester)
+    end
+    lia.db.insertTable({
+        timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+        targetName = targetName,
+        targetSteam = targetSteam,
+        adminSteam = IsValid(admin) and admin:SteamID() or "Console",
+        adminName = IsValid(admin) and admin:Name() or "Console",
+        adminGroup = IsValid(admin) and admin:GetUserGroup() or "Console",
+        action = "ticketClaim",
+        message = nil,
+        charID = nil
+    }, nil, "staffactions")
     lia.db.count("staffactions", "adminSteam = " .. lia.db.convertDataType(admin:SteamID()) .. " AND action = 'ticketClaim'"):next(function(count)
         lia.log.add(admin, "ticketClaimed", requester:Name(), count)
     end)
@@ -91,7 +86,34 @@ function MODULE:PlayerSay(client, text)
         text = string.sub(text, 2)
         ClientAddText(client, Color(70, 0, 130), L("ticketMessageYou"), Color(151, 211, 255), " " .. L("ticketMessageToAdmins") .. " ", Color(0, 255, 0), text)
         self:SendPopup(client, text)
-        logStaffAction(client, "ticketOpen", client, text)
+        local targetName
+        local targetSteam
+        if IsValid(client) and client:IsPlayer() then
+            targetName = client:Name()
+            targetSteam = client:SteamID()
+        elseif isstring(client) then
+            targetSteam = client
+            local ply = player.GetBySteamID(client) or player.GetBySteamID64(client)
+            if IsValid(ply) then
+                targetName = ply:Name()
+            else
+                targetName = client
+            end
+        else
+            targetName = tostring(client)
+            targetSteam = tostring(client)
+        end
+        lia.db.insertTable({
+            timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+            targetName = targetName,
+            targetSteam = targetSteam,
+            adminSteam = IsValid(client) and client:SteamID() or "Console",
+            adminName = IsValid(client) and client:Name() or "Console",
+            adminGroup = IsValid(client) and client:GetUserGroup() or "Console",
+            action = "ticketOpen",
+            message = text,
+            charID = nil
+        }, nil, "staffactions")
         return ""
     end
 end


### PR DESCRIPTION
## Summary
- avoid global `lia.admin.addStaffAction`
- inline staff action logging in admin commands and ticket system

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884960ecf7483279a32555088da83ce