### PR TITLE
Update DB view to open all tables

### DIFF
--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -1024,20 +1024,6 @@ else
                 local ps = vgui.Create("DPropertySheet", pnl)
                 ps:Dock(FILL)
                 lia.gui.dbBrowserPS = ps
-                local tblPanel = vgui.Create("DPanel", ps)
-                tblPanel:Dock(FILL)
-                tblPanel.Paint = function() end
-                local list = vgui.Create("DListView", tblPanel)
-                list:Dock(FILL)
-                list:AddColumn("Table")
-                lia.gui.dbBrowserList = list
-                function list:OnRowSelected(_, line)
-                    net.Start("liaRequestTableData")
-                    net.WriteString(line:GetColumnText(1))
-                    net.SendToServer()
-                end
-
-                ps:AddSheet("Tables", tblPanel, "icon16/database.png")
                 net.Start("liaDBTablesRequest")
                 net.SendToServer()
                 return pnl

--- a/gamemode/modules/administration/netcalls/client.lua
+++ b/gamemode/modules/administration/netcalls/client.lua
@@ -131,11 +131,10 @@ end
 
 net.Receive("liaDBTables", function()
     local tables = net.ReadTable()
-    local list = lia.gui.dbBrowserList
-    if not IsValid(list) then return end
-    list:Clear()
     for _, tbl in ipairs(tables or {}) do
-        list:AddLine(tbl)
+        net.Start("liaRequestTableData")
+        net.WriteString(tbl)
+        net.SendToServer()
     end
 end)
 


### PR DESCRIPTION
## Summary
- remove the Tables list from the admin DB view
- automatically request data for every table when opening DB view

## Testing
- `luacheck gamemode --no-color` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885bbf00bb08327833b7a78549cded1