### PR TITLE
Fix missing admingroups table error

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -855,18 +855,24 @@ function lia.admin.load()
                 end)
             end)
         else
-            lia.db.selectOne({"data"}, "admingroups"):next(function(res)
-                local groups = res and util.JSONToTable(res.data or "") or {}
-                local rows = {}
-                for name, dat in pairs(groups) do
-                    rows[#rows + 1] = {
-                        name = name,
-                        data = util.TableToJSON(dat)
-                    }
-                end
+            lia.db.tableExists("admingroups"):next(function(admExists)
+                if admExists then
+                    lia.db.selectOne({"data"}, "admingroups"):next(function(res)
+                        local groups = res and util.JSONToTable(res.data or "") or {}
+                        local rows = {}
+                        for name, dat in pairs(groups) do
+                            rows[#rows + 1] = {
+                                name = name,
+                                data = util.TableToJSON(dat)
+                            }
+                        end
 
-                if #rows > 0 then lia.db.bulkUpsert("usergroups", rows) end
-                continueLoad(groups)
+                        if #rows > 0 then lia.db.bulkUpsert("usergroups", rows) end
+                        continueLoad(groups)
+                    end)
+                else
+                    continueLoad({})
+                end
             end)
         end
     end)


### PR DESCRIPTION
## Summary
- check that `lia_admingroups` table exists before reading from it

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6884ff18b300832793bd3ce1a8432e64