### PR TITLE
Add Category to privileges

### DIFF
--- a/gamemode/core/libraries/commands.lua
+++ b/gamemode/core/libraries/commands.lua
@@ -15,7 +15,8 @@ function lia.command.add(command, data)
         if not lia.administration.privileges[privilegeName] then
             lia.administration.registerPrivilege({
                 Name = privilegeName,
-                MinAccess = superAdminOnly and "superadmin" or "admin"
+                MinAccess = superAdminOnly and "superadmin" or "admin",
+                Category = data.Category
             })
         end
     end

--- a/gamemode/core/libraries/compatibility/pac.lua
+++ b/gamemode/core/libraries/compatibility/pac.lua
@@ -240,7 +240,8 @@ lia.config.add("BlockPackURLoad", "Block Pack URL Load", true, nil, {
 
 lia.administration.registerPrivilege({
     Name = "Can Use PAC3",
-    MinAccess = "admin"
+    MinAccess = "admin",
+    Category = "PAC3"
 })
 
 lia.flag.add("P", "Access to PAC3.")

--- a/gamemode/core/libraries/compatibility/sam.lua
+++ b/gamemode/core/libraries/compatibility/sam.lua
@@ -210,12 +210,14 @@ lia.command.add("plygetplaytime", {
 
 lia.administration.registerPrivilege({
     Name = "Can See SAM Notifications Outside Staff Character",
-    MinAccess = "superadmin"
+    MinAccess = "superadmin",
+    Category = "SAM"
 })
 
 lia.administration.registerPrivilege({
     Name = "Can Bypass Staff Faction SAM Command whitelist",
-    MinAccess = "superadmin"
+    MinAccess = "superadmin",
+    Category = "SAM"
 })
 
 lia.config.add("AdminOnlyNotification", "Admin Only Notifications", true, nil, {

--- a/gamemode/core/libraries/compatibility/simfphys.lua
+++ b/gamemode/core/libraries/compatibility/simfphys.lua
@@ -71,7 +71,8 @@ lia.config.add("TimeToEnterVehicle", "Time To Enter Vehicle", 4, nil, {
 
 lia.administration.registerPrivilege({
     Name = "Can Edit Simfphys Cars",
-    MinAccess = "superadmin"
+    MinAccess = "superadmin",
+    Category = "Simfphys"
 })
 
 hook.Add("simfphysPhysicsCollide", "SIMFPHYS_simfphysPhysicsCollide", function() return true end)

--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -5,23 +5,28 @@ MODULE.desc = "Provides a suite of administrative commands, configuration menus,
 MODULE.Privileges = {
     {
         Name = "Can Remove Warns",
-        MinAccess = "superadmin"
+        MinAccess = "superadmin",
+        Category = MODULE.name
     },
     {
         Name = "Manage Prop Blacklist",
-        MinAccess = "superadmin"
+        MinAccess = "superadmin",
+        Category = MODULE.name
     },
     {
         Name = "Access Configuration Menu",
-        MinAccess = "superadmin"
+        MinAccess = "superadmin",
+        Category = MODULE.name
     },
     {
         Name = "Access Edit Configuration Menu",
-        MinAccess = "superadmin"
+        MinAccess = "superadmin",
+        Category = MODULE.name
     },
     {
         Name = "Manage UserGroups",
-        MinAccess = "superadmin"
+        MinAccess = "superadmin",
+        Category = MODULE.name
     }
 }
 

--- a/gamemode/modules/administration/submodules/adminstick/module.lua
+++ b/gamemode/modules/administration/submodules/adminstick/module.lua
@@ -5,6 +5,7 @@ MODULE.desc = "Adds the Admin Stick tool, allowing staff to quickly perform comm
 MODULE.Privileges = {
     {
         Name = "Use Admin Stick",
-        MinAccess = "superadmin"
+        MinAccess = "superadmin",
+        Category = MODULE.name
     },
 }

--- a/gamemode/modules/administration/submodules/itemspawner/module.lua
+++ b/gamemode/modules/administration/submodules/itemspawner/module.lua
@@ -5,6 +5,7 @@ MODULE.desc = "Offers an in-game item spawner interface so administrators can qu
 MODULE.Privileges = {
     {
         Name = "Can Use Item Spawner",
-        MinAccess = "admin"
+        MinAccess = "admin",
+        Category = MODULE.name
     }
 }

--- a/gamemode/modules/administration/submodules/logging/module.lua
+++ b/gamemode/modules/administration/submodules/logging/module.lua
@@ -5,6 +5,7 @@ MODULE.desc = "Tracks administrative actions and server events, writing detailed
 MODULE.Privileges = {
     {
         Name = "Can See Logs",
-        MinAccess = "superadmin"
+        MinAccess = "superadmin",
+        Category = MODULE.name
     }
 }

--- a/gamemode/modules/administration/submodules/permissions/libraries/shared.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/shared.lua
@@ -10,7 +10,8 @@ function MODULE:InitializedModules()
                 if not lia.administration.privileges[privilege] then
                     lia.administration.registerPrivilege({
                         Name = privilege,
-                        MinAccess = "admin"
+                        MinAccess = "admin",
+                        Category = MODULE.name
                     })
                 end
             end
@@ -24,7 +25,8 @@ function MODULE:InitializedModules()
                 if not lia.administration.privileges[privilege] then
                     lia.administration.registerPrivilege({
                         Name = privilege,
-                        MinAccess = defaultUserTools[string.lower(tool)] and "user" or "admin"
+                        MinAccess = defaultUserTools[string.lower(tool)] and "user" or "admin",
+                        Category = MODULE.name
                     })
                 end
             end

--- a/gamemode/modules/administration/submodules/permissions/module.lua
+++ b/gamemode/modules/administration/submodules/permissions/module.lua
@@ -6,117 +6,146 @@ MODULE.Privileges = {
     {
         Name = "Can Bypass Character Lock",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Can Grab World Props",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Can Grab Players",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Physgun Pickup",
         MinAccess = "admin",
+        Category = MODULE.name,
     },
     {
         Name = "Can Access Item Informations",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Physgun Pickup on Restricted Entities",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Physgun Pickup on Vehicles",
         MinAccess = "admin",
+        Category = MODULE.name,
     },
     {
         Name = "Can't be Grabbed with PhysGun",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Can Physgun Reload",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "No Clip Outside Staff Character",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "No Clip ESP Outside Staff Character",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Can Property World Entities",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Manage Car Blacklist",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Can Spawn Ragdolls",
         MinAccess = "admin",
+        Category = MODULE.name,
     },
     {
         Name = "Can Spawn SWEPs",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Can Spawn Effects",
         MinAccess = "admin",
+        Category = MODULE.name,
     },
     {
         Name = "Can Spawn Props",
         MinAccess = "admin",
+        Category = MODULE.name,
     },
     {
         Name = "Can Spawn Blacklisted Props",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Can Spawn NPCs",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "No Car Spawn Delay",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "No Spawn Delay",
         MinAccess = "admin",
+        Category = MODULE.name,
     },
     {
         Name = "Can Spawn Cars",
         MinAccess = "admin",
+        Category = MODULE.name,
     },
     {
         Name = "Can Spawn Blacklisted Cars",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Can Spawn SENTs",
         MinAccess = "admin",
+        Category = MODULE.name,
     },
     {
         Name = "UserGroups - Staff Group",
         MinAccess = "admin",
+        Category = MODULE.name,
     },
     {
         Name = "UserGroups - VIP Group",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "List Entities",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Can Remove Blocked Entities",
         MinAccess = "admin",
+        Category = MODULE.name,
     },
     {
         Name = "Can Remove World Entities",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
 }

--- a/gamemode/modules/administration/submodules/staffmanagement/module.lua
+++ b/gamemode/modules/administration/submodules/staffmanagement/module.lua
@@ -5,14 +5,17 @@ MODULE.desc = "Shows staff activity statistics and allows viewing warnings and t
 MODULE.Privileges = {
     {
         Name = "View Staff Actions",
-        MinAccess = "admin"
+        MinAccess = "admin",
+        Category = MODULE.name
     },
     {
         Name = "View Player Warnings",
-        MinAccess = "admin"
+        MinAccess = "admin",
+        Category = MODULE.name
     },
     {
         Name = "View Claims",
-        MinAccess = "admin"
+        MinAccess = "admin",
+        Category = MODULE.name
     }
 }

--- a/gamemode/modules/administration/submodules/tickets/module.lua
+++ b/gamemode/modules/administration/submodules/tickets/module.lua
@@ -6,6 +6,7 @@ MODULE.desc = "Introduces a ticket system where players can submit help requests
 MODULE.Privileges = {
     {
         Name = "Always See Tickets",
-        MinAccess = "superadmin"
+        MinAccess = "superadmin",
+        Category = MODULE.name
     },
 }

--- a/gamemode/modules/chatbox/module.lua
+++ b/gamemode/modules/chatbox/module.lua
@@ -5,22 +5,27 @@ MODULE.desc = "Replaces the default chat with a configurable box that supports c
 MODULE.Privileges = {
     {
         Name = "No OOC Cooldown",
-        MinAccess = "admin"
+        MinAccess = "admin",
+        Category = MODULE.name
     },
     {
         Name = "Admin Chat",
-        MinAccess = "admin"
+        MinAccess = "admin",
+        Category = MODULE.name
     },
     {
         Name = "Local Event Chat",
-        MinAccess = "admin"
+        MinAccess = "admin",
+        Category = MODULE.name
     },
     {
         Name = "Event Chat",
-        MinAccess = "admin"
+        MinAccess = "admin",
+        Category = MODULE.name
     },
     {
         Name = "Always Have Access to Help Chat",
-        MinAccess = "superadmin"
+        MinAccess = "superadmin",
+        Category = MODULE.name
     },
 }

--- a/gamemode/modules/f1menu/module.lua
+++ b/gamemode/modules/f1menu/module.lua
@@ -5,23 +5,28 @@ MODULE.desc = "Adds a comprehensive F1 menu that gathers character management sc
 MODULE.Privileges = {
     {
         Name = "Access Entity List",
-        MinAccess = "admin"
+        MinAccess = "admin",
+        Category = MODULE.name
     },
     {
         Name = "Teleport to Entity",
-        MinAccess = "admin"
+        MinAccess = "admin",
+        Category = MODULE.name
     },
     {
         Name = "Teleport to Entity (Entity Tab)",
-        MinAccess = "admin"
+        MinAccess = "admin",
+        Category = MODULE.name
     },
     {
         Name = "View Entity (Entity Tab)",
-        MinAccess = "admin"
+        MinAccess = "admin",
+        Category = MODULE.name
     },
     {
         Name = "Access Module List",
-        MinAccess = "user"
+        MinAccess = "user",
+        Category = MODULE.name
     }
 }
 

--- a/gamemode/modules/inventory/submodules/storage/module.lua
+++ b/gamemode/modules/inventory/submodules/storage/module.lua
@@ -5,6 +5,7 @@ MODULE.desc = "Adds persistent storage containers and player vaults that integra
 MODULE.Privileges = {
     {
         Name = "Can Spawn Storage",
-        MinAccess = "superadmin"
+        MinAccess = "superadmin",
+        Category = MODULE.name
     }
 }

--- a/gamemode/modules/inventory/submodules/vendor/module.lua
+++ b/gamemode/modules/inventory/submodules/vendor/module.lua
@@ -5,7 +5,8 @@ MODULE.desc = "Provides NPC vendors who can buy and sell items with stock manage
 MODULE.Privileges = {
     {
         Name = "Can Edit Vendors",
-        MinAccess = "admin"
+        MinAccess = "admin",
+        Category = MODULE.name
     },
 }
 

--- a/gamemode/modules/protection/module.lua
+++ b/gamemode/modules/protection/module.lua
@@ -5,6 +5,7 @@ MODULE.desc = "Adds anti-cheat and anti-exploit protections along with monitorin
 MODULE.Privileges = {
     {
         Name = "Can See Alting Notifications",
-        MinAccess = "admin"
+        MinAccess = "admin",
+        Category = MODULE.name
     },
 }

--- a/gamemode/modules/scoreboard/module.lua
+++ b/gamemode/modules/scoreboard/module.lua
@@ -5,10 +5,12 @@ MODULE.desc = "Displays an immersive scoreboard showing recognized players, fact
 MODULE.Privileges = {
     {
         Name = "Can Access Scoreboard Admin Options",
-        MinAccess = "admin"
+        MinAccess = "admin",
+        Category = MODULE.name
     },
     {
         Name = "Can Access Scoreboard Info Out Of Staff",
-        MinAccess = "admin"
+        MinAccess = "admin",
+        Category = MODULE.name
     },
 }


### PR DESCRIPTION
## Summary
- include Category field on privileges for every module
- assign categories for compatibility privileges
- carry Category from command definitions when auto-registering privileges

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6885a98f0bd08327a92aea41100cbf7f