### PR TITLE
Move class menu to F1 when joinable

### DIFF
--- a/gamemode/core/libraries/keybind.lua
+++ b/gamemode/core/libraries/keybind.lua
@@ -340,7 +340,7 @@ lia.keybind.add(KEY_NONE, "Open Inventory", function()
 end)
 
 lia.keybind.add(KEY_NONE, "Admin Mode", function() lia.command.send("adminmode") end)
-lia.keybind.add(KEY_NONE, "Open Classes Menu", function()
+function lia.gui.openClassesMenu()
     local client = LocalPlayer()
     if not client:getChar() or vgui.CursorVisible() then return end
     if IsValid(lia.gui.classesFrame) then
@@ -528,4 +528,8 @@ lia.keybind.add(KEY_NONE, "Open Classes Menu", function()
 
     lia.gui.classesFrame = frame
     loadClasses()
+end
+
+lia.keybind.add(KEY_NONE, "Open Classes Menu", function()
+    lia.gui.openClassesMenu()
 end)

--- a/gamemode/modules/f1menu/libraries/client.lua
+++ b/gamemode/modules/f1menu/libraries/client.lua
@@ -64,8 +64,21 @@ function MODULE:PlayerBindPress(client, bind, pressed)
         if IsValid(lia.gui.menu) then
             lia.gui.menu:remove()
         elseif client:getChar() then
-            vgui.Create("liaMenu")
+            local joinable = false
+            for _, class in pairs(lia.class.list) do
+                if class.faction == client:Team() and lia.class.canBe(client, class.index) then
+                    joinable = true
+                    break
+                end
+            end
+
+            if joinable then
+                lia.gui.openClassesMenu()
+            else
+                vgui.Create("liaMenu")
+            end
         end
+
         return true
     end
 end


### PR DESCRIPTION
## Summary
- create `lia.gui.openClassesMenu` for showing the class selection UI
- bind "Open Classes Menu" keybind to the new function
- show the class menu when pressing F1 if at least one joinable class exists

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68857e3d7a988327af72555042aa3842