### PR TITLE
Update admin panels and character browser

### DIFF
--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -71,7 +71,9 @@ hook.Add("liaAdminRegisterTab", "liaStaffManagementTab", function(parent, tabs)
             local list = vgui.Create("DListView", pnl)
             list:Dock(FILL)
             list:AddColumn(L("player"))
+            list:AddColumn(L("steamID"))
             list:AddColumn(L("admin"))
+            list:AddColumn(L("steamID"))
             list:AddColumn(L("reason"))
             list:AddColumn(L("timestamp"))
             MODULE.warnList = list
@@ -107,7 +109,9 @@ hook.Add("liaAdminRegisterTab", "liaStaffManagementTab", function(parent, tabs)
             list:Dock(FILL)
             list:AddColumn(L("timestamp"))
             list:AddColumn(L("requester"))
+            list:AddColumn(L("steamID"))
             list:AddColumn(L("admin"))
+            list:AddColumn(L("steamID"))
             list:AddColumn(L("message"))
             MODULE.ticketList = list
             list.OnRowRightClick = function(_, _, line)
@@ -1149,7 +1153,7 @@ else
 
     hook.Add("liaAdminRegisterTab", "AdminTabCharBrowser", function(parent, tabs)
         if not canAccess() then return end
-        tabs["Char Browser"] = {
+        tabs["Character List"] = {
             icon = "icon16/table.png",
             build = function(sheet)
                 local pnl = vgui.Create("DPanel", sheet)
@@ -1161,7 +1165,6 @@ else
                 online:Dock(FILL)
                 online.Paint = function() end
                 lia.gui.charBrowserOnline = online
-                ps:AddSheet("By Player Online", online, "icon16/user.png")
                 buildCharListUI(online, "online")
                 buildPlayerTabs(ps)
                 local all = vgui.Create("DPanel", ps)

--- a/gamemode/modules/administration/submodules/staffmanagement/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/staffmanagement/libraries/client.lua
@@ -14,7 +14,7 @@ net.Receive("PlayerWarnings", function()
     if IsValid(MODULE.warnList) then
         MODULE.warnList:Clear()
         for _, w in ipairs(warnings) do
-            MODULE.warnList:AddLine(w.warned or "", w.admin or "", w.warning or "", w.timestamp or "")
+            MODULE.warnList:AddLine(w.warned or "", w.warnedSteamID or "", w.admin or "", w.adminSteamID or "", w.warning or "", w.timestamp or "")
         end
     end
 end)
@@ -24,7 +24,7 @@ net.Receive("TicketClaims", function()
     if IsValid(MODULE.ticketList) then
         MODULE.ticketList:Clear()
         for _, c in ipairs(claims) do
-            MODULE.ticketList:AddLine(os.date("%Y-%m-%d %H:%M:%S", c.timestamp or 0), c.requester or "", c.admin or "", c.message or "")
+            MODULE.ticketList:AddLine(os.date("%Y-%m-%d %H:%M:%S", c.timestamp or 0), c.requester or "", c.requesterSteamID or "", c.admin or "", c.adminSteamID or "", c.message or "")
         end
     end
 end)

--- a/gamemode/modules/administration/submodules/warns/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/warns/libraries/server.lua
@@ -2,7 +2,7 @@ local MODULE = MODULE
 
 function MODULE:GetWarnings(steamID)
     local condition = "warnedSteamID = " .. lia.db.convertDataType(steamID)
-    return lia.db.select({"id", "timestamp", "warning", "admin", "adminSteamID"}, "warnings", condition)
+    return lia.db.select({"id", "timestamp", "warning", "admin", "adminSteamID", "warned", "warnedSteamID"}, "warnings", condition)
         :next(function(res) return res.results or {} end)
 end
 


### PR DESCRIPTION
## Summary
- rename Char Browser tab to **Character List**
- remove the "By Player Online" sheet from the Character List property sheet
- display player and admin SteamIDs in warning and ticket lists
- include warned player fields in server warning lookups

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6885a492bcf883279d617784de815017