### PR TITLE
Fix charlist banned status

### DIFF
--- a/gamemode/modules/administration/submodules/permissions/commands.lua
+++ b/gamemode/modules/administration/submodules/permissions/commands.lua
@@ -156,12 +156,22 @@ lia.command.add("charlist", {
                     lastUsedText = row.lastJoinTime
                 end
 
+                local bannedState = false
+                if isBanned then
+                    local num = tonumber(isBanned)
+                    if num then
+                        bannedState = num == 1 or num > os.time()
+                    else
+                        bannedState = tobool(isBanned)
+                    end
+                end
+
                 local entry = {
                     ID = row.id,
                     Name = row.name,
                     Desc = row.desc,
                     Faction = row.faction,
-                    Banned = isBanned and "Yes" or "No",
+                    Banned = bannedState and "Yes" or "No",
                     BanningAdminName = info.charBanInfo and info.charBanInfo.name or "",
                     BanningAdminSteamID = info.charBanInfo and info.charBanInfo.steamID or "",
                     BanningAdminRank = info.charBanInfo and info.charBanInfo.rank or "",


### PR DESCRIPTION
## Summary
- fix incorrect banned label in admin `charlist` command

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688575d42bac832789715c80b00470f0