### PR TITLE
Fix settings order

### DIFF
--- a/gamemode/modules/f1menu/libraries/client.lua
+++ b/gamemode/modules/f1menu/libraries/client.lua
@@ -355,6 +355,9 @@ function MODULE:CreateMenuButtons(tabs)
         local pages = {}
         hook.Run("PopulateConfigurationButtons", pages)
         if not pages then return end
+        table.sort(pages, function(a, b)
+            return tostring(a.name) < tostring(b.name)
+        end)
         for _, page in ipairs(pages) do
             local pnl = vgui.Create("DPanel", sheet)
             pnl:Dock(FILL)


### PR DESCRIPTION
## Summary
- sort settings sheets alphabetically

## Testing
- `apt-get update` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68865f926e0c8327baa22f40f22cfe50