### PR TITLE
Improve group change feedback

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -218,6 +218,9 @@ if SERVER then
         ply:SetUserGroup(usergroup)
         if CAMI and CAMI.SignalUserGroupChanged then CAMI.SignalUserGroupChanged(ply, old, usergroup, "Lilia") end
         lia.db.query(Format("UPDATE lia_players SET userGroup = '%s' WHERE steamID = %s", lia.db.escape(usergroup), ply:SteamID64()))
+        if old ~= usergroup then
+            ply:notifyLocalized("yourGroupSet", usergroup)
+        end
     end
 
     function lia.administration.addBan(steamid, reason, duration)
@@ -383,6 +386,8 @@ concommand.Add("plysetgroup", function(ply, _, args)
         if IsValid(target) then
             if lia.administration.groups[args[2]] then
                 lia.administration.setPlayerGroup(target, args[2])
+                lia.admin("PlySetGroup", string.format("%s's usergroup set to '%s'", target:Name(), args[2]))
+                target:notifyLocalized("yourGroupSet", args[2])
             else
                 lia.admin("Error", "Usergroup not found.")
             end

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -693,6 +693,7 @@ LANGUAGE = {
     plyBanned = "Player banned.",
     plyKilled = "Player killed.",
     plyGroupSet = "Player's group has been set.",
+    yourGroupSet = "Your usergroup has been set to %s.",
     plyKickDesc = "Kick a player from the server.",
     plyBanDesc = "Ban a player from the server for a duration.",
     plyKillDesc = "Kill the specified player.",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -693,6 +693,7 @@ LANGUAGE = {
     plyBanned = "Joueur banni.",
     plyKilled = "Joueur tué.",
     plyGroupSet = "Groupe du joueur défini.",
+    yourGroupSet = "Votre groupe d'utilisateurs est désormais %s.",
     plyKickDesc = "Kick un joueur.",
     plyBanDesc = "Ban un joueur.",
     plyKillDesc = "Tue un joueur.",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -693,6 +693,7 @@ LANGUAGE = {
     plyBanned = "Giocatore bannato.",
     plyKilled = "Giocatore ucciso.",
     plyGroupSet = "Gruppo del giocatore impostato.",
+    yourGroupSet = "Il tuo gruppo utente è stato impostato su %s.",
     plyKickDesc = "Kicka un giocatore dal server.",
     plyBanDesc = "Banna un giocatore dal server per una durata.",
     plyKillDesc = "Uccidi il giocatore specificato.",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -693,6 +693,7 @@ LANGUAGE = {
     plyBanned = "Jogador banido.",
     plyKilled = "Jogador morto.",
     plyGroupSet = "Grupo do jogador definido.",
+    yourGroupSet = "Seu grupo de usuário foi definido para %s.",
     plyKickDesc = "Expulsa jogador.",
     plyBanDesc = "Bane jogador por duração.",
     plyKillDesc = "Mata jogador.",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -693,6 +693,7 @@ LANGUAGE = {
     plyBanned = "Игрок забанен.",
     plyKilled = "Игрок убит.",
     plyGroupSet = "Группа игрока установлена.",
+    yourGroupSet = "Ваша группа установлена на %s.",
     plyKickDesc = "Кик игрока.",
     plyBanDesc = "Бан игрока на время.",
     plyKillDesc = "Убить игрока.",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -693,6 +693,7 @@ LANGUAGE = {
     plyBanned = "Jugador baneado.",
     plyKilled = "Jugador matado.",
     plyGroupSet = "Grupo del jugador cambiado.",
+    yourGroupSet = "Tu grupo de usuario ha sido establecido en %s.",
     plyKickDesc = "Expulsa jugador.",
     plyBanDesc = "Banea jugador.",
     plyKillDesc = "Mata jugador.",

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -214,7 +214,9 @@ lia.command.add("plysetgroup", {
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) and lia.administration.groups[arguments[2]] then
             lia.administration.setPlayerGroup(target, arguments[2])
+            target:notifyLocalized("yourGroupSet", arguments[2])
             client:notifyLocalized("plyGroupSet")
+            lia.admin("PlySetGroup", string.format("%s's usergroup set to '%s' by %s", target:Name(), arguments[2], client:Name()))
             lia.log.add(client, "plySetGroup", target:Name(), arguments[2])
         elseif IsValid(target) and not lia.administration.groups[arguments[2]] then
             client:notifyLocalized("groupNotExists")


### PR DESCRIPTION
## Summary
- notify players when their usergroup changes
- add more console feedback for `plysetgroup`
- translate new notice across languages

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68858412ea6c8327887c5c00f61521f6