### PR TITLE
Add door noKeying property

### DIFF
--- a/gamemode/core/meta/entity.lua
+++ b/gamemode/core/meta/entity.lua
@@ -134,6 +134,12 @@ if SERVER then
         self:setNetVar("locked", state)
     end
 
+    function entityMeta:setKeysNonOwnable(state)
+        local flag = state and true or nil
+        self:setNetVar("noSell", flag)
+        self:setNetVar("noKeying", flag)
+    end
+
     function entityMeta:isDoor()
         if not IsValid(self) then return end
         local class = self:GetClass():lower()

--- a/gamemode/modules/doors/libraries/server.lua
+++ b/gamemode/modules/doors/libraries/server.lua
@@ -190,6 +190,7 @@ end
 
 function MODULE:KeyLock(client, door, time)
     if not IsValid(door) or not IsValid(client) then return end
+    if door:getNetVar("noKeying") then return end
     if hook.Run("CanPlayerLock", client, door) == false then return end
     local distance = client:GetPos():Distance(door:GetPos())
     local isProperEntity = door:isDoor() or door:IsVehicle() or door:isSimfphysCar()
@@ -202,6 +203,7 @@ end
 
 function MODULE:KeyUnlock(client, door, time)
     if not IsValid(door) or not IsValid(client) then return end
+    if door:getNetVar("noKeying") then return end
     if hook.Run("CanPlayerUnlock", client, door) == false then return end
     local distance = client:GetPos():Distance(door:GetPos())
     local isProperEntity = door:isDoor() or door:IsVehicle() or door:isSimfphysCar()


### PR DESCRIPTION
## Summary
- add `setKeysNonOwnable` method to `entityMeta`
- respect `noKeying` on doors to block key usage

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688579e5541483279657813cea363a8e