### PR TITLE
Implement staff action logging

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -266,7 +266,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS `lia_saveditems`;
     DROP TABLE IF EXISTS `lia_privileges`;
     DROP TABLE IF EXISTS `lia_persistence`;
-    DROP TABLE IF EXISTS `lia_warnings`;
+    DROP TABLE IF EXISTS `lia_staffactions`;
 ]])
             local done = 0
             for i = 1, #queries do
@@ -296,7 +296,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS lia_saveditems;
     DROP TABLE IF EXISTS lia_privileges;
     DROP TABLE IF EXISTS lia_persistence;
-    DROP TABLE IF EXISTS lia_warnings;
+    DROP TABLE IF EXISTS lia_staffactions;
     DROP TABLE IF EXISTS lia_chardata;
 ]], realCallback)
     end
@@ -404,20 +404,14 @@ function lia.db.loadTables()
                 steamID VARCHAR
             );
 
-            CREATE TABLE IF NOT EXISTS lia_ticketclaims (
-                requester TEXT,
-                admin TEXT,
-                message TEXT,
-                timestamp INTEGER
-            );
-
-            CREATE TABLE IF NOT EXISTS lia_warnings (
+            CREATE TABLE IF NOT EXISTS lia_staffactions (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
-                charID INTEGER,
-                steamID TEXT,
                 timestamp DATETIME,
-                reason TEXT,
-                admin TEXT
+                action TEXT,
+                target TEXT,
+                targetSteamID TEXT,
+                admin TEXT,
+                adminSteamID TEXT
             );
 
             CREATE TABLE IF NOT EXISTS lia_doors (
@@ -549,20 +543,14 @@ function lia.db.loadTables()
                 PRIMARY KEY (`id`)
             );
 
-            CREATE TABLE IF NOT EXISTS `lia_ticketclaims` (
-                `requester` VARCHAR(64) NOT NULL COLLATE 'utf8mb4_general_ci',
-                `admin` VARCHAR(128) NOT NULL COLLATE 'utf8mb4_general_ci',
-                `message` TEXT NOT NULL COLLATE 'utf8mb4_general_ci',
-                `timestamp` INT(32) NOT NULL
-            );
-
-            CREATE TABLE IF NOT EXISTS `lia_warnings` (
+            CREATE TABLE IF NOT EXISTS `lia_staffactions` (
                 `id` INT(12) NOT NULL AUTO_INCREMENT,
-                `charID` INT(12) NULL DEFAULT NULL,
-                `steamID` VARCHAR(64) NULL DEFAULT NULL COLLATE 'utf8mb4_general_ci',
                 `timestamp` DATETIME NOT NULL,
-                `reason` TEXT NULL COLLATE 'utf8mb4_general_ci',
-                `admin` TEXT NULL COLLATE 'utf8mb4_general_ci',
+                `action` VARCHAR(64) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `target` VARCHAR(128) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `targetSteamID` VARCHAR(32) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `admin` VARCHAR(128) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `adminSteamID` VARCHAR(32) NOT NULL COLLATE 'utf8mb4_general_ci',
                 PRIMARY KEY (`id`)
             );
 

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -1,4 +1,4 @@
-﻿lia.command.add("adminmode", {
+lia.command.add("adminmode", {
     desc = "adminModeDesc",
     onRun = function(client)
         if not IsValid(client) then return end
@@ -171,6 +171,15 @@ lia.command.add("plykick", {
             target:Kick(L("kickMessage", target, arguments[2] or L("genericReason")))
             client:notifyLocalized("plyKicked")
             lia.log.add(client, "plyKick", target:Name())
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plykick",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })
@@ -186,6 +195,15 @@ lia.command.add("plyban", {
             target:banPlayer(arguments[3] or L("genericReason"), arguments[2])
             client:notifyLocalized("plyBanned")
             lia.log.add(client, "plyBan", target:Name())
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plyban",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })
@@ -201,6 +219,15 @@ lia.command.add("plykill", {
             target:Kill()
             client:notifyLocalized("plyKilled")
             lia.log.add(client, "plyKill", target:Name())
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plykill",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })
@@ -216,6 +243,15 @@ lia.command.add("plysetgroup", {
             lia.administration.setPlayerGroup(target, arguments[2])
             client:notifyLocalized("plyGroupSet")
             lia.log.add(client, "plySetGroup", target:Name(), arguments[2])
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plysetgroup",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         elseif IsValid(target) and not lia.administration.groups[arguments[2]] then
             client:notifyLocalized("groupNotExists")
         end
@@ -233,6 +269,15 @@ lia.command.add("plyunban", {
             lia.administration.removeBan(steamid)
             client:notify("Player unbanned")
             lia.log.add(client, "plyUnban", steamid)
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plyunban",
+                target = steamid,
+                targetSteamID = steamid,
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })
@@ -249,6 +294,15 @@ lia.command.add("plyfreeze", {
             local dur = tonumber(arguments[2]) or 0
             if dur > 0 then timer.Simple(dur, function() if IsValid(target) then target:Freeze(false) end end) end
             lia.log.add(client, "plyFreeze", target:Name(), dur)
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plyfreeze",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })
@@ -263,6 +317,15 @@ lia.command.add("plyunfreeze", {
         if IsValid(target) then
             target:Freeze(false)
             lia.log.add(client, "plyUnfreeze", target:Name())
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plyunfreeze",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })
@@ -277,6 +340,15 @@ lia.command.add("plyslay", {
         if IsValid(target) then
             target:Kill()
             lia.log.add(client, "plySlay", target:Name())
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plyslay",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })
@@ -291,6 +363,15 @@ lia.command.add("plyrespawn", {
         if IsValid(target) then
             target:Spawn()
             lia.log.add(client, "plyRespawn", target:Name())
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plyrespawn",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })
@@ -318,6 +399,15 @@ lia.command.add("plyblind", {
             end
 
             lia.log.add(client, "plyBlind", target:Name(), dur or 0)
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plyblind",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })
@@ -334,6 +424,15 @@ lia.command.add("plyunblind", {
             net.WriteBool(false)
             net.Send(target)
             lia.log.add(client, "plyUnblind", target:Name())
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plyunblind",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })
@@ -359,6 +458,15 @@ lia.command.add("plyblindfade", {
             net.WriteFloat(fadeOut)
             net.Send(target)
             lia.log.add(client, "plyBlindFade", target:Name(), duration, colorName)
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plyblindfade",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })
@@ -368,7 +476,7 @@ lia.command.add("blindfadeall", {
     privilege = "Blind Fade All",
     desc = "blindFadeAllDesc",
     syntax = "[number Time optional] [string Color optional] [number FadeIn optional] [number FadeOut optional]",
-    onRun = function(_, arguments)
+    onRun = function(client, arguments)
         local duration = tonumber(arguments[1]) or 0
         local colorName = (arguments[2] or "black"):lower()
         local fadeIn = tonumber(arguments[3]) or duration * 0.05
@@ -384,6 +492,15 @@ lia.command.add("blindfadeall", {
                 net.Send(ply)
             end
         end
+        local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+        lia.db.insertTable({
+            timestamp = timestamp,
+            action = "blindfadeall",
+            target = "ALL",
+            targetSteamID = "0",
+            admin = IsValid(client) and client:Name() or tostring(client or ""),
+            adminSteamID = IsValid(client) and client:SteamID() or ""
+        }, nil, "staffactions")
     end
 })
 
@@ -397,6 +514,15 @@ lia.command.add("plygag", {
         if IsValid(target) then
             target:setNetVar("liaGagged", true)
             lia.log.add(client, "plyGag", target:Name())
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plygag",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
             hook.Run("PlayerGagged", target, client)
         end
     end
@@ -412,6 +538,15 @@ lia.command.add("plyungag", {
         if IsValid(target) then
             target:setNetVar("liaGagged", false)
             lia.log.add(client, "plyUngag", target:Name())
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plyungag",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
             hook.Run("PlayerUngagged", target, client)
         end
     end
@@ -427,6 +562,15 @@ lia.command.add("plymute", {
         if IsValid(target) then
             target:setLiliaData("VoiceBan", true)
             lia.log.add(client, "plyMute", target:Name())
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plymute",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
             hook.Run("PlayerMuted", target, client)
         end
     end
@@ -442,6 +586,15 @@ lia.command.add("plyunmute", {
         if IsValid(target) then
             target:setLiliaData("VoiceBan", false)
             lia.log.add(client, "plyUnmute", target:Name())
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plyunmute",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
             hook.Run("PlayerUnmuted", target, client)
         end
     end
@@ -459,6 +612,15 @@ lia.command.add("plybring", {
             returnPositions[target] = target:GetPos()
             target:SetPos(client:GetPos() + client:GetForward() * 50)
             lia.log.add(client, "plyBring", target:Name())
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plybring",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })
@@ -474,6 +636,15 @@ lia.command.add("plygoto", {
             returnPositions[client] = client:GetPos()
             client:SetPos(target:GetPos() + target:GetForward() * 50)
             lia.log.add(client, "plyGoto", target:Name())
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plygoto",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })
@@ -491,6 +662,15 @@ lia.command.add("plyreturn", {
             target:SetPos(pos)
             returnPositions[target] = nil
             lia.log.add(client, "plyReturn", target:Name())
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plyreturn",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })
@@ -506,6 +686,15 @@ lia.command.add("plyjail", {
             target:Lock()
             target:Freeze(true)
             lia.log.add(client, "plyJail", target:Name())
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plyjail",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })
@@ -521,6 +710,15 @@ lia.command.add("plyunjail", {
             target:UnLock()
             target:Freeze(false)
             lia.log.add(client, "plyUnjail", target:Name())
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plyunjail",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })
@@ -535,6 +733,15 @@ lia.command.add("plycloak", {
         if IsValid(target) then
             target:SetNoDraw(true)
             lia.log.add(client, "plyCloak", target:Name())
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plycloak",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })
@@ -549,6 +756,15 @@ lia.command.add("plyuncloak", {
         if IsValid(target) then
             target:SetNoDraw(false)
             lia.log.add(client, "plyUncloak", target:Name())
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plyuncloak",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })
@@ -563,6 +779,15 @@ lia.command.add("plygod", {
         if IsValid(target) then
             target:GodEnable()
             lia.log.add(client, "plyGod", target:Name())
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plygod",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })
@@ -577,6 +802,15 @@ lia.command.add("plyungod", {
         if IsValid(target) then
             target:GodDisable()
             lia.log.add(client, "plyUngod", target:Name())
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plyungod",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })
@@ -592,6 +826,15 @@ lia.command.add("plyignite", {
             local dur = tonumber(arguments[2]) or 5
             target:Ignite(dur)
             lia.log.add(client, "plyIgnite", target:Name(), dur)
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plyignite",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })
@@ -606,6 +849,15 @@ lia.command.add("plyextinguish", {
         if IsValid(target) then
             target:Extinguish()
             lia.log.add(client, "plyExtinguish", target:Name())
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plyextinguish",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })
@@ -620,6 +872,15 @@ lia.command.add("plystrip", {
         if IsValid(target) then
             target:StripWeapons()
             lia.log.add(client, "plyStrip", target:Name())
+            local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+            lia.db.insertTable({
+                timestamp = timestamp,
+                action = "plystrip",
+                target = target:Name(),
+                targetSteamID = target:SteamID(),
+                admin = IsValid(client) and client:Name() or tostring(client or ""),
+                adminSteamID = IsValid(client) and client:SteamID() or ""
+            }, nil, "staffactions")
         end
     end
 })


### PR DESCRIPTION
## Summary
- replace ticket/warning tables with a single `lia_staffactions` table
- log staff actions directly within administration commands
- remove helper function so commands insert log entries themselves

## Testing
- `luacheck` not available in environment
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68858360453483279192cee5e46f5207