### PR TITLE
Use lia_players table for bans

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -999,20 +999,8 @@ function GM:PlayerCanHearPlayersVoice(listener, speaker)
 end
 
 function GM:OnDatabaseLoaded()
-    lia.db.query("SELECT steamID, banReason, banStart, banDuration FROM lia_players WHERE banStart IS NOT NULL", function(data)
-        if istable(data) then
-            local bans = {}
-            for _, ban in pairs(data) do
-                bans[ban.steamID] = {
-                    reason = ban.banReason,
-                    start = tonumber(ban.banStart),
-                    duration = tonumber(ban.banDuration)
-                }
-            end
-
-            lia.admin.banList = bans
-        end
-    end)
+    -- Bans are now read directly from the lia_players table when needed,
+    -- so there is no need to populate lia.admin.banList on startup.
 end
 
 local networkStrings = {"actBar", "AdminModeSwapCharacter", "AnimationStatus", "ArgumentsRequest", "attrib", "BinaryQuestionRequest", "blindFade", "blindTarget", "ButtonRequest", "cfgList", "cfgSet", "charInfo", "charKick", "charSet", "charVar", "CheckHack", "CheckSeed", "classUpdate", "cmd", "cMsg", "CreateTableUI", "DisplayCharList", "doorMenu", "doorPerm", "gVar", "invAct", "invData", "invQuantity", "KickCharacter", "lia_managesitrooms_action", "liaCharacterData", "liaCharacterInvList", "liaCharChoose", "liaCharCreate", "liaCharDelete", "liaCharFetchNames", "liaCharList", "liaCmdArgPrompt", "liaData", "liaDataSync", "liaDBTableDataChunk", "liaDBTableDataDone", "liaDBTables", "liaGroupsAdd", "liaGroupsDefaults", "liaGroupsNotice", "liaGroupsRemove", "liaGroupsRename", "liaGroupsRequest", "liaInventoryAdd", "liaInventoryData", "liaInventoryDelete", "liaInventoryInit", "liaInventoryRemove", "liaItemDelete", "liaItemInspect", "liaItemInstance", "liaNotify", "liaNotifyL", "liaPACPartAdd", "liaPACPartRemove", "liaPACPartReset", "liaPACSync", "liaPlayersRequest", "liaRequestCharList", "liaRequestDBTables", "liaRequestPlayerGroup", "liaRequestTableData", "liaStorageExit", "liaStorageOpen", "liaStorageTransfer", "liaStorageUnlock", "liaTeleportToEntity", "liaTransferItem", "managesitrooms", "msg", "nDel", "NetStreamDS", "nLcl", "nVar", "OpenInvMenu", "OptionsRequest", "PKMessage", "playerLoadedChar", "postPlayerLoadedChar", "prePlayerLoadedChar", "RegenChat", "removeF1", "request_respawn", "RequestDropdown", "rgnDone", "RosterData", "RosterRequest", "send_logs", "send_logs_request", "seqSet", "ServerChatAddText", "setWaypoint", "setWaypointWithLogo", "SpawnMenuGiveItem", "SpawnMenuSpawnItem", "StringRequest", "TicketSystem", "TicketSystemClaim", "TicketSystemClose", "TransferMoneyFromP2P", "trunkInitStorage", "updateAdminGroups", "VendorAllowClass", "VendorAllowFaction", "VendorEdit", "VendorExit", "VendorMaxStock", "VendorMode", "VendorMoney", "VendorOpen", "VendorPrice", "VendorStock", "VendorSync", "VendorTrade", "VerifyCheats", "VerifyCheatsResponse", "ViewClaims", "WorkshopDownloader_Info", "WorkshopDownloader_Request", "WorkshopDownloader_Start", "liaStaffRequest", "liaStaffDataChunk", "liaStaffDataDone"}

--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -1,6 +1,5 @@
 ﻿lia.admin = lia.admin or {}
 lia.admin.groups = lia.admin.groups or {}
-lia.admin.banList = lia.admin.banList or {}
 lia.admin.privileges = lia.admin.privileges or {}
 lia.admin.steamAdmins = lia.admin.steamAdmins or {}
 if SERVER then
@@ -712,12 +711,7 @@ if SERVER then
     function lia.admin.addBan(steamid, reason, duration)
         if not steamid then Error("[Lilia Administration] lia.admin.addBan: no steam id specified!") end
         local banStart = os.time()
-        lia.admin.banList[steamid] = {
-            reason = reason or L("genericReason"),
-            start = banStart,
-            duration = (duration or 0) * 60
-        }
-
+        -- persist the ban details in the lia_players table
         lia.db.updateTable({
             banStart = banStart,
             banDuration = (duration or 0) * 60,
@@ -727,7 +721,7 @@ if SERVER then
 
     function lia.admin.removeBan(steamid)
         if not steamid then Error("[Lilia Administration] lia.admin.removeBan: no steam id specified!") end
-        lia.admin.banList[steamid] = nil
+        -- clear ban information from the lia_players table
         lia.db.updateTable({
             banStart = nil,
             banDuration = 0,


### PR DESCRIPTION
## Summary
- remove `banList` usage
- rely solely on `lia_players` table for bans

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68850eeb95988327bb2463c043f90580