### PR TITLE
Tie permission flags to player data

### DIFF
--- a/gamemode/core/hooks/client.lua
+++ b/gamemode/core/hooks/client.lua
@@ -445,7 +445,7 @@ end
 
 function GM:SpawnMenuOpen()
     local client = LocalPlayer()
-    if lia.config.get("SpawnMenuLimit", false) and not (client:getChar():hasFlags("pet") or client:isStaffOnDuty() or client:hasPrivilege("Can Spawn Props")) then return end
+    if lia.config.get("SpawnMenuLimit", false) and not (client:hasFlags("pet") or client:isStaffOnDuty() or client:hasPrivilege("Can Spawn Props")) then return end
     return true
 end
 

--- a/gamemode/core/libraries/flags.lua
+++ b/gamemode/core/libraries/flags.lua
@@ -10,13 +10,11 @@ end
 
 if SERVER then
     function lia.flag.onSpawn(client)
-        if client:getChar() then
-            local flags = client:getChar():getFlags()
-            for i = 1, #flags do
-                local flag = flags:sub(i, i)
-                local info = lia.flag.list[flag]
-                if info and info.callback then info.callback(client, true) end
-            end
+        local flags = client:getFlags()
+        for i = 1, #flags do
+            local flag = flags:sub(i, i)
+            local info = lia.flag.list[flag]
+            if info and info.callback then info.callback(client, true) end
         end
     end
 end
@@ -75,7 +73,7 @@ hook.Add("CreateInformationButtons", "liaInformationFlags", function(pages)
                     flagPanel:DockMargin(10, 5, 10, 0)
                     flagPanel:SetTall(height)
                     flagPanel.Paint = function(pnl, w, h)
-                        local hasFlag = client:getChar():hasFlags(flagName)
+                        local hasFlag = client:hasFlags(flagName)
                         derma.SkinHook("Paint", "Panel", pnl, w, h)
                         draw.SimpleText(L("flagLabel", flagName), "liaMediumFont", 20, 10, color_white, TEXT_ALIGN_LEFT, TEXT_ALIGN_TOP)
                         local icon = hasFlag and "checkbox.png" or "unchecked.png"

--- a/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
@@ -342,7 +342,7 @@ local function IncludeFlagManagement(tgt, menu, stores)
     local take = GetOrCreateSubMenu(fm, "takeFlagsMenu", stores)
     local toGive, toTake = {}, {}
     for fl in pairs(lia.flag.list) do
-        if not tgt:getChar():hasFlags(fl) then
+        if not tgt:hasFlags(fl) then
             table.insert(toGive, {
                 name = L("giveFlagFormat", fl),
                 cmd = 'say /giveflag ' .. QuoteArgs(GetIdentifier(tgt), fl),

--- a/gamemode/modules/administration/submodules/permissions/commands.lua
+++ b/gamemode/modules/administration/submodules/permissions/commands.lua
@@ -482,7 +482,7 @@ lia.command.add("flaggive", {
         if not flags then
             local available = ""
             for k in SortedPairs(lia.flag.list) do
-                if not target:getChar():hasFlags(k) then available = available .. k .. " " end
+                if not target:hasFlags(k) then available = available .. k .. " " end
             end
 
             available = available:Trim()
@@ -493,7 +493,7 @@ lia.command.add("flaggive", {
             return client:requestString(L("giveFlagsMenu"), L("flagGiveDesc"), function(text) lia.command.run(client, "flaggive", {target:Name(), text}) end, available)
         end
 
-        target:getChar():giveFlags(flags)
+        target:giveFlags(flags)
         client:notifyLocalized("flagGive", client:Name(), flags, target:Name())
         lia.log.add(client, "flagGive", target:Name(), flags)
     end,
@@ -518,9 +518,8 @@ lia.command.add("flaggiveall", {
             return
         end
 
-        local character = target:getChar()
         for k, _ in SortedPairs(lia.flag.list) do
-            if not character:hasFlags(k) then character:giveFlags(k) end
+            if not target:hasFlags(k) then target:giveFlags(k) end
         end
 
         client:notifyLocalized("gaveAllFlags")
@@ -553,7 +552,7 @@ lia.command.add("flagtakeall", {
         end
 
         for k, _ in SortedPairs(lia.flag.list) do
-            if character:hasFlags(k) then character:takeFlags(k) end
+            if target:hasFlags(k) then target:takeFlags(k) end
         end
 
         client:notifyLocalized("tookAllFlags")
@@ -575,11 +574,11 @@ lia.command.add("flagtake", {
 
         local flags = arguments[2]
         if not flags then
-            local currentFlags = target:getChar():getFlags()
+            local currentFlags = target:getFlags()
             return client:requestString(L("takeFlagsMenu"), L("flagTakeDesc"), function(text) lia.command.run(client, "flagtake", {target:Name(), text}) end, table.concat(currentFlags, ", "))
         end
 
-        target:getChar():takeFlags(flags)
+        target:takeFlags(flags)
         client:notifyLocalized("flagTake", client:Name(), flags, target:Name())
         lia.log.add(client, "flagTake", target:Name(), flags)
     end,
@@ -1416,7 +1415,7 @@ lia.command.add("checkflags", {
             return
         end
 
-        local flags = target:getChar():getFlags()
+        local flags = target:getFlags()
         if flags and #flags > 0 then
             client:ChatPrint(L("charFlags", target:Name(), table.concat(flags, ", ")))
         else

--- a/gamemode/modules/administration/submodules/permissions/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/server.lua
@@ -14,7 +14,7 @@ function GM:PlayerSpawnProp(client, model)
         return false
     end
 
-    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Can Spawn Props") or client:getChar():hasFlags("e")
+    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Can Spawn Props") or client:hasFlags("e")
     if not canSpawn then
         lia.log.add(client, "spawnDenied", "prop", model)
         client:notifyLocalized("noSpawnPropsPerm")
@@ -99,7 +99,7 @@ function GM:PlayerSpawnVehicle(client, model)
         return false
     end
 
-    local canSpawn = client:isStaffOnDuty() or client:hasPrivilege("Can Spawn Cars") or client:getChar():hasFlags("C")
+    local canSpawn = client:isStaffOnDuty() or client:hasPrivilege("Can Spawn Cars") or client:hasFlags("C")
     if not canSpawn then
         lia.log.add(client, "spawnDenied", "vehicle", model)
         client:notifyLocalized("noSpawnVehicles")
@@ -122,7 +122,7 @@ function GM:PlayerNoClip(ply, enabled)
 end
 
 function GM:PlayerSpawnEffect(client)
-    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Can Spawn Effects") or client:getChar():hasFlags("L")
+    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Can Spawn Effects") or client:hasFlags("L")
     if not canSpawn then
         lia.log.add(client, "spawnDenied", "effect")
         client:notifyLocalized("noSpawnEffects")
@@ -131,7 +131,7 @@ function GM:PlayerSpawnEffect(client)
 end
 
 function GM:PlayerSpawnNPC(client)
-    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Can Spawn NPCs") or client:getChar():hasFlags("n")
+    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Can Spawn NPCs") or client:hasFlags("n")
     if not canSpawn then
         lia.log.add(client, "spawnDenied", "npc")
         client:notifyLocalized("noSpawnNPCs")
@@ -140,7 +140,7 @@ function GM:PlayerSpawnNPC(client)
 end
 
 function GM:PlayerSpawnRagdoll(client)
-    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Can Spawn Ragdolls") or client:getChar():hasFlags("r")
+    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Can Spawn Ragdolls") or client:hasFlags("r")
     if not canSpawn then
         lia.log.add(client, "spawnDenied", "ragdoll")
         client:notifyLocalized("noSpawnRagdolls")
@@ -149,7 +149,7 @@ function GM:PlayerSpawnRagdoll(client)
 end
 
 function GM:PlayerSpawnSENT(client)
-    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Can Spawn SENTs") or client:getChar():hasFlags("E")
+    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Can Spawn SENTs") or client:hasFlags("E")
     if not canSpawn then
         lia.log.add(client, "spawnDenied", "sent")
         client:notifyLocalized("noSpawnSents")
@@ -158,7 +158,7 @@ function GM:PlayerSpawnSENT(client)
 end
 
 function GM:PlayerSpawnSWEP(client)
-    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Can Spawn SWEPs") or client:getChar():hasFlags("z")
+    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Can Spawn SWEPs") or client:hasFlags("z")
     if not canSpawn then
         lia.log.add(client, "spawnDenied", "swep", tostring(swep))
         client:notifyLocalized("noSpawnSweps")
@@ -167,7 +167,7 @@ function GM:PlayerSpawnSWEP(client)
 end
 
 function GM:PlayerGiveSWEP(client)
-    local canGive = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Can Spawn SWEPs") or client:getChar():hasFlags("W")
+    local canGive = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Can Spawn SWEPs") or client:hasFlags("W")
     if not canGive then
         lia.log.add(client, "permissionDenied", "give swep")
         client:notifyLocalized("noGiveSweps")
@@ -217,7 +217,7 @@ function GM:CanTool(client, _, tool)
 
     local privilege = "Access Tool " .. tool:gsub("^%l", string.upper)
     local isSuperAdmin = client:IsSuperAdmin()
-    local isStaffOrFlagged = client:isStaffOnDuty() or client:getChar():hasFlags("t")
+    local isStaffOrFlagged = client:isStaffOnDuty() or client:hasFlags("t")
     local hasPriv = client:hasPrivilege(privilege)
     if not isSuperAdmin and not (isStaffOrFlagged and hasPriv) then
         local reasons = {}

--- a/gamemode/modules/inventory/submodules/vendor/libraries/server.lua
+++ b/gamemode/modules/inventory/submodules/vendor/libraries/server.lua
@@ -13,7 +13,7 @@ function MODULE:CanPlayerAccessVendor(client, vendor)
     if client:CanEditVendor(vendor) then return true end
     if vendor:isClassAllowed(character:getClass()) then return true end
     if vendor:isFactionAllowed(client:Team()) then return true end
-    if flag and string.len(flag) == 1 and client:getChar():hasFlags(flag) then return true end
+    if flag and string.len(flag) == 1 and client:hasFlags(flag) then return true end
 end
 
 function MODULE:CanPlayerTradeWithVendor(client, vendor, itemType, isSellingToVendor)
@@ -68,7 +68,7 @@ function MODULE:CanPlayerTradeWithVendor(client, vendor, itemType, isSellingToVe
         end
     end
 
-    if flag and not client:getChar():hasFlags(flag) then return false, L("vendorTradeRestrictedFlag") end
+    if flag and not client:hasFlags(flag) then return false, L("vendorTradeRestrictedFlag") end
     return true, nil, isWhitelisted
 end
 


### PR DESCRIPTION
## Summary
- store and check flags directly on players instead of characters
- simplify flag checks in vendor logic
- adjust permissions and admin commands to use player flags
- update spawn flag logic

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6885796199fc8327be9959ae64ebfb4b