### PR TITLE
Switch admin logs to SteamID

### DIFF
--- a/gamemode/modules/chatbox/commands.lua
+++ b/gamemode/modules/chatbox/commands.lua
@@ -19,7 +19,7 @@ lia.command.add("banooc", {
 
         target:setLiliaData("oocBan", true)
         client:notifyLocalized("playerBannedFromOOC", target:Name())
-        lia.log.add(client, "banOOC", target:Name(), target:SteamID64())
+        lia.log.add(client, "banOOC", target:Name(), target:SteamID())
     end
 })
 
@@ -43,7 +43,7 @@ lia.command.add("unbanooc", {
 
         target:setLiliaData("oocBan", false)
         client:notifyLocalized("playerUnbannedFromOOC", target:Name())
-        lia.log.add(client, "unbanOOC", target:Name(), target:SteamID64())
+        lia.log.add(client, "unbanOOC", target:Name(), target:SteamID())
     end
 })
 

--- a/gamemode/modules/protection/libraries/server.lua
+++ b/gamemode/modules/protection/libraries/server.lua
@@ -244,7 +244,7 @@ function MODULE:PlayerAuthed(client, steamid)
     local steamID64 = util.SteamIDTo64(steamid)
     local ownerSteamID64 = client:OwnerSteamID64()
     local steamName = client:SteamName()
-    local steamID = client:SteamID64()
+    local steamID = client:SteamID()
     if KnownCheaters[steamID64] or KnownCheaters[ownerSteamID64] then
         lia.applyPunishment(client, L("usingThirdPartyCheats"), false, true, 0)
         lia.notifyAdmin(L("bannedCheaterNotify", steamName, steamID))
@@ -423,13 +423,13 @@ end
 
 function MODULE:OnCheaterCaught(client)
     if IsValid(client) then
-        lia.log.add(client, "cheaterDetected", client:Name(), client:SteamID64())
+        lia.log.add(client, "cheaterDetected", client:Name(), client:SteamID())
         local hadKeys = client:HasWeapon("lia_keys")
         client:StripWeapons()
         if hadKeys then client:Give("lia_keys") end
         client:notifyLocalized("caughtCheating")
         for _, p in player.Iterator() do
-            if p:isStaffOnDuty() or p:IsSuperAdmin() then p:notifyLocalized("cheaterDetectedStaff", client:Name(), client:SteamID64()) end
+            if p:isStaffOnDuty() or p:IsSuperAdmin() then p:notifyLocalized("cheaterDetectedStaff", client:Name(), client:SteamID()) end
         end
     end
 end

--- a/gamemode/modules/protection/netcalls/server.lua
+++ b/gamemode/modules/protection/netcalls/server.lua
@@ -526,10 +526,10 @@ function MODULE:InitializedModules()
             client.nextExploitNotify = client.nextExploitNotify or 0
             if client.nextExploitNotify > CurTime() then return end
             client.nextExploitNotify = CurTime() + 2
-            lia.log.add(client, "exploitAttempt", client:Name(), client:SteamID64(), tostring(name))
+            lia.log.add(client, "exploitAttempt", client:Name(), client:SteamID(), tostring(name))
             client:notifyLocalized("caughtExploiting")
             for _, p in player.Iterator() do
-                if p:isStaffOnDuty() or p:IsSuperAdmin() then p:notifyLocalized("exploitAttempt", client:Name(), client:SteamID64(), tostring(name)) end
+                if p:isStaffOnDuty() or p:IsSuperAdmin() then p:notifyLocalized("exploitAttempt", client:Name(), client:SteamID(), tostring(name)) end
             end
         end)
     end
@@ -546,9 +546,9 @@ function MODULE:InitializedModules()
             end
 
             net.Receive(netName, function(_, client)
-                lia.log.add(client, "exploitAttempt", client:Name(), client:SteamID64(), tostring(netName))
+                lia.log.add(client, "exploitAttempt", client:Name(), client:SteamID(), tostring(netName))
                 for _, p in player.Iterator() do
-                    if p:isStaffOnDuty() or p:IsSuperAdmin() then p:notifyLocalized("exploitAttempt", client:Name(), client:SteamID64(), tostring(netName)) end
+                    if p:isStaffOnDuty() or p:IsSuperAdmin() then p:notifyLocalized("exploitAttempt", client:Name(), client:SteamID(), tostring(netName)) end
                 end
             end)
         end
@@ -558,14 +558,14 @@ end
 net.Receive("CheckSeed", function(_, client)
     local sentSteamID = net.ReadString()
     if not sentSteamID or sentSteamID == "" then
-        lia.notifyAdmin(L("steamIDMissing", client:Name(), client:SteamID64()))
-        lia.log.add(client, "steamIDMissing", client:Name(), client:SteamID64())
+        lia.notifyAdmin(L("steamIDMissing", client:Name(), client:SteamID()))
+        lia.log.add(client, "steamIDMissing", client:Name(), client:SteamID())
         return
     end
 
     if client:SteamID64() ~= sentSteamID then
-        lia.notifyAdmin(L("steamIDMismatch", client:Name(), client:SteamID64(), sentSteamID))
-        lia.log.add(client, "steamIDMismatch", client:Name(), client:SteamID64(), sentSteamID)
+        lia.notifyAdmin(L("steamIDMismatch", client:Name(), client:SteamID(), sentSteamID))
+        lia.log.add(client, "steamIDMismatch", client:Name(), client:SteamID(), sentSteamID)
     end
 end)
 


### PR DESCRIPTION
## Summary
- use `SteamID` when logging admin actions

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68869808295c8327848f1612134d9a44