### PR TITLE
Add usergroup and action counts to Staff Management

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -453,6 +453,7 @@ LANGUAGE = {
     staffManagement = "Staff Management",
     staffAction = "Action",
     staffActionCount = "Action Count",
+    userGroup = "Usergroup",
     ticketsTab = "Tickets",
     failedRetrieveLogs = "Failed to retrieve logs.",
     searchLogs = "Search logs...",

--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -38,8 +38,8 @@ hook.Add("liaAdminRegisterTab", "liaStaffManagementTab", function(parent, tabs)
             list:Dock(FILL)
             list:AddColumn(L("adminName"))
             list:AddColumn(L("steamID"))
-            list:AddColumn(L("staffAction"))
-            list:AddColumn(L("count"))
+            list:AddColumn(L("userGroup"))
+            list:AddColumn(L("staffActionCount"))
             MODULE.actionList = list
             list.OnRowRightClick = function(_, _, line)
                 if not IsValid(line) then return end

--- a/gamemode/modules/administration/submodules/staffmanagement/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/staffmanagement/libraries/client.lua
@@ -4,7 +4,7 @@ net.Receive("StaffActions", function()
     if IsValid(MODULE.actionList) then
         MODULE.actionList:Clear()
         for _, row in ipairs(data) do
-            MODULE.actionList:AddLine(row.admin or "N/A", row.adminSteamID or "", row.action or "", row.count or 0)
+            MODULE.actionList:AddLine(row.admin or "N/A", row.adminSteamID or "", row.userGroup or "", row.count or 0)
         end
     end
 end)

--- a/gamemode/modules/administration/submodules/staffmanagement/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/staffmanagement/libraries/server.lua
@@ -1,6 +1,11 @@
 local MODULE = MODULE
 local function queryStaffActions(callback)
-    lia.db.query([[SELECT admin, adminSteamID, action, COUNT(*) AS count FROM lia_staffactions GROUP BY adminSteamID, action]], callback)
+    lia.db.query([[
+        SELECT sa.admin, sa.adminSteamID, lp.userGroup, COUNT(*) AS count
+        FROM lia_staffactions AS sa
+        LEFT JOIN lia_players AS lp ON lp.steamID = sa.adminSteamID
+        GROUP BY sa.adminSteamID, sa.admin
+    ]], callback)
 end
 
 net.Receive("RequestStaffActions", function(_, client)


### PR DESCRIPTION
## Summary
- enhance staff actions query to pull total action counts per admin and include usergroup
- update Staff Management UI to show usergroup and total actions
- adjust client handler for new data format
- add `userGroup` translation entry

## Testing
- `luacheck gamemode` *(fails: command not found)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6885a9245b40832789b28ec953b55d53