### PR TITLE
Sort admin tabs alphabetically

### DIFF
--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -887,7 +887,7 @@ else
             sheet:Dock(FILL)
             local reg = {}
             hook.Run("liaAdminRegisterTab", parent, reg)
-            for name, data in pairs(reg) do
+            for name, data in SortedPairs(reg) do
                 local pnl = data.build(sheet)
                 sheet:AddSheet(name, pnl, data.icon or "icon16/application.png")
             end


### PR DESCRIPTION
## Summary
- ensure admin tabs are displayed in alphabetical order in the administration menu

## Testing
- `luacheck .` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68857e444a4883279c41781ae0b696bb