### PR TITLE
Refactor to lia.db

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -231,7 +231,7 @@ if SERVER then
             if q:error() then return nil end
             return q:getData() and q:getData()[1] or nil
         else
-            local data = sql.Query(query)
+            local data = lia.db.querySync(query)
             return istable(data) and data[1] or nil
         end
     end

--- a/gamemode/core/libraries/character.lua
+++ b/gamemode/core/libraries/character.lua
@@ -438,7 +438,7 @@ lia.char.registerVar("banned", {
 function lia.char.getCharData(charID, key)
     local charIDsafe = tonumber(charID)
     if not charIDsafe then return end
-    local results = sql.Query("SELECT key, value FROM lia_chardata WHERE charID = " .. charIDsafe)
+    local results = lia.db.querySync("SELECT key, value FROM lia_chardata WHERE charID = " .. charIDsafe)
     local data = {}
     if istable(results) then
         for _, row in ipairs(results) do
@@ -455,13 +455,13 @@ function lia.char.getCharDataRaw(charID, key)
     local charIDsafe = tonumber(charID)
     if not charIDsafe then return end
     if key then
-        local row = sql.Query("SELECT value FROM lia_chardata WHERE charID = " .. charIDsafe .. " AND key = '" .. lia.db.escape(key) .. "'")
+        local row = lia.db.querySync("SELECT value FROM lia_chardata WHERE charID = " .. charIDsafe .. " AND key = '" .. lia.db.escape(key) .. "'")
         if not row or not row[1] then return false end
         local decoded = pon.decode(row[1].value)
         return decoded[1]
     end
 
-    local results = sql.Query("SELECT key, value FROM lia_chardata WHERE charID = " .. charIDsafe)
+    local results = lia.db.querySync("SELECT key, value FROM lia_chardata WHERE charID = " .. charIDsafe)
     local data = {}
     if istable(results) then
         for _, r in ipairs(results) do

--- a/gamemode/core/libraries/compatibility/sam.lua
+++ b/gamemode/core/libraries/compatibility/sam.lua
@@ -163,7 +163,8 @@ lia.command.add("playtime", {
     desc = "playtimeDesc",
     onRun = function(client)
         local steamID = client:SteamID64()
-        local result = sql.QueryRow("SELECT play_time FROM sam_players WHERE steamid = " .. SQLStr(steamID) .. ";")
+        local rows = lia.db.querySync("SELECT play_time FROM sam_players WHERE steamid = " .. lia.db.convertDataType(steamID) .. ";")
+        local result = rows and rows[1]
         if result then
             local secs = tonumber(result.play_time) or 0
             local h = math.floor(secs / 3600)

--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -953,6 +953,29 @@ function lia.db.escapeIdentifier(id)
     return "`" .. tostring(id):gsub("`", "``") .. "`"
 end
 
+--[[
+    Executes a database query synchronously and returns the raw results.
+    This replaces direct usage of the `sql` library outside of this module so
+    other code can rely solely on lia.db for data access.
+
+    Returns a table with the query results on success or nil on failure.
+]]
+function lia.db.querySync(query)
+    if lia.db.module == "mysqloo" and mysqloo and lia.db.getObject then
+        local db = lia.db.getObject()
+        if not db then return nil end
+        local q = db:query(query)
+        q:start()
+        q:wait()
+        if q:error() then return nil end
+        return q:getData()
+    else
+        local data = sql.Query(query)
+        if data == false then return nil end
+        return data
+    end
+end
+
 function lia.db.upsert(value, dbTable)
     local query
     if lia.db.object then

--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -156,7 +156,7 @@ if SERVER then
                 end
             end
         else
-            local data = sql.Query(query)
+            local data = lia.db.querySync(query)
             if istable(data) then
                 for _, row in ipairs(data) do
                     t[row.steamID] = true


### PR DESCRIPTION
## Summary
- expose `lia.db.querySync` to run synchronous queries
- use `lia.db` instead of `sql.*` in administrative and character helpers
- use `lia.db` to fetch SAM playtime

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688552e14384832780534ff5d81cc301