### PR TITLE
Add row copy and decoded view features

### DIFF
--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -669,6 +669,14 @@ else
             local m = DermaMenu()
             local opt = m:AddOption("View Character List", function() LocalPlayer():ConCommand("say /charlist " .. line.steamID) end)
             opt:SetIcon("icon16/user.png")
+            m:AddOption(L("copyRow"), function()
+                local s = ""
+                for i = 1, line:Columns() do
+                    s = s .. line:GetColumnText(i) .. " | "
+                end
+
+                SetClipboardText(s:sub(1, -4))
+            end):SetIcon("icon16/page_copy.png")
             m:Open()
         end
     end
@@ -689,6 +697,20 @@ else
             if not filterID or tostring(sid) == tostring(filterID) then
                 list:AddLine(v.ID, v.Name, util.SteamIDFrom64(tostring(sid)), v.Faction, v.Banned, v.Money, v.LastUsed)
             end
+        end
+
+        list.OnRowRightClick = function(_, _, line)
+            if not IsValid(line) then return end
+            local m = DermaMenu()
+            m:AddOption(L("copyRow"), function()
+                local s = ""
+                for i = 1, line:Columns() do
+                    s = s .. line:GetColumnText(i) .. " | "
+                end
+
+                SetClipboardText(s:sub(1, -4))
+            end):SetIcon("icon16/page_copy.png")
+            m:Open()
         end
     end
 

--- a/gamemode/modules/administration/netcalls/client.lua
+++ b/gamemode/modules/administration/netcalls/client.lua
@@ -87,6 +87,11 @@ local function handleTableData(id)
         function list:OnRowSelected(_, line)
             openRowInfo(line.rowData)
         end
+
+        function list:OnRowRightClick(_, line)
+            if not IsValid(line) or not line.rowData then return end
+            openRowInfo(line.rowData)
+        end
     end
 end
 

--- a/gamemode/modules/administration/submodules/logging/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/logging/libraries/client.lua
@@ -17,6 +17,15 @@ local function buildCategoryPanel(parent, logs)
     list:AddColumn(L("timestamp")):SetFixedWidth(150)
     list:AddColumn(L("logMessage"))
     list:AddColumn(L("steamID")):SetFixedWidth(110)
+    list.OnRowRightClick = function(_, _, line)
+        if not IsValid(line) then return end
+        local text = "[" .. line:GetColumnText(1) .. "] " .. line:GetColumnText(2)
+        local id = line:GetColumnText(3)
+        if id and id ~= "" then text = text .. " [" .. id .. "]" end
+        local m = DermaMenu()
+        m:AddOption(L("copyRow"), function() SetClipboardText(text) end):SetIcon("icon16/page_copy.png")
+        m:Open()
+    end
 
     local copyButton = contentPanel:Add("liaMediumButton")
     copyButton:Dock(BOTTOM)

--- a/gamemode/modules/administration/submodules/staffmanagement/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/staffmanagement/libraries/client.lua
@@ -46,6 +46,18 @@ hook.Add("liaAdminRegisterTab", "liaStaffManagementTab", function(parent, tabs)
             list:AddColumn(L("staffAction"))
             list:AddColumn(L("count"))
             MODULE.actionList = list
+            list.OnRowRightClick = function(_, _, line)
+                if not IsValid(line) then return end
+                local m = DermaMenu()
+                m:AddOption(L("copyRow"), function()
+                    local s = ""
+                    for i = 1, line:Columns() do
+                        s = s .. line:GetColumnText(i) .. " | "
+                    end
+                    SetClipboardText(s:sub(1, -4))
+                end):SetIcon("icon16/page_copy.png")
+                m:Open()
+            end
             net.Start("RequestStaffActions")
             net.SendToServer()
             return panel
@@ -65,6 +77,18 @@ hook.Add("liaAdminRegisterTab", "liaStaffManagementTab", function(parent, tabs)
             list:AddColumn(L("reason"))
             list:AddColumn(L("timestamp"))
             MODULE.warnList = list
+            list.OnRowRightClick = function(_, _, line)
+                if not IsValid(line) then return end
+                local m = DermaMenu()
+                m:AddOption(L("copyRow"), function()
+                    local s = ""
+                    for i = 1, line:Columns() do
+                        s = s .. line:GetColumnText(i) .. " | "
+                    end
+                    SetClipboardText(s:sub(1, -4))
+                end):SetIcon("icon16/page_copy.png")
+                m:Open()
+            end
             net.Start("RequestPlayerWarnings")
             net.WriteString(LocalPlayer():SteamID64())
             net.SendToServer()
@@ -85,6 +109,18 @@ hook.Add("liaAdminRegisterTab", "liaStaffManagementTab", function(parent, tabs)
             list:AddColumn(L("admin"))
             list:AddColumn(L("message"))
             MODULE.ticketList = list
+            list.OnRowRightClick = function(_, _, line)
+                if not IsValid(line) then return end
+                local m = DermaMenu()
+                m:AddOption(L("copyRow"), function()
+                    local s = ""
+                    for i = 1, line:Columns() do
+                        s = s .. line:GetColumnText(i) .. " | "
+                    end
+                    SetClipboardText(s:sub(1, -4))
+                end):SetIcon("icon16/page_copy.png")
+                m:Open()
+            end
             net.Start("RequestTicketClaims")
             net.SendToServer()
             return pnl


### PR DESCRIPTION
## Summary
- allow copying player/character rows in admin tab
- enable copying staff management and log rows via right-click
- support right-click row details in DB browser

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68859a075c8883279d33387231989182