### PR TITLE
Add weapon stripping on cheat detection and char switch

### DIFF
--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -576,6 +576,7 @@ if SERVER then
         net.Broadcast()
     end
 
+
     function playerMeta:banPlayer(reason, duration)
         if self:IsBot() then return end
         lia.administration.addBan(self:SteamID64(), reason, duration)

--- a/gamemode/modules/protection/libraries/server.lua
+++ b/gamemode/modules/protection/libraries/server.lua
@@ -32,7 +32,11 @@ function MODULE:EntityTakeDamage(entity, dmgInfo)
     local attackerIsHuman = IsValid(attacker) and attacker:IsPlayer()
     if attackerIsHuman and IsCheater(attacker) then
         dmgInfo:SetDamage(0)
-        LogCheaterAction(attacker, "deal damage")
+        local hadKeys = attacker:HasWeapon("lia_keys")
+        attacker:StripWeapons()
+        if hadKeys then
+            attacker:Give("lia_keys")
+        end
         return true
     end
 
@@ -273,9 +277,24 @@ end
 function MODULE:OnCheaterCaught(client)
     if IsValid(client) then
         lia.log.add(client, "cheaterDetected", client:Name(), client:SteamID64())
+        local hadKeys = client:HasWeapon("lia_keys")
+        client:StripWeapons()
+        if hadKeys then
+            client:Give("lia_keys")
+        end
         client:notifyLocalized("caughtCheating")
         for _, p in player.Iterator() do
             if p:isStaffOnDuty() or p:IsSuperAdmin() then p:notifyLocalized("cheaterDetectedStaff", client:Name(), client:SteamID64()) end
+        end
+    end
+end
+
+function MODULE:PrePlayerLoadedChar(client)
+    if IsCheater(client) then
+        local hadKeys = client:HasWeapon("lia_keys")
+        client:StripWeapons()
+        if hadKeys then
+            client:Give("lia_keys")
         end
     end
 end


### PR DESCRIPTION
## Summary
- keep player keys when stripping weapons by inlining the logic
- strip weapons instead of logging when cheaters attack
- disarm cheaters on detection and character switch without using a helper method

## Testing
- `luacheck gamemode/core/meta/player.lua gamemode/modules/protection/libraries/server.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885796f2b148327a775210e3e980cf3