### PR TITLE
Fix nil return in character data retrieval

### DIFF
--- a/gamemode/core/meta/character.lua
+++ b/gamemode/core/meta/character.lua
@@ -187,8 +187,14 @@ function characterMeta:setData(k, v, noReplication, receiver)
 end
 
 function characterMeta:getData(key, default)
+    self.dataVars = self.dataVars or {}
     if not key then return self.dataVars end
-    local value = self.dataVars and self.dataVars[key] or default
+
+    local value = self.dataVars[key]
+    if value == nil then
+        return default
+    end
+
     return value
 end
 


### PR DESCRIPTION
## Summary
- ensure `characterMeta:getData` always returns a table

## Testing
- `luacheck gamemode/core/meta/character.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68869a42a6fc83278a665b969c37bb33