### PR TITLE
Update creator info in admin stick

### DIFF
--- a/gamemode/modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua
+++ b/gamemode/modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua
@@ -36,7 +36,12 @@ function SWEP:DrawHUD()
     if IsValid(target) then
         if not target:IsPlayer() then
             if target.GetCreator and IsValid(target:GetCreator()) then
-                table.Add(information, {L("entityClassESPLabel", target:GetClass()), L("entityCreatorESPLabel", tostring(target:GetCreator()))})
+                local creator = target:GetCreator()
+                local creatorInfo = creator:Name()
+                if creator.SteamID then
+                    creatorInfo = creatorInfo .. " - " .. creator:SteamID()
+                end
+                table.Add(information, {L("entityClassESPLabel", target:GetClass()), L("entityCreatorESPLabel", creatorInfo)})
             end
             if target:IsVehicle() and IsValid(target:GetDriver()) then target = target:GetDriver() end
 
@@ -48,7 +53,7 @@ function SWEP:DrawHUD()
                     table.insert(information, L("itemHeightESPLabel", item.height or 1))
                     local creator = target:GetCreator()
                     if IsValid(creator) then
-                        table.insert(information, L("spawner") .. ": " .. creator:Name() .. " - " .. creator:SteamID())
+                        table.insert(information, L("entityCreatorESPLabel", creator:Name() .. " - " .. creator:SteamID()))
                     end
                     local extra = {}
                     hook.Run("GetAdminStickItemInfo", extra, item, target)


### PR DESCRIPTION
## Summary
- show item creator's SteamID in admin stick info
- remove old spawner label usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886917239388327934a30d79755ee2d