### PR TITLE
Add warnings and ticket ticketclaims tables

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -264,6 +264,8 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS `lia_logs`;
     DROP TABLE IF EXISTS `lia_doors`;
     DROP TABLE IF EXISTS `lia_saveditems`;
+    DROP TABLE IF EXISTS `lia_warnings`;
+    DROP TABLE IF EXISTS `lia_ticketclaims`;
     DROP TABLE IF EXISTS `lia_privileges`;
     DROP TABLE IF EXISTS `lia_persistence`;
     DROP TABLE IF EXISTS `lia_staffactions`;
@@ -294,6 +296,8 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS lia_logs;
     DROP TABLE IF EXISTS lia_doors;
     DROP TABLE IF EXISTS lia_saveditems;
+    DROP TABLE IF EXISTS lia_warnings;
+    DROP TABLE IF EXISTS lia_ticketclaims;
     DROP TABLE IF EXISTS lia_privileges;
     DROP TABLE IF EXISTS lia_persistence;
     DROP TABLE IF EXISTS lia_staffactions;
@@ -455,6 +459,26 @@ function lia.db.loadTables()
                 angles TEXT
             );
 
+            CREATE TABLE IF NOT EXISTS lia_warnings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp DATETIME,
+                warned TEXT,
+                warnedSteamID TEXT,
+                warning TEXT,
+                admin TEXT,
+                adminSteamID TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS lia_ticketclaims (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp DATETIME,
+                requester TEXT,
+                requesterSteamID TEXT,
+                message TEXT,
+                admin TEXT,
+                adminSteamID TEXT
+            );
+
             CREATE TABLE IF NOT EXISTS lia_privileges (
                 usergroup TEXT PRIMARY KEY,
                 privileges TEXT
@@ -595,6 +619,28 @@ function lia.db.loadTables()
                 `itemID` INT(12) NOT NULL,
                 `pos` TEXT NULL,
                 `angles` TEXT NULL,
+                PRIMARY KEY (`id`)
+            );
+
+            CREATE TABLE IF NOT EXISTS `lia_warnings` (
+                `id` INT(12) NOT NULL AUTO_INCREMENT,
+                `timestamp` DATETIME NOT NULL,
+                `warned` VARCHAR(128) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `warnedSteamID` VARCHAR(32) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `warning` TEXT NOT NULL COLLATE 'utf8mb4_general_ci',
+                `admin` VARCHAR(128) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `adminSteamID` VARCHAR(32) NOT NULL COLLATE 'utf8mb4_general_ci',
+                PRIMARY KEY (`id`)
+            );
+
+            CREATE TABLE IF NOT EXISTS `lia_ticketclaims` (
+                `id` INT(12) NOT NULL AUTO_INCREMENT,
+                `timestamp` DATETIME NOT NULL,
+                `requester` VARCHAR(128) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `requesterSteamID` VARCHAR(32) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `message` TEXT NOT NULL COLLATE 'utf8mb4_general_ci',
+                `admin` VARCHAR(128) NOT NULL COLLATE 'utf8mb4_general_ci',
+                `adminSteamID` VARCHAR(32) NOT NULL COLLATE 'utf8mb4_general_ci',
                 PRIMARY KEY (`id`)
             );
 

--- a/gamemode/modules/administration/submodules/logging/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/logging/libraries/server.lua
@@ -181,21 +181,21 @@ function MODULE:OnPlayerObserve(client, state)
 end
 
 function MODULE:TicketSystemClaim(admin, requester)
-    local pattern = "admin LIKE '%" .. admin:SteamID64() .. "'"
+    local pattern = "adminSteamID = " .. lia.db.convertDataType(admin:SteamID64())
     lia.db.count("ticketclaims", pattern):next(function(count) lia.log.add(admin, "ticketClaimed", requester:Name(), count) end)
 end
 
 function MODULE:TicketSystemClose(admin, requester)
-    local pattern = "admin LIKE '%" .. admin:SteamID64() .. "'"
+    local pattern = "adminSteamID = " .. lia.db.convertDataType(admin:SteamID64())
     lia.db.count("ticketclaims", pattern):next(function(count) lia.log.add(admin, "ticketClosed", requester:Name(), count) end)
 end
 
 function MODULE:WarningIssued(admin, target, reason, index)
-    lia.db.count("warnings", "charID = " .. lia.db.convertDataType(target:getChar():getID())):next(function(count) lia.log.add(admin, "warningIssued", target, reason, count, index) end)
+    lia.db.count("warnings", "warnedSteamID = " .. lia.db.convertDataType(target:SteamID64())):next(function(count) lia.log.add(admin, "warningIssued", target, reason, count, index) end)
 end
 
 function MODULE:WarningRemoved(admin, target, warning, index)
-    lia.db.count("warnings", "charID = " .. lia.db.convertDataType(target:getChar():getID())):next(function(count) lia.log.add(admin, "warningRemoved", target, warning, count, index) end)
+    lia.db.count("warnings", "warnedSteamID = " .. lia.db.convertDataType(target:SteamID64())):next(function(count) lia.log.add(admin, "warningRemoved", target, warning, count, index) end)
 end
 
 function MODULE:ItemTransfered(context)

--- a/gamemode/modules/administration/submodules/tickets/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/tickets/libraries/server.lua
@@ -1,10 +1,10 @@
 ﻿local function buildClaimTable(rows)
     local caseclaims = {}
     for _, row in ipairs(rows or {}) do
-        local adminID = row.admin
-        if adminID ~= "Unassigned" then adminID = tostring(adminID):match("(%d+)$") or adminID end
+        local adminID = row.adminSteamID
+        if adminID ~= "" and adminID ~= "Unassigned" then adminID = tostring(adminID) end
         caseclaims[adminID] = caseclaims[adminID] or {
-            name = adminID,
+            name = row.admin or adminID,
             claims = 0,
             lastclaim = 0,
             claimedFor = {}
@@ -13,8 +13,8 @@
         local info = caseclaims[adminID]
         info.claims = info.claims + 1
         if row.timestamp > info.lastclaim then info.lastclaim = row.timestamp end
-        local reqPly = player.GetBySteamID64(row.requester)
-        info.claimedFor[row.requester] = IsValid(reqPly) and reqPly:Nick() or row.requester
+        local reqPly = player.GetBySteamID64(row.requesterSteamID)
+        info.claimedFor[row.requesterSteamID] = IsValid(reqPly) and reqPly:Nick() or row.requester
     end
 
     for adminID, info in pairs(caseclaims) do
@@ -25,13 +25,15 @@
 end
 
 function MODULE:GetAllCaseClaims()
-    return lia.db.select({"requester", "admin", "timestamp"}, "ticketclaims"):next(function(res) return buildClaimTable(res.results) end)
+    return lia.db.select({"requesterSteamID", "adminSteamID", "timestamp"}, "ticketclaims")
+        :next(function(res) return buildClaimTable(res.results) end)
 end
 
 function MODULE:TicketSystemClaim(admin, requester)
     lia.db.updateTable({
-        admin = admin:Name() .. " " .. admin:SteamID64()
-    }, nil, "ticketclaims", "requester = " .. lia.db.convertDataType(requester:SteamID64()) .. " AND admin = 'Unassigned'")
+        admin = admin:Name(),
+        adminSteamID = admin:SteamID64()
+    }, nil, "ticketclaims", "requesterSteamID = " .. lia.db.convertDataType(requester:SteamID64()) .. " AND admin = 'Unassigned'")
 end
 
 function MODULE:PlayerSay(client, text)
@@ -40,8 +42,10 @@ function MODULE:PlayerSay(client, text)
         ClientAddText(client, Color(70, 0, 130), L("ticketMessageYou"), Color(151, 211, 255), " " .. L("ticketMessageToAdmins") .. " ", Color(0, 255, 0), text)
         self:SendPopup(client, text)
         lia.db.insertTable({
-            requester = client:SteamID64(),
+            requester = client:Name(),
+            requesterSteamID = client:SteamID64(),
             admin = "Unassigned",
+            adminSteamID = "",
             message = text,
             timestamp = os.time()
         }, nil, "ticketclaims")

--- a/gamemode/modules/administration/submodules/warns/commands.lua
+++ b/gamemode/modules/administration/submodules/warns/commands.lua
@@ -21,10 +21,9 @@ lia.command.add("warn", {
         end
 
         local timestamp = os.date("%Y-%m-%d %H:%M:%S")
-        local adminStr = client:Nick() .. " (" .. client:SteamID() .. ")"
-        MODULE:AddWarning(target:getChar():getID(), target:SteamID64(), timestamp, reason, adminStr)
-        lia.db.count("warnings", "charID = " .. lia.db.convertDataType(target:getChar():getID())):next(function(count)
-            target:notifyLocalized("playerWarned", adminStr, reason)
+        MODULE:AddWarning(target, timestamp, reason, client)
+        lia.db.count("warnings", "warnedSteamID = " .. lia.db.convertDataType(target:SteamID64())):next(function(count)
+            target:notifyLocalized("playerWarned", client:Nick(), reason)
             client:notifyLocalized("warningIssued", target:Nick())
             hook.Run("WarningIssued", client, target, reason, count)
         end)
@@ -49,7 +48,7 @@ lia.command.add("viewwarns", {
             return
         end
 
-        MODULE:GetWarnings(target:getChar():getID()):next(function(warns)
+        MODULE:GetWarnings(target:SteamID64()):next(function(warns)
             if #warns == 0 then
                 client:notifyLocalized("noWarnings", target:Nick())
                 return
@@ -60,8 +59,8 @@ lia.command.add("viewwarns", {
                 table.insert(warningList, {
                     index = index,
                     timestamp = warn.timestamp or L("na"),
-                    reason = warn.reason or L("na"),
-                    admin = warn.admin or L("na")
+                    reason = warn.warning or L("na"),
+                    admin = (warn.admin or "") .. (warn.adminSteamID and " (" .. warn.adminSteamID .. ")" or "")
                 })
             end
 

--- a/gamemode/modules/protection/commands.lua
+++ b/gamemode/modules/protection/commands.lua
@@ -20,12 +20,11 @@
             client:notifyLocalized("cheaterMarked", target:Name())
             target:notifyLocalized("cheaterMarkedByAdmin")
             local timestamp = os.date("%Y-%m-%d %H:%M:%S")
-            local adminStr = client:Nick() .. " (" .. client:SteamID() .. ")"
             local warnsModule = lia.module.list["warns"]
             if warnsModule and warnsModule.AddWarning then
-                warnsModule:AddWarning(target:getChar():getID(), target:SteamID64(), timestamp, L("cheaterWarningReason"), adminStr)
-                lia.db.count("warnings", "charID = " .. lia.db.convertDataType(target:getChar():getID())):next(function(count)
-                    target:notifyLocalized("playerWarned", adminStr, L("cheaterWarningReason"))
+                warnsModule:AddWarning(target, timestamp, L("cheaterWarningReason"), client)
+                lia.db.count("warnings", "warnedSteamID = " .. lia.db.convertDataType(target:SteamID64())):next(function(count)
+                    target:notifyLocalized("playerWarned", client:Nick(), L("cheaterWarningReason"))
                     client:notifyLocalized("warningIssued", target:Nick())
                     hook.Run("WarningIssued", client, target, L("cheaterWarningReason"), count)
                 end)


### PR DESCRIPTION
## Summary
- create `lia_warnings` and `lia_ticketclaims` tables
- drop new tables in database wipe
- track warnings by SteamID and store admin details separately
- expand ticket system to record requester and admin SteamIDs

## Testing
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68859155f58c8327aab652ce4a3dd542