### PR TITLE
Register staff faction via helper

### DIFF
--- a/gamemode/core/libraries/classes.lua
+++ b/gamemode/core/libraries/classes.lua
@@ -1,5 +1,31 @@
 ﻿lia.class = lia.class or {}
 lia.class.list = lia.class.list or {}
+
+function lia.class.register(uniqueID, data)
+    assert(isstring(uniqueID), "uniqueID must be a string")
+    data = data or {}
+    for _, class in ipairs(lia.class.list) do
+        if class.uniqueID == uniqueID then return end
+    end
+
+    local index = #lia.class.list + 1
+    local CLASS = table.Copy(data)
+    CLASS.index = index
+    CLASS.uniqueID = uniqueID
+    CLASS.name = L(CLASS.name or "unknown")
+    CLASS.desc = L(CLASS.desc or "noDesc")
+    CLASS.limit = CLASS.limit or 0
+
+    if not CLASS.faction or not team.Valid(CLASS.faction) then
+        lia.error("Class '" .. uniqueID .. "' does not have a valid faction!\n")
+        return
+    end
+
+    if not CLASS.OnCanBe then CLASS.OnCanBe = function() return true end end
+
+    lia.class.list[index] = CLASS
+    return CLASS
+end
 function lia.class.loadFromDir(directory)
     for _, v in ipairs(file.Find(directory .. "/*.lua", "LUA")) do
         local index = #lia.class.list + 1

--- a/gamemode/core/libraries/factions.lua
+++ b/gamemode/core/libraries/factions.lua
@@ -2,6 +2,53 @@
 lia.faction.indices = lia.faction.indices or {}
 lia.faction.teams = lia.faction.teams or {}
 local DefaultModels = {"models/player/barney.mdl", "models/player/alyx.mdl", "models/player/breen.mdl", "models/player/p2_chell.mdl"}
+
+function lia.faction.register(uniqueID, data)
+    assert(isstring(uniqueID), "uniqueID must be a string")
+    data = data or {}
+    local faction = lia.faction.teams[uniqueID] or {
+        index = table.Count(lia.faction.teams) + 1,
+        isDefault = data.isDefault ~= false
+    }
+
+    for k, v in pairs(data) do
+        faction[k] = v
+    end
+
+    if not faction.name then
+        faction.name = "unknown"
+        lia.error("Faction '" .. uniqueID .. "' is missing a name. You need to add a FACTION.name = \"Name\"\n")
+    end
+
+    if not faction.desc then
+        faction.desc = "noDesc"
+        lia.error("Faction '" .. uniqueID .. "' is missing a description. You need to add a FACTION.desc = \"Description\"\n")
+    end
+
+    faction.name = L(faction.name)
+    faction.desc = L(faction.desc)
+
+    if not faction.color then
+        faction.color = Color(150, 150, 150)
+        lia.error("Faction '" .. uniqueID .. "' is missing a color. You need to add FACTION.color = Color(1, 2, 3)\n")
+    end
+
+    team.SetUp(faction.index, faction.name or L("unknown"), faction.color or Color(125, 125, 125))
+    faction.models = faction.models or DefaultModels
+    faction.uniqueID = uniqueID
+
+    for _, modelData in pairs(faction.models) do
+        if isstring(modelData) then
+            util.PrecacheModel(modelData)
+        elseif istable(modelData) then
+            util.PrecacheModel(modelData[1])
+        end
+    end
+
+    lia.faction.indices[faction.index] = faction
+    lia.faction.teams[uniqueID] = faction
+    return faction
+end
 function lia.faction.loadFromDir(directory)
     for _, v in ipairs(file.Find(directory .. "/*.lua", "LUA")) do
         local niceName

--- a/gamemode/modules/administration/submodules/permissions/factions/staff.lua
+++ b/gamemode/modules/administration/submodules/permissions/factions/staff.lua
@@ -1,7 +1,0 @@
-﻿FACTION.name = "factionStaffName"
-FACTION.desc = "factionStaffDesc"
-FACTION.color = Color(255, 56, 252)
-FACTION.isDefault = false
-FACTION.models = {"models/Humans/Group02/male_07.mdl", "models/Humans/Group02/male_07.mdl", "models/Humans/Group02/male_07.mdl", "models/Humans/Group02/male_07.mdl", "models/Humans/Group02/male_07.mdl"}
-FACTION.weapons = {"weapon_physgun", "gmod_tool"}
-FactionStaff = FACTION.index

--- a/gamemode/modules/administration/submodules/permissions/module.lua
+++ b/gamemode/modules/administration/submodules/permissions/module.lua
@@ -120,3 +120,19 @@ MODULE.Privileges = {
         MinAccess = "superadmin",
     },
 }
+
+FACTION_STAFF = lia.faction.register("staff", {
+    name = "factionStaffName",
+    desc = "factionStaffDesc",
+    color = Color(255, 56, 252),
+    isDefault = false,
+    models = {
+        "models/Humans/Group02/male_07.mdl",
+        "models/Humans/Group02/male_07.mdl",
+        "models/Humans/Group02/male_07.mdl",
+        "models/Humans/Group02/male_07.mdl",
+        "models/Humans/Group02/male_07.mdl",
+    },
+    weapons = {"weapon_physgun", "gmod_tool"}
+})
+FactionStaff = FACTION_STAFF.index


### PR DESCRIPTION
## Summary
- remove the old staff faction definition file
- register the staff faction in the permissions module using `lia.faction.register`
- change variable to `FACTION_STAFF` for readability

## Testing
- `luacheck gamemode/core/libraries/factions.lua gamemode/core/libraries/classes.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68856e1d1f2c83278f9c116c42a960fd