### PR TITLE
Fix false banned status on new characters

### DIFF
--- a/gamemode/core/derma/mainmenu/character.lua
+++ b/gamemode/core/derma/mainmenu/character.lua
@@ -486,7 +486,7 @@ function PANEL:createSelectedCharacterInfoPanel(character)
     local clientChar = LocalPlayer().getChar and LocalPlayer():getChar()
     local selectText = L("selectCharacter")
     local banned = character:getBanned()
-    local isBanned = banned and banned ~= 0 and banned ~= "0"
+    local isBanned = banned and ((isnumber(banned) and banned > os.time()) or banned == 1)
     if clientChar and character:getID() == clientChar:getID() then
         selectText = L("alreadyUsingCharacter")
     elseif isBanned then

--- a/gamemode/core/libraries/character.lua
+++ b/gamemode/core/libraries/character.lua
@@ -430,7 +430,8 @@ lia.char.registerVar("lastPos", {
 
 lia.char.registerVar("banned", {
     field = "_banned",
-    fieldType = "text",
+    fieldType = "integer",
+    default = 0,
     isLocal = true,
     noDisplay = true
 })

--- a/gamemode/modules/mainmenu/libraries/server.lua
+++ b/gamemode/modules/mainmenu/libraries/server.lua
@@ -36,14 +36,18 @@ end
 
 function MODULE:CanPlayerUseChar(_, character)
     local banned = character:getBanned()
-    if banned and isnumber(banned) and banned > os.time() then return false, L("bannedCharacter") end
+    if banned and ((isnumber(banned) and banned > os.time()) or banned == 1) then
+        return false, L("bannedCharacter")
+    end
     return true
 end
 
 function MODULE:CanPlayerSwitchChar(client, character, newCharacter)
     local banned = character:getBanned()
     if character:getID() == newCharacter:getID() then return false, L("alreadyUsingCharacter") end
-    if banned and isnumber(banned) and banned > os.time() then return false, L("bannedCharacter") end
+    if banned and ((isnumber(banned) and banned > os.time()) or banned == 1) then
+        return false, L("bannedCharacter")
+    end
     if not client:Alive() then return false, L("youAreDead") end
     if client:hasRagdoll() then return false, L("youAreRagdolled") end
     if client:hasValidVehicle() then return false, L("cannotSwitchInVehicle") end


### PR DESCRIPTION
## Summary
- ensure character banned flag defaults to `0`
- handle permanent bans server-side
- respect correct ban status in the character menu

## Testing
- `apt-get update` *(fails: repository signature verification due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_68856b628710832797b68b35ad1648ce