### PR TITLE
Fix spawn menu not assigning creator

### DIFF
--- a/gamemode/core/netcalls/server.lua
+++ b/gamemode/core/netcalls/server.lua
@@ -571,6 +571,7 @@ net.Receive("SpawnMenuSpawnItem", function(_, client)
     lia.item.spawn(id, tr.HitPos, function(item)
         local ent = item:getEntity()
         if not IsValid(ent) then return end
+        ent:SetCreator(client)
         tryFixPropPosition(client, ent)
         undo.Create("item")
         undo.SetPlayer(client)


### PR DESCRIPTION
## Summary
- assign the creator when spawning an item via spawn menu

## Testing
- `luacheck gamemode --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688691821b448327a994407affafa556