### PR TITLE
Add config for disabling doors on load

### DIFF
--- a/gamemode/modules/doors/config.lua
+++ b/gamemode/modules/doors/config.lua
@@ -1,4 +1,4 @@
-﻿lia.config.add("DoorLockTime", "Door Lock Time", 0.5, nil, {
+lia.config.add("DoorLockTime", "Door Lock Time", 0.5, nil, {
     desc = "Time it takes to lock a door",
     category = "Doors",
     type = "Float",
@@ -12,4 +12,10 @@ lia.config.add("DoorSellRatio", "Door Sell Ratio", 0.5, nil, {
     type = "Float",
     min = 0.0,
     max = 1.0
+})
+
+lia.config.add("DoorsAlwaysDisabled", "Doors Always Disabled", false, nil, {
+    desc = "Should all doors start disabled when the map loads?",
+    category = "Doors",
+    type = "Boolean"
 })

--- a/gamemode/modules/doors/libraries/server.lua
+++ b/gamemode/modules/doors/libraries/server.lua
@@ -1,5 +1,5 @@
-﻿function MODULE:PostLoadData()
-    if self.DoorsAlwaysDisabled then
+function MODULE:PostLoadData()
+    if lia.config.get("DoorsAlwaysDisabled") then
         local count = 0
         for _, door in ents.Iterator() do
             if IsValid(door) and door:isDoor() then


### PR DESCRIPTION
## Summary
- allow server owners to disable every door on map load
- new boolean config `DoorsAlwaysDisabled`
- server library now checks this config

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6885310599dc8327b5cc8c7c52c08d2c