### PR TITLE
Move netcall definitions to netcalls

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -397,8 +397,5 @@ if SERVER then
         net.Send(client)
     end)
 else
-    net.Receive("updateAdminGroups", function()
-        local data = net.ReadTable() or {}
-        lia.administration.groups = data
-    end)
+    -- moved to netcalls
 end

--- a/gamemode/core/libraries/workshop.lua
+++ b/gamemode/core/libraries/workshop.lua
@@ -61,10 +61,7 @@ if SERVER then
         end)
     end)
 
-    net.Receive("WorkshopDownloader_Request", function(_, client)
-        if not lia.config.get("AutoDownloadWorkshop", true) then return end
-        lia.workshop.send(client)
-    end)
+    -- netcall moved to netcalls
 
     lia.workshop.AddWorkshop("3527535922")
     resource.AddWorkshop = lia.workshop.AddWorkshop
@@ -193,6 +190,7 @@ else
             end)
         end
     end
+    lia.workshop.start = start
 
     local function buildQueue(all)
         table.Empty(queue)
@@ -200,10 +198,12 @@ else
             if id == FORCE_ID or all then queue[id] = true end
         end
     end
+    lia.workshop.buildQueue = buildQueue
 
     local function refresh(tbl)
         if tbl then lia.workshop.serverIds = tbl end
     end
+    lia.workshop.refresh = refresh
 
     function lia.workshop.checkPrompt()
         local opt = lia.option.get("autoDownloadWorkshop")
@@ -244,16 +244,7 @@ else
         end
     end
 
-    net.Receive("WorkshopDownloader_Start", function()
-        refresh(net.ReadTable())
-        buildQueue(true)
-        start()
-    end)
-
-    net.Receive("WorkshopDownloader_Info", function()
-        refresh(net.ReadTable())
-        lia.workshop.checkPrompt()
-    end)
+    -- netcalls moved to netcalls
 
     hook.Add("InitializedOptions", "liaWorkshopPromptCheck", function() timer.Simple(0, lia.workshop.checkPrompt) end)
     concommand.Add("workshop_force_redownload", function()

--- a/gamemode/core/netcalls/client.lua
+++ b/gamemode/core/netcalls/client.lua
@@ -910,3 +910,21 @@ net.Receive("liaStorageOpen", function()
     hook.Run("StorageOpen", isCar and carInv or entity, isCar)
 end)
 
+-- from libraries/admin.lua
+net.Receive("updateAdminGroups", function()
+    local data = net.ReadTable() or {}
+    lia.administration.groups = data
+end)
+
+-- from libraries/workshop.lua
+net.Receive("WorkshopDownloader_Start", function()
+    lia.workshop.refresh(net.ReadTable())
+    lia.workshop.buildQueue(true)
+    lia.workshop.start()
+end)
+
+net.Receive("WorkshopDownloader_Info", function()
+    lia.workshop.refresh(net.ReadTable())
+    lia.workshop.checkPrompt()
+end)
+

--- a/gamemode/core/netcalls/server.lua
+++ b/gamemode/core/netcalls/server.lua
@@ -367,3 +367,9 @@ net.Receive("trunkInitStorage", function()
     end
 end)
 
+-- from libraries/workshop.lua
+net.Receive("WorkshopDownloader_Request", function(_, client)
+    if not lia.config.get("AutoDownloadWorkshop", true) then return end
+    lia.workshop.send(client)
+end)
+


### PR DESCRIPTION
## Summary
- move scattered `net.Receive` calls from `core` libs into dedicated netcall files
- expose workshop helper functions so moved netcalls still work
- mark original spots with comments

## Testing
- `luac` not available so Lua syntax could not be checked

------
https://chatgpt.com/codex/tasks/task_e_68855cc3271c83278b823ec0b2764183