### PR TITLE
Sort scoreboard admin options alphabetically

### DIFF
--- a/gamemode/modules/administration/libraries/client.lua
+++ b/gamemode/modules/administration/libraries/client.lua
@@ -118,6 +118,10 @@
             }
         }
 
+        table.sort(orderedOptions, function(a, b)
+            return tostring(a.name) < tostring(b.name)
+        end)
+
         for _, option in ipairs(orderedOptions) do
             table.insert(options, option)
         end


### PR DESCRIPTION
## Summary
- ensure scoreboard admin options appear in alphabetical order

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68859ff5f3208327a3b717e3ec1e9c20