### PR TITLE
Fix undefined admin utilities in server netcalls

### DIFF
--- a/gamemode/core/netcalls/server.lua
+++ b/gamemode/core/netcalls/server.lua
@@ -624,7 +624,7 @@ net.Receive("liaGroupsRequest", function(_, p)
     end
 
     syncPrivileges()
-    sendBigTable(p, payloadGroups(), "liaGroupsDataChunk", "liaGroupsDataDone")
+    lia.administration.sendBigTable(p, lia.administration.payloadGroups(), "liaGroupsDataChunk", "liaGroupsDataDone")
 end)
 
 net.Receive("liaPlayersRequest", function(_, p)
@@ -633,7 +633,7 @@ net.Receive("liaPlayersRequest", function(_, p)
     end
 
     if not allowed(p) then return end
-    sendBigTable(p, payloadPlayers(), "liaPlayersDataChunk", "liaPlayersDataDone")
+    lia.administration.sendBigTable(p, lia.administration.payloadPlayers(), "liaPlayersDataChunk", "liaPlayersDataDone")
 end)
 
 net.Receive("liaCharBrowserRequest", function(_, p)
@@ -644,15 +644,15 @@ net.Receive("liaCharBrowserRequest", function(_, p)
     if not allowed(p) then return end
     local mode = net.ReadString()
     if mode == "all" then
-        queryAllCharacters(p, function(data)
-            sendBigTable(p, {
+        lia.administration.queryAllCharacters(p, function(data)
+            lia.administration.sendBigTable(p, {
                 mode = "all",
                 list = data
             }, "liaCharBrowserChunk", "liaCharBrowserDone")
         end)
     else
-        collectOnlineCharacters(p, function(data)
-            sendBigTable(p, {
+        lia.administration.collectOnlineCharacters(p, function(data)
+            lia.administration.sendBigTable(p, {
                 mode = "online",
                 list = data
             }, "liaCharBrowserChunk", "liaCharBrowserDone")
@@ -682,12 +682,12 @@ net.Receive("liaGroupsAdd", function(_, p)
     local n = net.ReadString()
     if n == "" then return end
     lia.administration.createGroup(n)
-    lia.administration.groups[n] = buildDefaultTable(n)
-    ensureCAMIGroup(n, "user")
+    lia.administration.groups[n] = lia.administration.buildDefaultTable(n)
+    lia.administration.ensureCAMIGroup(n, "user")
     lia.administration.save(true)
-    applyToCAMI(n, lia.administration.groups[n])
-    sendBigTable(nil, payloadGroups(), "liaGroupsDataChunk", "liaGroupsDataDone")
-    notify(p, "Group '" .. n .. "' created.")
+    lia.administration.applyToCAMI(n, lia.administration.groups[n])
+    lia.administration.sendBigTable(nil, lia.administration.payloadGroups(), "liaGroupsDataChunk", "liaGroupsDataDone")
+    lia.administration.notify(p, "Group '" .. n .. "' created.")
 end)
 
 net.Receive("liaGroupsRemove", function(_, p)
@@ -697,13 +697,13 @@ net.Receive("liaGroupsRemove", function(_, p)
 
     if not allowed(p) then return end
     local n = net.ReadString()
-    if n == "" or DEFAULT_GROUPS[n] then return end
+    if n == "" or lia.administration.DEFAULT_GROUPS[n] then return end
     lia.administration.removeGroup(n)
     lia.administration.groups[n] = nil
-    dropCAMIGroup(n)
+    lia.administration.dropCAMIGroup(n)
     lia.administration.save(true)
-    sendBigTable(nil, payloadGroups(), "liaGroupsDataChunk", "liaGroupsDataDone")
-    notify(p, "Group '" .. n .. "' removed.")
+    lia.administration.sendBigTable(nil, lia.administration.payloadGroups(), "liaGroupsDataChunk", "liaGroupsDataDone")
+    lia.administration.notify(p, "Group '" .. n .. "' removed.")
 end)
 
 net.Receive("liaGroupsRename", function(_, p)
@@ -714,20 +714,20 @@ net.Receive("liaGroupsRename", function(_, p)
     if not allowed(p) then return end
     local old = net.ReadString()
     local new = net.ReadString()
-    if old == "" or new == "" or DEFAULT_GROUPS[old] or DEFAULT_GROUPS[new] then return end
+    if old == "" or new == "" or lia.administration.DEFAULT_GROUPS[old] or lia.administration.DEFAULT_GROUPS[new] then return end
     if lia.administration.groups[new] or not lia.administration.groups[old] then return end
     lia.administration.groups[new] = lia.administration.groups[old]
     lia.administration.groups[old] = nil
-    dropCAMIGroup(old)
-    ensureCAMIGroup(new, "user")
+    lia.administration.dropCAMIGroup(old)
+    lia.administration.ensureCAMIGroup(new, "user")
     lia.administration.save(true)
-    applyToCAMI(new, lia.administration.groups[new])
+    lia.administration.applyToCAMI(new, lia.administration.groups[new])
     for _, ply in player.Iterator() do
         if ply:GetUserGroup() == old then lia.administration.setPlayerGroup(ply, new) end
     end
 
-    sendBigTable(nil, payloadGroups(), "liaGroupsDataChunk", "liaGroupsDataDone")
-    notify(p, "Group '" .. old .. "' renamed to '" .. new .. "'.")
+    lia.administration.sendBigTable(nil, lia.administration.payloadGroups(), "liaGroupsDataChunk", "liaGroupsDataDone")
+    lia.administration.notify(p, "Group '" .. old .. "' renamed to '" .. new .. "'.")
 end)
 
 net.Receive("liaGroupsApply", function(_, p)
@@ -738,16 +738,16 @@ net.Receive("liaGroupsApply", function(_, p)
     if not allowed(p) then return end
     local g = net.ReadString()
     local t = net.ReadTable()
-    if g == "" or DEFAULT_GROUPS[g] then return end
+    if g == "" or lia.administration.DEFAULT_GROUPS[g] then return end
     lia.administration.groups[g] = {}
     for k, v in pairs(t) do
         if v then lia.administration.groups[g][k] = true end
     end
 
     lia.administration.save(true)
-    applyToCAMI(g, lia.administration.groups[g])
-    sendBigTable(nil, payloadGroups(), "liaGroupsDataChunk", "liaGroupsDataDone")
-    notify(p, "Permissions saved for '" .. g .. "'.")
+    lia.administration.applyToCAMI(g, lia.administration.groups[g])
+    lia.administration.sendBigTable(nil, lia.administration.payloadGroups(), "liaGroupsDataChunk", "liaGroupsDataDone")
+    lia.administration.notify(p, "Permissions saved for '" .. g .. "'.")
 end)
 
 net.Receive("liaGroupsDefaults", function(_, p)
@@ -757,12 +757,12 @@ net.Receive("liaGroupsDefaults", function(_, p)
 
     if not allowed(p) then return end
     local g = net.ReadString()
-    if g == "" or DEFAULT_GROUPS[g] then return end
-    lia.administration.groups[g] = buildDefaultTable(g)
+    if g == "" or lia.administration.DEFAULT_GROUPS[g] then return end
+    lia.administration.groups[g] = lia.administration.buildDefaultTable(g)
     lia.administration.save(true)
-    applyToCAMI(g, lia.administration.groups[g])
-    sendBigTable(nil, payloadGroups(), "liaGroupsDataChunk", "liaGroupsDataDone")
-    notify(p, "Defaults restored for '" .. g .. "'.")
+    lia.administration.applyToCAMI(g, lia.administration.groups[g])
+    lia.administration.sendBigTable(nil, lia.administration.payloadGroups(), "liaGroupsDataChunk", "liaGroupsDataDone")
+    lia.administration.notify(p, "Defaults restored for '" .. g .. "'.")
 end)
 
 -- from modules/spawns/libraries/server.lua

--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -613,6 +613,24 @@ if SERVER then
         end
     end
 
+    -- expose helper functions to other modules
+    lia.administration.DEFAULT_GROUPS = DEFAULT_GROUPS
+    lia.administration.buildDefaultTable = buildDefaultTable
+    lia.administration.ensureCAMIGroup = ensureCAMIGroup
+    lia.administration.dropCAMIGroup = dropCAMIGroup
+    lia.administration.sendBigTable = sendBigTable
+    lia.administration.payloadGroups = payloadGroups
+    lia.administration.payloadPlayers = payloadPlayers
+    lia.administration.collectOnlineCharacters = collectOnlineCharacters
+    lia.administration.queryAllCharacters = queryAllCharacters
+    lia.administration.applyToCAMI = applyToCAMI
+    lia.administration.notify = notify
+
+    function lia.administration.syncAdminGroups(payload)
+        lia.administration.groups = payload or lia.administration.groups
+        lia.administration.updateAdminGroups()
+    end
+
     syncPrivileges()
 else
     local groupChunks, playerChunks, charChunks = {}, {}, {}


### PR DESCRIPTION
## Summary
- expose several admin helper functions through `lia.administration`
- update server netcalls to reference the new helpers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885bffb028883278d2b2697d91afb67