### PR TITLE
Fix privilege category default

### DIFF
--- a/gamemode/core/libraries/modularity.lua
+++ b/gamemode/core/libraries/modularity.lua
@@ -10,7 +10,7 @@ local function loadPermissions(Privileges)
             lia.administration.registerPrivilege({
                 Name = privilegeName,
                 MinAccess = privilegeData.MinAccess or "admin",
-                Category = privilegeData.Category
+                Category = privilegeData.Category or MODULE.name
             })
         end
     end


### PR DESCRIPTION
## Summary
- ensure module privilege categories default to the module's name if not set

## Testing
- `luacheck gamemode` *(fails: `luacheck` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885ab4cb4f48327b587e4792ea7566d