### PR TITLE
Sort information sheets alphabetically

### DIFF
--- a/gamemode/modules/f1menu/libraries/client.lua
+++ b/gamemode/modules/f1menu/libraries/client.lua
@@ -339,6 +339,9 @@ function MODULE:CreateMenuButtons(tabs)
         local pages = {}
         hook.Run("CreateInformationButtons", pages)
         if not pages then return end
+        table.sort(pages, function(a, b)
+            return tostring(a.name):lower() < tostring(b.name):lower()
+        end)
         for _, page in ipairs(pages) do
             local pnl = vgui.Create("DPanel", sheet)
             pnl:Dock(FILL)


### PR DESCRIPTION
## Summary
- sort information pages alphabetically in the F1 menu

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68865f89a3988327af2b689f3c8a1052