### PR TITLE
Fix client variable nil in spectate view

### DIFF
--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -197,7 +197,7 @@ hook.Add("liaAdminRegisterTab", "liaStaffManagementTab", function(tabs)
 end)
 
 local function startSpectateView(ent, originalThirdPerson)
-    local yaw = client:EyeAngles().yaw
+    local yaw = LocalPlayer():EyeAngles().yaw
     local camZOffset = 50
     hook.Add("CalcView", "EntityViewCalcView", function()
         return {


### PR DESCRIPTION
## Summary
- fix `startSpectateView` using undefined `client`

## Testing
- `apt-get update` *(fails: network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6886a78cfe008327ac63a113129526f5