### PR TITLE
Move sitrooms/spawns to lia_data

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -264,9 +264,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS `lia_logs`;
     DROP TABLE IF EXISTS `lia_bans`;
     DROP TABLE IF EXISTS `lia_doors`;
-    DROP TABLE IF EXISTS `lia_spawns`;
     DROP TABLE IF EXISTS `lia_admingroups`;
-    DROP TABLE IF EXISTS `lia_sitrooms`;
     DROP TABLE IF EXISTS `lia_saveditems`;
     DROP TABLE IF EXISTS `lia_persistence`;
     DROP TABLE IF EXISTS `lia_warnings`;
@@ -297,9 +295,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS lia_logs;
     DROP TABLE IF EXISTS lia_bans;
     DROP TABLE IF EXISTS lia_doors;
-    DROP TABLE IF EXISTS lia_spawns;
     DROP TABLE IF EXISTS lia_admingroups;
-    DROP TABLE IF EXISTS lia_sitrooms;
     DROP TABLE IF EXISTS lia_saveditems;
     DROP TABLE IF EXISTS lia_persistence;
     DROP TABLE IF EXISTS lia_warnings;
@@ -445,22 +441,6 @@ function lia.db.loadTables()
                 _locked INTEGER,
                 _children TEXT,
                 PRIMARY KEY (_folder, _map, _id)
-            );
-
-            CREATE TABLE IF NOT EXISTS lia_spawns (
-                _schema TEXT,
-                _map TEXT,
-                _data TEXT,
-                PRIMARY KEY (_schema, _map)
-            );
-
-
-            CREATE TABLE IF NOT EXISTS lia_sitrooms (
-                _folder TEXT,
-                _map TEXT,
-                _name TEXT,
-                _pos TEXT,
-                PRIMARY KEY (_folder, _map, _name)
             );
 
             CREATE TABLE IF NOT EXISTS lia_data (
@@ -616,21 +596,7 @@ function lia.db.loadTables()
                 PRIMARY KEY (`_folder`, `_map`, `_id`)
             );
 
-            CREATE TABLE IF NOT EXISTS `lia_spawns` (
-                `_schema` TEXT NULL,
-                `_map` TEXT NULL,
-                `_data` TEXT NULL,
-                PRIMARY KEY (`_schema`, `_map`)
-            );
 
-
-            CREATE TABLE IF NOT EXISTS `lia_sitrooms` (
-                `_folder` TEXT NULL,
-                `_map` TEXT NULL,
-                `_name` TEXT NULL,
-                `_pos` TEXT NULL,
-                PRIMARY KEY (`_folder`, `_map`, `_name`)
-            );
 
             CREATE TABLE IF NOT EXISTS `lia_data` (
                 `_folder` TEXT NULL,

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -40,19 +40,11 @@ lia.command.add("managesitrooms", {
     desc = "manageSitroomsDesc",
     onRun = function(client)
         if not client:hasPrivilege("Manage SitRooms") then return end
-        local mapName = game.GetMap()
-        local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-        local condition = "_folder = " .. lia.db.convertDataType(folder) .. " AND _map = " .. lia.db.convertDataType(mapName)
-        lia.db.select({"_name", "_pos"}, "sitrooms", condition):next(function(res)
-            local rooms = {}
-            for _, row in ipairs(res.results or {}) do
-                rooms[row._name] = lia.data.decodeVector(row._pos)
-            end
-
-            net.Start("managesitrooms")
-            net.WriteTable(rooms)
-            net.Send(client)
-        end)
+        local data = lia.data.get("sitrooms", {})
+        local rooms = data.rooms or data
+        net.Start("managesitrooms")
+        net.WriteTable(rooms)
+        net.Send(client)
     end
 })
 
@@ -67,17 +59,14 @@ lia.command.add("addsitroom", {
                 return
             end
 
-            local mapName = game.GetMap()
-            local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-            lia.db.upsert({
-                _folder = folder,
-                _map = mapName,
-                _name = name,
-                _pos = lia.data.serialize(client:GetPos()),
-            }, "sitrooms")
+
+            local data = lia.data.get("sitrooms", {map = game.GetMap(), rooms = {}})
+            local rooms = data.rooms or data
+            rooms[name] = client:GetPos()
+            lia.data.set("sitrooms", {map = game.GetMap(), rooms = rooms})
 
             client:notifyLocalized("sitroomSet")
-            lia.log.add(client, "sitRoomSet", string.format("Map: %s | Name: %s | Position: %s", mapName, name, tostring(client:GetPos())), "Set the sitroom location")
+            lia.log.add(client, "sitRoomSet", string.format("Map: %s | Name: %s | Position: %s", game.GetMap(), name, tostring(client:GetPos())), "Set the sitroom location")
         end)
     end
 })
@@ -100,35 +89,29 @@ lia.command.add("sendtositroom", {
             return
         end
 
-        local mapName = game.GetMap()
-        local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-        local condition = "_folder = " .. lia.db.convertDataType(folder) .. " AND _map = " .. lia.db.convertDataType(mapName)
-        lia.db.select({"_name", "_pos"}, "sitrooms", condition):next(function(res)
-            local rooms = {}
-            local names = {}
-            for _, row in ipairs(res.results or {}) do
-                local pos = lia.data.decodeVector(row._pos)
-                rooms[row._name] = pos
-                names[#names + 1] = row._name
-            end
+        local data = lia.data.get("sitrooms", {})
+        local rooms = data.rooms or data
+        local names = {}
+        for name in pairs(rooms) do
+            names[#names + 1] = name
+        end
 
-            if #names == 0 then
+        if #names == 0 then
+            client:notifyLocalized("sitroomNotSet")
+            return
+        end
+
+        client:requestDropdown(L("chooseSitroomTitle"), L("selectSitroomPrompt"), names, function(selection)
+            local pos = rooms[selection]
+            if not pos then
                 client:notifyLocalized("sitroomNotSet")
                 return
             end
 
-            client:requestDropdown(L("chooseSitroomTitle"), L("selectSitroomPrompt"), names, function(selection)
-                local pos = rooms[selection]
-                if not pos then
-                    client:notifyLocalized("sitroomNotSet")
-                    return
-                end
-
-                target:SetPos(pos)
-                client:notifyLocalized("sitroomTeleport", target:Nick())
-                target:notifyLocalized("sitroomArrive")
-                lia.log.add(client, "sendToSitRoom", target:Nick(), selection)
-            end)
+            target:SetPos(pos)
+            client:notifyLocalized("sitroomTeleport", target:Nick())
+            target:notifyLocalized("sitroomArrive")
+            lia.log.add(client, "sendToSitRoom", target:Nick(), selection)
         end)
     end
 })

--- a/gamemode/modules/administration/netcalls/server.lua
+++ b/gamemode/modules/administration/netcalls/server.lua
@@ -62,42 +62,35 @@ net.Receive("lia_managesitrooms_action", function(_, client)
     if not client:hasPrivilege("Manage SitRooms") then return end
     local action = net.ReadUInt(2)
     local name = net.ReadString()
-    local mapName = game.GetMap()
-    local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-    local baseCondition = "_folder = " .. lia.db.convertDataType(folder) .. " AND _map = " .. lia.db.convertDataType(mapName)
+    local data = lia.data.get("sitrooms", {})
+    local rooms = data.rooms or data
     if action == 1 then
-        local condition = baseCondition .. " AND _name = " .. lia.db.convertDataType(name)
-        lia.db.selectOne({"_pos"}, "sitrooms", condition):next(function(row)
-            local targetPos = row and lia.data.decodeVector(row._pos)
-            if targetPos then
-                client:SetNW2Vector("previousSitroomPos", client:GetPos())
-                client:SetPos(targetPos)
-                client:notifyLocalized("sitroomTeleport", name)
-                lia.log.add(client, "sendToSitRoom", client:Name(), name)
-            end
-        end)
+        local targetPos = rooms[name]
+        if targetPos then
+            client:SetNW2Vector("previousSitroomPos", client:GetPos())
+            client:SetPos(targetPos)
+            client:notifyLocalized("sitroomTeleport", name)
+            lia.log.add(client, "sendToSitRoom", client:Name(), name)
+        end
     elseif action == 2 then
         local newName = net.ReadString()
         if newName ~= "" then
-            local newCondition = baseCondition .. " AND _name = " .. lia.db.convertDataType(newName)
-            lia.db.exists("sitrooms", newCondition):next(function(exists)
-                if exists then return end
-                local condition = baseCondition .. " AND _name = " .. lia.db.convertDataType(name)
-                lia.db.updateTable({
-                    _name = newName
-                }, nil, "sitrooms", condition)
+            if not rooms[newName] and rooms[name] then
+                rooms[newName] = rooms[name]
+                rooms[name] = nil
+                lia.data.set("sitrooms", {map = game.GetMap(), rooms = rooms})
 
                 client:notifyLocalized("sitroomRenamed")
-                lia.log.add(client, "sitRoomRenamed", string.format("Map: %s | Old: %s | New: %s", mapName, name, newName), L("logRenamedSitroom"))
-            end)
+                lia.log.add(client, "sitRoomRenamed", string.format("Map: %s | Old: %s | New: %s", game.GetMap(), name, newName), L("logRenamedSitroom"))
+            end
         end
     elseif action == 3 then
-        local condition = baseCondition .. " AND _name = " .. lia.db.convertDataType(name)
-        lia.db.updateTable({
-            _pos = lia.data.serialize(client:GetPos())
-        }, nil, "sitrooms", condition)
+        if rooms[name] then
+            rooms[name] = client:GetPos()
+            lia.data.set("sitrooms", {map = game.GetMap(), rooms = rooms})
 
-        client:notifyLocalized("sitroomRepositioned")
-        lia.log.add(client, "sitRoomRepositioned", string.format("Map: %s | Name: %s | New Position: %s", mapName, name, tostring(client:GetPos())), L("logRepositionedSitroom"))
+            client:notifyLocalized("sitroomRepositioned")
+            lia.log.add(client, "sitRoomRepositioned", string.format("Map: %s | Name: %s | New Position: %s", game.GetMap(), name, tostring(client:GetPos())), L("logRepositionedSitroom"))
+        end
     end
 end)


### PR DESCRIPTION
## Summary
- store faction spawns and sitrooms through `lia.data` with map info
- remove dedicated `lia_spawns`/`lia_sitrooms` tables
- ensure spawns and sitrooms entries track the current map

## Testing
- `git status --short`
- `apt-get update` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68853c8380b88327abfeadf046be6f7c