### PR TITLE
Remove obsolete admin disable checks

### DIFF
--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -696,7 +696,6 @@ else
 end
 
 hook.Add("CAMI.OnUsergroupRegistered", "liaSyncAdminGroupAdd", function(g)
-    if lia.administration.isDisabled() then return end
     lia.administration.groups[g.Name] = buildDefaultTable(g.Name)
     if SERVER then
         ensureCAMIGroup(g.Name, g.Inherits or "user")
@@ -705,7 +704,6 @@ hook.Add("CAMI.OnUsergroupRegistered", "liaSyncAdminGroupAdd", function(g)
 end)
 
 hook.Add("CAMI.OnUsergroupUnregistered", "liaSyncAdminGroupRemove", function(g)
-    if lia.administration.isDisabled() then return end
     lia.administration.groups[g.Name] = nil
     if SERVER then
         dropCAMIGroup(g.Name)
@@ -714,7 +712,7 @@ hook.Add("CAMI.OnUsergroupUnregistered", "liaSyncAdminGroupRemove", function(g)
 end)
 
 hook.Add("CAMI.OnPrivilegeRegistered", "liaSyncAdminPrivilegeAdd", function(pv)
-    if lia.administration.isDisabled() or not pv or not pv.Name then return end
+    if not pv or not pv.Name then return end
     lia.administration.privileges[pv.Name] = {
         Name = pv.Name,
         MinAccess = pv.MinAccess or "user"
@@ -728,7 +726,7 @@ hook.Add("CAMI.OnPrivilegeRegistered", "liaSyncAdminPrivilegeAdd", function(pv)
 end)
 
 hook.Add("CAMI.OnPrivilegeUnregistered", "liaSyncAdminPrivilegeRemove", function(pv)
-    if lia.administration.isDisabled() or not pv or not pv.Name then return end
+    if not pv or not pv.Name then return end
     lia.administration.privileges[pv.Name] = nil
     for _, p in pairs(lia.administration.groups) do
         p[pv.Name] = nil
@@ -738,7 +736,7 @@ hook.Add("CAMI.OnPrivilegeUnregistered", "liaSyncAdminPrivilegeRemove", function
 end)
 
 hook.Add("CAMI.PlayerUsergroupChanged", "liaSyncAdminPlayerGroup", function(ply, old, new)
-    if lia.administration.isDisabled() or not IsValid(ply) then return end
+    if not IsValid(ply) then return end
     if not SERVER then return end
     lia.db.query(string.format("UPDATE lia_players SET userGroup = '%s' WHERE steamID = %s", lia.db.escape(new), ply:SteamID64()))
 end)


### PR DESCRIPTION
## Summary
- remove `lia.administration.isDisabled` helper and its calls

## Testing
- `grep -R "isDisabled" -n`

------
https://chatgpt.com/codex/tasks/task_e_68856a27c7ec83279c125ce188194c7c