### PR TITLE
Rename getRecognizedAs variable

### DIFF
--- a/gamemode/core/libraries/character.lua
+++ b/gamemode/core/libraries/character.lua
@@ -413,7 +413,7 @@ lia.char.registerVar("recognition", {
     noDisplay = true
 })
 
-lia.char.registerVar("RecognizedAs", {
+lia.char.registerVar("FakeName", {
     field = "recognized_as",
     fieldType = "text",
     default = {},
@@ -523,7 +523,7 @@ if SERVER then
             faction = data.faction or L("unknown"),
             money = data.money,
             recognition = data.recognition or "",
-            recognized_as = ""
+            recognized_as = {}
         }, function(_, charID)
             local client
             for _, v in player.Iterator() do

--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -359,7 +359,7 @@ function lia.db.loadTables()
                 faction VARCHAR,
                 class INTEGER,
                 recognition TEXT NOT NULL DEFAULT '',
-                recognized_as TEXT NOT NULL DEFAULT ''
+                recognized_as TEXT NOT NULL DEFAULT '[]'
             );
 
             CREATE TABLE IF NOT EXISTS lia_inventories (
@@ -505,7 +505,7 @@ function lia.db.loadTables()
                 `faction` VARCHAR(255) DEFAULT NULL COLLATE 'utf8mb4_general_ci',
                 `class` INT(12) NULL DEFAULT NULL,
                 `recognition` TEXT NOT NULL COLLATE 'utf8mb4_general_ci',
-                `recognized_as` TEXT NOT NULL COLLATE 'utf8mb4_general_ci',
+                `recognized_as` TEXT NOT NULL DEFAULT '[]' COLLATE 'utf8mb4_general_ci',
                 PRIMARY KEY (`id`)
             );
 

--- a/gamemode/core/meta/character.lua
+++ b/gamemode/core/meta/character.lua
@@ -41,7 +41,7 @@ function characterMeta:getDisplayedName(client)
     if self:getPlayer() == client then return self:getName() end
     local characterID = self:getID()
     if ourCharacter:doesRecognize(characterID) then return self:getName() end
-    local myReg = ourCharacter:getRecognizedAs()
+    local myReg = ourCharacter:getFakeName()
     if ourCharacter:doesFakeRecognize(characterID) and myReg[characterID] then return myReg[characterID] end
     return L("unknown")
 end
@@ -202,10 +202,10 @@ if SERVER then
         end
 
         local recognized = self:getRecognition()
-        local nameList = self:getRecognizedAs()
+        local nameList = self:getFakeName()
         if name ~= nil then
             nameList[id] = name
-            self:setRecognizedAs(nameList)
+            self:setFakeName(nameList)
         else
             self:setRecognition(recognized .. "," .. id .. ",")
         end

--- a/gamemode/modules/recognition/libraries/client.lua
+++ b/gamemode/modules/recognition/libraries/client.lua
@@ -24,7 +24,7 @@ function MODULE:GetDisplayedName(client, chatType)
     local character = client:getChar()
     local ourCharacter = lp:getChar()
     if not character or not ourCharacter then return L("unknown") end
-    local myReg = ourCharacter:getRecognizedAs()
+    local myReg = ourCharacter:getFakeName()
     local characterID = character:getID()
     if not ourCharacter:doesRecognize(characterID) then
         if ourCharacter:doesFakeRecognize(characterID) and myReg[characterID] then return myReg[characterID] end

--- a/gamemode/modules/recognition/libraries/shared.lua
+++ b/gamemode/modules/recognition/libraries/shared.lua
@@ -30,7 +30,7 @@ end
 
 function MODULE:isCharFakeRecognized(character, id)
     local other = lia.char.loaded[id]
-    local CharNameList = character:getRecognizedAs()
+    local CharNameList = character:getFakeName()
     local clientName = CharNameList[other:getID()]
     return lia.config.get("FakeNamesEnabled", false) and isFakeNameExistant(clientName, CharNameList)
 end


### PR DESCRIPTION
## Summary
- rename `RecognizedAs` charvar to `FakeName`
- store fake names in JSON rather than empty string
- use `setFakeName` when assigning fake names

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68854df0e5f88327b67b14b0919cc36c