### PR TITLE
Add background panel for faction roster

### DIFF
--- a/gamemode/modules/teams/libraries/shared.lua
+++ b/gamemode/modules/teams/libraries/shared.lua
@@ -179,7 +179,15 @@ else
         local fac = lia.faction.indices[char:getFaction()]
         if not fac then return end
         local uid = fac.uniqueID
-        lists[uid] = makeList(panel)
+
+        local bg = panel:Add("DPanel")
+        bg:Dock(FILL)
+        bg:DockPadding(10, 10, 10, 10)
+        bg.Paint = function(pnl, w, h)
+            derma.SkinHook("Paint", "Panel", pnl, w, h)
+        end
+
+        lists[uid] = makeList(bg)
         built = true
         net.Start("RosterRequest")
         net.WriteString(uid)
@@ -192,7 +200,14 @@ else
         for _, fac in pairs(lia.faction.indices) do
             local pnl = ps:Add("Panel")
             pnl:Dock(FILL)
-            lists[fac.uniqueID] = makeList(pnl)
+            local bg = pnl:Add("DPanel")
+            bg:Dock(FILL)
+            bg:DockPadding(10, 10, 10, 10)
+            bg.Paint = function(p, w, h)
+                derma.SkinHook("Paint", "Panel", p, w, h)
+            end
+
+            lists[fac.uniqueID] = makeList(bg)
             ps:AddSheet(fac.name or fac.uniqueID, pnl)
             net.Start("RosterRequest")
             net.WriteString(fac.uniqueID)


### PR DESCRIPTION
## Summary
- add a `DPanel` behind the faction roster and faction sheets
- skin the new panel using the gamemode skin hook

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68857eced0e883279090f9b9c479476f