### PR TITLE
Add privileges table

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -264,6 +264,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS `lia_logs`;
     DROP TABLE IF EXISTS `lia_doors`;
     DROP TABLE IF EXISTS `lia_saveditems`;
+    DROP TABLE IF EXISTS `lia_privileges`;
     DROP TABLE IF EXISTS `lia_persistence`;
     DROP TABLE IF EXISTS `lia_warnings`;
 ]])
@@ -293,6 +294,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS lia_logs;
     DROP TABLE IF EXISTS lia_doors;
     DROP TABLE IF EXISTS lia_saveditems;
+    DROP TABLE IF EXISTS lia_privileges;
     DROP TABLE IF EXISTS lia_persistence;
     DROP TABLE IF EXISTS lia_warnings;
     DROP TABLE IF EXISTS lia_chardata;
@@ -459,6 +461,11 @@ function lia.db.loadTables()
                 angles TEXT
             );
 
+            CREATE TABLE IF NOT EXISTS lia_privileges (
+                usergroup TEXT PRIMARY KEY,
+                privileges TEXT
+            );
+
         ]], done)
     else
         local queries = string.Explode(";", [[
@@ -601,6 +608,12 @@ function lia.db.loadTables()
                 `pos` TEXT NULL,
                 `angles` TEXT NULL,
                 PRIMARY KEY (`id`)
+            );
+
+            CREATE TABLE IF NOT EXISTS `lia_privileges` (
+                `usergroup` VARCHAR(32) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `privileges` TEXT NOT NULL COLLATE 'utf8mb4_general_ci',
+                PRIMARY KEY (`usergroup`)
             );
 
         ]])


### PR DESCRIPTION
## Summary
- introduce `lia_privileges` table for SQLite and MySQL
- track privileges per usergroup in admin library
- ensure privileges table is kept up to date when groups or permissions change

## Testing
- `luacheck gamemode --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688582018ec48327b4f2db5db0815d5e