### PR TITLE
Fix privilege categories not syncing

### DIFF
--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -1243,7 +1243,8 @@ hook.Add("CAMI.OnPrivilegeRegistered", "liaSyncAdminPrivilegeAdd", function(pv)
     if not pv or not pv.Name then return end
     lia.administration.privileges[pv.Name] = {
         Name = pv.Name,
-        MinAccess = pv.MinAccess or "user"
+        MinAccess = pv.MinAccess or "user",
+        Category = pv.Category or "Unassigned"
     }
 
     for g in pairs(lia.administration.groups) do


### PR DESCRIPTION
## Summary
- ensure privilege category is copied from CAMI when new privileges register

## Testing
- `luac -p gamemode/modules/administration/module.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885a413d99083279caf625a6d8ce0b4