### PR TITLE
Fix char browser serialization error

### DIFF
--- a/gamemode/core/netcalls/server.lua
+++ b/gamemode/core/netcalls/server.lua
@@ -731,6 +731,10 @@ local function buildCharEntry(client, row)
     local isBanned = stored and stored:getBanned() or row.banned
     local allVars = {}
     for varName, varInfo in pairs(lia.char.vars) do
+        if varInfo.noDisplay or varInfo.noNetworking then
+            continue
+        end
+
         local value
         if stored then
             if varName == "data" then
@@ -764,7 +768,9 @@ local function buildCharEntry(client, row)
             end
         end
 
-        allVars[varName] = value
+        if not checkBadType(varName, value) then
+            allVars[varName] = value
+        end
     end
 
     local lastUsedText


### PR DESCRIPTION
## Summary
- avoid sending non-networkable character vars in admin char list
- filter out invalid values before encoding

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886a93842ac832793be78d3c0a0f2ed