### PR TITLE
Reset invalid class on spawn

### DIFF
--- a/gamemode/core/meta/character.lua
+++ b/gamemode/core/meta/character.lua
@@ -268,7 +268,7 @@ if SERVER then
             self:joinClass(validDefaultClass)
             hook.Run("OnPlayerJoinClass", client, validDefaultClass)
         else
-            self:setClass(nil)
+            self:setClass(0)
         end
     end
 

--- a/gamemode/modules/teams/libraries/server.lua
+++ b/gamemode/modules/teams/libraries/server.lua
@@ -49,21 +49,14 @@ function MODULE:PlayerLoadedChar(client, character)
 
     local classIndex = character:getClass()
     local class = lia.class.list[classIndex]
-    if character then
-        if class and client:Team() == class.faction then
-            local oldClass = classIndex
-            timer.Simple(.3, function()
-                character:setClass(classIndex)
-                hook.Run("OnPlayerJoinClass", client, classIndex, oldClass)
-            end)
-        else
-            for _, v in pairs(lia.class.list) do
-                if v.faction == client:Team() and v.isDefault then
-                    character:setClass(v.index)
-                    break
-                end
-            end
-        end
+    if class and client:Team() == class.faction then
+        local oldClass = classIndex
+        timer.Simple(.3, function()
+            character:setClass(classIndex)
+            hook.Run("OnPlayerJoinClass", client, classIndex, oldClass)
+        end)
+    else
+        character:setClass(0)
     end
 end
 


### PR DESCRIPTION
## Summary
- ensure PlayerLoadedChar drops invalid class
- default to no class if class is missing

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68857e31806c83279d1b9f4ef88b786a