### PR TITLE
Fix comparison in admin ban check

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -223,11 +223,17 @@ if SERVER then
 
     function lia.administration.isBanned(steamid)
         local row = fetchBanRow(steamid)
-        if not row or tonumber(row.banStart or 0) <= 0 then return false end
+        if not row then return false end
+
+        local start = tonumber(row.banStart) or 0
+        if start <= 0 then return false end
+
+        local duration = tonumber(row.banDuration) or 0
+
         return {
             reason = row.reason,
-            start = tonumber(row.banStart) or 0,
-            duration = tonumber(row.banDuration) or 0,
+            start = start,
+            duration = duration,
         }
     end
 


### PR DESCRIPTION
## Summary
- fix isBanned comparison when `banStart` or `banDuration` are empty strings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68856b64240083278b408f05976b5d58