### PR TITLE
Refactor admin netcalls

### DIFF
--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -517,15 +517,7 @@ if SERVER then
         ensureCAMIGroup(g, CAMI.GetUsergroups()[g] and CAMI.GetUsergroups()[g].Inherits or "user")
     end
 
-    lia.administration.buildDefaultTable = buildDefaultTable
-    lia.administration.ensureCAMIGroup = ensureCAMIGroup
-    lia.administration.dropCAMIGroup = dropCAMIGroup
-    lia.administration.sendBigTable = sendBigTable
-    lia.administration.payloadGroups = payloadGroups
-    lia.administration.payloadPlayers = payloadPlayers
-    lia.administration.collectOnlineCharacters = collectOnlineCharacters
-    lia.administration.queryAllCharacters = queryAllCharacters
-    lia.administration.applyToCAMI = applyToCAMI
+    -- expose only what is necessary; helper functions are kept local
     function lia.administration.syncAdminGroups(payload)
         lia.administration.groups = payload or lia.administration.groups
         lia.administration.updateAdminGroups()


### PR DESCRIPTION
## Summary
- avoid assigning helper functions globally in `administration` module
- define required helper functions locally in `netcalls/server.lua`
- update netcalls to use the local helpers

## Testing
- `make test` *(fails: No rule to make target `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68867f212e5c8327a9b560e39af5b15e