### PR TITLE
Move logs and configuration to admin tab

### DIFF
--- a/gamemode/core/libraries/config.lua
+++ b/gamemode/core/libraries/config.lua
@@ -472,7 +472,7 @@ lia.config.add("DermaSkin", "Derma UI Skin", "Lilia Skin", function(_, newSkin) 
     options = CLIENT and getDermaSkins() or {"Lilia Skin"}
 })
 
-hook.Add("PopulateConfigurationButtons", "liaConfigPopulate", function(pages)
+hook.Add("liaAdminRegisterTab", "liaConfigPopulate", function(parent, tabs)
     local ConfigFormatting = {
         Int = function(key, name, config, parent)
             local container = vgui.Create("DPanel", parent)
@@ -891,9 +891,14 @@ hook.Add("PopulateConfigurationButtons", "liaConfigPopulate", function(pages)
     end
 
     if hook.Run("CanPlayerModifyConfig", LocalPlayer()) ~= false then
-        pages[#pages + 1] = {
-            name = "Configuration",
-            drawFunc = function(parent) buildConfiguration(parent) end
+        tabs["Configuration"] = {
+            icon = "icon16/wrench.png",
+            build = function(sheet)
+                local pnl = vgui.Create("DPanel", sheet)
+                pnl:Dock(FILL)
+                buildConfiguration(pnl)
+                return pnl
+            end
         }
     end
 end)

--- a/gamemode/modules/administration/submodules/logging/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/logging/libraries/client.lua
@@ -97,12 +97,16 @@ net.Receive("send_logs", function()
     if IsValid(receivedPanel) then OpenLogsUI(receivedPanel, categorizedLogs) end
 end)
 
-function MODULE:CreateMenuButtons(tabs)
-    if IsValid(LocalPlayer()) and LocalPlayer():hasPrivilege("Can See Logs") then
-        tabs[L("logs")] = function(panel)
-            receivedPanel = panel
+hook.Add("liaAdminRegisterTab", "liaLogsTab", function(parent, tabs)
+    if not (IsValid(LocalPlayer()) and LocalPlayer():hasPrivilege("Can See Logs")) then return end
+    tabs[L("logs")] = {
+        icon = "icon16/page_white_text.png",
+        build = function(sheet)
+            receivedPanel = vgui.Create("DPanel", sheet)
+            receivedPanel:Dock(FILL)
             net.Start("send_logs_request")
             net.SendToServer()
+            return receivedPanel
         end
-    end
-end
+    }
+end)


### PR DESCRIPTION
## Summary
- show logs viewer from the Admin tab instead of the F1 menu
- move configuration options under the Admin tab

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68857268c9d483278a2aafd966adb80c