### PR TITLE
Fix duplicate creator info in admin stick

### DIFF
--- a/gamemode/modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua
+++ b/gamemode/modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua
@@ -35,7 +35,7 @@ function SWEP:DrawHUD()
     local information = {}
     if IsValid(target) then
         if not target:IsPlayer() then
-            if target.GetCreator and IsValid(target:GetCreator()) then
+            if target:GetClass() ~= "lia_item" and target.GetCreator and IsValid(target:GetCreator()) then
                 local creator = target:GetCreator()
                 local creatorInfo = creator:Name()
                 if creator.SteamID then


### PR DESCRIPTION
## Summary
- avoid adding duplicate creator info when using the admin stick

## Testing
- `luajit -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886a714a63083278a131cbc9b39e2cc