### PR TITLE
Remove noKeying door flag

### DIFF
--- a/gamemode/core/meta/entity.lua
+++ b/gamemode/core/meta/entity.lua
@@ -137,7 +137,6 @@ if SERVER then
     function entityMeta:setKeysNonOwnable(state)
         local flag = state and true or nil
         self:setNetVar("noSell", flag)
-        self:setNetVar("noKeying", flag)
     end
 
     function entityMeta:isDoor()

--- a/gamemode/modules/doors/libraries/server.lua
+++ b/gamemode/modules/doors/libraries/server.lua
@@ -190,7 +190,6 @@ end
 
 function MODULE:KeyLock(client, door, time)
     if not IsValid(door) or not IsValid(client) then return end
-    if door:getNetVar("noKeying") then return end
     if hook.Run("CanPlayerLock", client, door) == false then return end
     local distance = client:GetPos():Distance(door:GetPos())
     local isProperEntity = door:isDoor() or door:IsVehicle() or door:isSimfphysCar()
@@ -203,7 +202,6 @@ end
 
 function MODULE:KeyUnlock(client, door, time)
     if not IsValid(door) or not IsValid(client) then return end
-    if door:getNetVar("noKeying") then return end
     if hook.Run("CanPlayerUnlock", client, door) == false then return end
     local distance = client:GetPos():Distance(door:GetPos())
     local isProperEntity = door:isDoor() or door:IsVehicle() or door:isSimfphysCar()


### PR DESCRIPTION
## Summary
- remove `noKeying` usage in door library
- stop setting `noKeying` network variable

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885abe30a588327b72535122183956d