### PR TITLE
Fix quick menu closing

### DIFF
--- a/gamemode/core/hooks/client.lua
+++ b/gamemode/core/hooks/client.lua
@@ -366,12 +366,13 @@ end
 
 function GM:OnContextMenuOpen()
     self.BaseClass:OnContextMenuOpen()
-    vgui.Create("liaQuick")
+    if not IsValid(lia.gui.quick) then vgui.Create("liaQuick") end
 end
 
 function GM:OnContextMenuClose()
     self.BaseClass:OnContextMenuClose()
-    if IsValid(lia.gui.quick) then lia.gui.quick:Remove() end
+    -- keep the quick menu open if the user released the context menu key
+    -- it will be closed via the new keybind instead
 end
 
 function GM:CharListLoaded()

--- a/gamemode/core/libraries/keybind.lua
+++ b/gamemode/core/libraries/keybind.lua
@@ -533,3 +533,11 @@ end
 lia.keybind.add(KEY_NONE, "Open Classes Menu", function()
     lia.gui.openClassesMenu()
 end)
+
+lia.keybind.add(KEY_F3, "Quick Menu", function()
+    if IsValid(lia.gui.quick) then
+        lia.gui.quick:Remove()
+    else
+        vgui.Create("liaQuick")
+    end
+end)


### PR DESCRIPTION
## Summary
- tweak context menu hooks so `liaQuick` isn't removed automatically
- add F3 keybind for quick menu toggle

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68859016a2f083278fe8800fc2277609