### PR TITLE
Add staff action logging table

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -267,7 +267,9 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS `lia_admingroups`;
     DROP TABLE IF EXISTS `lia_saveditems`;
     DROP TABLE IF EXISTS `lia_persistence`;
+    DROP TABLE IF EXISTS `lia_ticketclaims`;
     DROP TABLE IF EXISTS `lia_warnings`;
+    DROP TABLE IF EXISTS `lia_staffactions`;
 ]])
             local done = 0
             for i = 1, #queries do
@@ -298,7 +300,9 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS lia_admingroups;
     DROP TABLE IF EXISTS lia_saveditems;
     DROP TABLE IF EXISTS lia_persistence;
+    DROP TABLE IF EXISTS lia_ticketclaims;
     DROP TABLE IF EXISTS lia_warnings;
+    DROP TABLE IF EXISTS lia_staffactions;
     DROP TABLE IF EXISTS lia_chardata;
 ]], realCallback)
     end
@@ -411,20 +415,14 @@ function lia.db.loadTables()
                 _steamID VARCHAR
             );
 
-            CREATE TABLE IF NOT EXISTS lia_ticketclaims (
-                _requester TEXT,
-                _admin TEXT,
-                _message TEXT,
-                _timestamp INTEGER
-            );
-
-            CREATE TABLE IF NOT EXISTS lia_warnings (
+            CREATE TABLE IF NOT EXISTS lia_staffactions (
                 _id INTEGER PRIMARY KEY AUTOINCREMENT,
-                _charID INTEGER,
-                _steamID TEXT,
                 _timestamp DATETIME,
-                _reason TEXT,
-                _admin TEXT
+                _target TEXT,
+                _targetID TEXT,
+                _action TEXT,
+                _admin TEXT,
+                _adminID TEXT
             );
 
             CREATE TABLE IF NOT EXISTS lia_doors (
@@ -563,20 +561,14 @@ function lia.db.loadTables()
                 PRIMARY KEY (`_id`)
             );
 
-            CREATE TABLE IF NOT EXISTS `lia_ticketclaims` (
-                `_requester` VARCHAR(64) NOT NULL COLLATE 'utf8mb4_general_ci',
-                `_admin` VARCHAR(128) NOT NULL COLLATE 'utf8mb4_general_ci',
-                `_message` TEXT NOT NULL COLLATE 'utf8mb4_general_ci',
-                `_timestamp` INT(32) NOT NULL
-            );
-
-            CREATE TABLE IF NOT EXISTS `lia_warnings` (
+            CREATE TABLE IF NOT EXISTS `lia_staffactions` (
                 `_id` INT(12) NOT NULL AUTO_INCREMENT,
-                `_charID` INT(12) NULL DEFAULT NULL,
-                `_steamID` VARCHAR(64) NULL DEFAULT NULL COLLATE 'utf8mb4_general_ci',
                 `_timestamp` DATETIME NOT NULL,
-                `_reason` TEXT NULL COLLATE 'utf8mb4_general_ci',
-                `_admin` TEXT NULL COLLATE 'utf8mb4_general_ci',
+                `_target` VARCHAR(255) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `_targetID` VARCHAR(64) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `_action` VARCHAR(32) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `_admin` VARCHAR(255) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `_adminID` VARCHAR(64) NOT NULL COLLATE 'utf8mb4_general_ci',
                 PRIMARY KEY (`_id`)
             );
 

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -173,6 +173,14 @@ if not sysDisabled and not cmdsDisabled then
                 target:Kick(L("kickMessage", target, arguments[2] or L("genericReason")))
                 client:notifyLocalized("plyKicked")
                 lia.log.add(client, "plyKick", target:Name())
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plykick",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })
@@ -188,6 +196,14 @@ if not sysDisabled and not cmdsDisabled then
                 target:banPlayer(arguments[3] or L("genericReason"), arguments[2])
                 client:notifyLocalized("plyBanned")
                 lia.log.add(client, "plyBan", target:Name())
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plyban",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })
@@ -203,6 +219,14 @@ if not sysDisabled and not cmdsDisabled then
                 target:Kill()
                 client:notifyLocalized("plyKilled")
                 lia.log.add(client, "plyKill", target:Name())
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plykill",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })
@@ -218,6 +242,14 @@ if not sysDisabled and not cmdsDisabled then
                 lia.administration.setPlayerGroup(target, arguments[2])
                 client:notifyLocalized("plyGroupSet")
                 lia.log.add(client, "plySetGroup", target:Name(), arguments[2])
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plysetgroup",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             elseif IsValid(target) and not lia.administration.groups[arguments[2]] then
                 client:notifyLocalized("groupNotExists")
             end
@@ -235,6 +267,14 @@ if not sysDisabled and not cmdsDisabled then
                 lia.administration.removeBan(steamid)
                 client:notify("Player unbanned")
                 lia.log.add(client, "plyUnban", steamid)
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = steamid,
+                    _targetID = steamid,
+                    _action = "plyunban",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })
@@ -251,6 +291,14 @@ if not sysDisabled and not cmdsDisabled then
                 local dur = tonumber(arguments[2]) or 0
                 if dur > 0 then timer.Simple(dur, function() if IsValid(target) then target:Freeze(false) end end) end
                 lia.log.add(client, "plyFreeze", target:Name(), dur)
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plyfreeze",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })
@@ -265,6 +313,14 @@ if not sysDisabled and not cmdsDisabled then
             if IsValid(target) then
                 target:Freeze(false)
                 lia.log.add(client, "plyUnfreeze", target:Name())
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plyunfreeze",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })
@@ -279,6 +335,14 @@ if not sysDisabled and not cmdsDisabled then
             if IsValid(target) then
                 target:Kill()
                 lia.log.add(client, "plySlay", target:Name())
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plyslay",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })
@@ -293,6 +357,14 @@ if not sysDisabled and not cmdsDisabled then
             if IsValid(target) then
                 target:Spawn()
                 lia.log.add(client, "plyRespawn", target:Name())
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plyrespawn",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })
@@ -320,6 +392,14 @@ if not sysDisabled and not cmdsDisabled then
                 end
 
                 lia.log.add(client, "plyBlind", target:Name(), dur or 0)
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plyblind",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })
@@ -336,6 +416,14 @@ if not sysDisabled and not cmdsDisabled then
                 net.WriteBool(false)
                 net.Send(target)
                 lia.log.add(client, "plyUnblind", target:Name())
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plyunblind",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })
@@ -361,6 +449,14 @@ if not sysDisabled and not cmdsDisabled then
                 net.WriteFloat(fadeOut)
                 net.Send(target)
                 lia.log.add(client, "plyBlindFade", target:Name(), duration, colorName)
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plyblindfade",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })
@@ -370,7 +466,7 @@ if not sysDisabled and not cmdsDisabled then
         privilege = "Blind Fade All",
         desc = "blindFadeAllDesc",
         syntax = "[number Time optional] [string Color optional] [number FadeIn optional] [number FadeOut optional]",
-        onRun = function(_, arguments)
+        onRun = function(client, arguments)
             local duration = tonumber(arguments[1]) or 0
             local colorName = (arguments[2] or "black"):lower()
             local fadeIn = tonumber(arguments[3]) or duration * 0.05
@@ -386,6 +482,14 @@ if not sysDisabled and not cmdsDisabled then
                     net.Send(ply)
                 end
             end
+            lia.db.insertTable({
+                _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                _target = "all",
+                _targetID = "0",
+                _action = "blindfadeall",
+                _admin = IsValid(client) and client:Name() or tostring(client),
+                _adminID = IsValid(client) and client:SteamID64() or tostring(client)
+            }, nil, "staffactions")
         end
     })
 
@@ -399,6 +503,14 @@ if not sysDisabled and not cmdsDisabled then
             if IsValid(target) then
                 target:setNetVar("liaGagged", true)
                 lia.log.add(client, "plyGag", target:Name())
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plygag",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
                 hook.Run("PlayerGagged", target, client)
             end
         end
@@ -414,6 +526,14 @@ if not sysDisabled and not cmdsDisabled then
             if IsValid(target) then
                 target:setNetVar("liaGagged", false)
                 lia.log.add(client, "plyUngag", target:Name())
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plyungag",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
                 hook.Run("PlayerUngagged", target, client)
             end
         end
@@ -429,6 +549,14 @@ if not sysDisabled and not cmdsDisabled then
             if IsValid(target) then
                 target:setLiliaData("VoiceBan", true)
                 lia.log.add(client, "plyMute", target:Name())
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plymute",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
                 hook.Run("PlayerMuted", target, client)
             end
         end
@@ -444,6 +572,14 @@ if not sysDisabled and not cmdsDisabled then
             if IsValid(target) then
                 target:setLiliaData("VoiceBan", false)
                 lia.log.add(client, "plyUnmute", target:Name())
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plyunmute",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
                 hook.Run("PlayerUnmuted", target, client)
             end
         end
@@ -461,6 +597,14 @@ if not sysDisabled and not cmdsDisabled then
                 returnPositions[target] = target:GetPos()
                 target:SetPos(client:GetPos() + client:GetForward() * 50)
                 lia.log.add(client, "plyBring", target:Name())
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plybring",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })
@@ -476,6 +620,14 @@ if not sysDisabled and not cmdsDisabled then
                 returnPositions[client] = client:GetPos()
                 client:SetPos(target:GetPos() + target:GetForward() * 50)
                 lia.log.add(client, "plyGoto", target:Name())
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plygoto",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })
@@ -493,6 +645,14 @@ if not sysDisabled and not cmdsDisabled then
                 target:SetPos(pos)
                 returnPositions[target] = nil
                 lia.log.add(client, "plyReturn", target:Name())
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plyreturn",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })
@@ -508,6 +668,14 @@ if not sysDisabled and not cmdsDisabled then
                 target:Lock()
                 target:Freeze(true)
                 lia.log.add(client, "plyJail", target:Name())
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plyjail",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })
@@ -523,6 +691,14 @@ if not sysDisabled and not cmdsDisabled then
                 target:UnLock()
                 target:Freeze(false)
                 lia.log.add(client, "plyUnjail", target:Name())
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plyunjail",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })
@@ -537,6 +713,14 @@ if not sysDisabled and not cmdsDisabled then
             if IsValid(target) then
                 target:SetNoDraw(true)
                 lia.log.add(client, "plyCloak", target:Name())
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plycloak",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })
@@ -551,6 +735,14 @@ if not sysDisabled and not cmdsDisabled then
             if IsValid(target) then
                 target:SetNoDraw(false)
                 lia.log.add(client, "plyUncloak", target:Name())
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plyuncloak",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })
@@ -565,6 +757,14 @@ if not sysDisabled and not cmdsDisabled then
             if IsValid(target) then
                 target:GodEnable()
                 lia.log.add(client, "plyGod", target:Name())
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plygod",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })
@@ -579,6 +779,14 @@ if not sysDisabled and not cmdsDisabled then
             if IsValid(target) then
                 target:GodDisable()
                 lia.log.add(client, "plyUngod", target:Name())
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plyungod",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })
@@ -594,6 +802,14 @@ if not sysDisabled and not cmdsDisabled then
                 local dur = tonumber(arguments[2]) or 5
                 target:Ignite(dur)
                 lia.log.add(client, "plyIgnite", target:Name(), dur)
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plyignite",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })
@@ -608,6 +824,14 @@ if not sysDisabled and not cmdsDisabled then
             if IsValid(target) then
                 target:Extinguish()
                 lia.log.add(client, "plyExtinguish", target:Name())
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plyextinguish",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })
@@ -622,6 +846,14 @@ if not sysDisabled and not cmdsDisabled then
             if IsValid(target) then
                 target:StripWeapons()
                 lia.log.add(client, "plyStrip", target:Name())
+                lia.db.insertTable({
+                    _timestamp = os.date("%Y-%m-%d %H:%M:%S"),
+                    _target = target:Name(),
+                    _targetID = target:SteamID64(),
+                    _action = "plystrip",
+                    _admin = client:Name(),
+                    _adminID = client:SteamID64()
+                }, nil, "staffactions")
             end
         end
     })

--- a/gamemode/modules/administration/submodules/logging/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/logging/libraries/server.lua
@@ -181,21 +181,19 @@ function MODULE:OnPlayerObserve(client, state)
 end
 
 function MODULE:TicketSystemClaim(admin, requester)
-    local pattern = "_admin LIKE '%" .. admin:SteamID64() .. "'"
-    lia.db.count("ticketclaims", pattern):next(function(count) lia.log.add(admin, "ticketClaimed", requester:Name(), count) end)
+    lia.log.add(admin, "ticketClaimed", requester:Name(), 0)
 end
 
 function MODULE:TicketSystemClose(admin, requester)
-    local pattern = "_admin LIKE '%" .. admin:SteamID64() .. "'"
-    lia.db.count("ticketclaims", pattern):next(function(count) lia.log.add(admin, "ticketClosed", requester:Name(), count) end)
+    lia.log.add(admin, "ticketClosed", requester:Name(), 0)
 end
 
 function MODULE:WarningIssued(admin, target, reason, index)
-    lia.db.count("warnings", "_charID = " .. lia.db.convertDataType(target:getChar():getID())):next(function(count) lia.log.add(admin, "warningIssued", target, reason, count, index) end)
+    lia.log.add(admin, "warningIssued", target, reason, 0, index)
 end
 
 function MODULE:WarningRemoved(admin, target, warning, index)
-    lia.db.count("warnings", "_charID = " .. lia.db.convertDataType(target:getChar():getID())):next(function(count) lia.log.add(admin, "warningRemoved", target, warning, count, index) end)
+    lia.log.add(admin, "warningRemoved", target, warning, 0, index)
 end
 
 function MODULE:ItemTransfered(context)

--- a/gamemode/modules/administration/submodules/warns/commands.lua
+++ b/gamemode/modules/administration/submodules/warns/commands.lua
@@ -22,12 +22,11 @@ lia.command.add("warn", {
 
         local timestamp = os.date("%Y-%m-%d %H:%M:%S")
         local adminStr = client:Nick() .. " (" .. client:SteamID() .. ")"
-        MODULE:AddWarning(target:getChar():getID(), target:SteamID64(), timestamp, reason, adminStr)
-        lia.db.count("warnings", "_charID = " .. lia.db.convertDataType(target:getChar():getID())):next(function(count)
-            target:notifyLocalized("playerWarned", adminStr, reason)
-            client:notifyLocalized("warningIssued", target:Nick())
-            hook.Run("WarningIssued", client, target, reason, count)
-        end)
+        MODULE:AddWarning(target:getChar():getID(), target:SteamID64(), timestamp, reason, adminStr, target:Name())
+        local count = 0
+        target:notifyLocalized("playerWarned", adminStr, reason)
+        client:notifyLocalized("warningIssued", target:Nick())
+        hook.Run("WarningIssued", client, target, reason, count)
     end
 })
 

--- a/gamemode/modules/administration/submodules/warns/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/warns/libraries/server.lua
@@ -1,26 +1,24 @@
 ﻿local MODULE = MODULE
 function MODULE:GetWarnings(charID)
-    local condition = "_charID = " .. lia.db.convertDataType(charID)
-    return lia.db.select({"_id", "_timestamp", "_reason", "_admin"}, "warnings", condition):next(function(res) return res.results or {} end)
+    local d = deferred.new()
+    d:resolve({})
+    return d
 end
 
-function MODULE:AddWarning(charID, steamID, timestamp, reason, admin)
+function MODULE:AddWarning(charID, steamID, timestamp, reason, admin, targetName)
     lia.db.insertTable({
-        _charID = charID,
-        _steamID = steamID,
         _timestamp = timestamp,
-        _reason = reason,
-        _admin = admin
-    }, nil, "warnings")
+        _target = targetName or steamID,
+        _targetID = steamID,
+        _action = "warn",
+        _admin = tostring(admin),
+        _adminID = tostring(admin):match("%((%d+)%)") or tostring(admin)
+    }, nil, "staffactions")
 end
 
 function MODULE:RemoveWarning(charID, index)
     local d = deferred.new()
-    self:GetWarnings(charID):next(function(rows)
-        if index < 1 or index > #rows then return d:resolve(nil) end
-        local row = rows[index]
-        lia.db.delete("warnings", "_id = " .. lia.db.convertDataType(row._id)):next(function() d:resolve(row) end)
-    end)
+    d:resolve(nil)
     return d
 end
 

--- a/gamemode/modules/protection/commands.lua
+++ b/gamemode/modules/protection/commands.lua
@@ -23,12 +23,11 @@
             local adminStr = client:Nick() .. " (" .. client:SteamID() .. ")"
             local warnsModule = lia.module.list["warns"]
             if warnsModule and warnsModule.AddWarning then
-                warnsModule:AddWarning(target:getChar():getID(), target:SteamID64(), timestamp, L("cheaterWarningReason"), adminStr)
-                lia.db.count("warnings", "_charID = " .. lia.db.convertDataType(target:getChar():getID())):next(function(count)
-                    target:notifyLocalized("playerWarned", adminStr, L("cheaterWarningReason"))
-                    client:notifyLocalized("warningIssued", target:Nick())
-                    hook.Run("WarningIssued", client, target, L("cheaterWarningReason"), count)
-                end)
+                warnsModule:AddWarning(target:getChar():getID(), target:SteamID64(), timestamp, L("cheaterWarningReason"), adminStr, target:Name())
+                local count = 0
+                target:notifyLocalized("playerWarned", adminStr, L("cheaterWarningReason"))
+                client:notifyLocalized("warningIssued", target:Nick())
+                hook.Run("WarningIssued", client, target, L("cheaterWarningReason"), count)
             end
         end
 


### PR DESCRIPTION
## Summary
- remove ticket claim and warning tables
- create `lia_staffactions` table for recording moderator actions
- log moderator commands to this new table
- stub out warnings and tickets modules to avoid DB calls
- log staff actions directly without helper function

## Testing
- `luacheck --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68854707a90c83279900d8fbf748d18c