### PR TITLE
Fix admin stick overlay persisting after closing sub windows

### DIFF
--- a/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
@@ -46,6 +46,7 @@ local function OpenPlayerModelUI(tgt)
     fr:Center()
     function fr:OnClose()
         fr:Remove()
+        LocalPlayer().AdminStickTarget = nil
         AdminStickIsOpen = false
     end
 
@@ -64,6 +65,7 @@ local function OpenPlayerModelUI(tgt)
         local id = GetIdentifier(tgt)
         if id ~= "" then RunConsoleCommand("say", "/charsetmodel " .. QuoteArgs(id, txt)) end
         fr:Remove()
+        LocalPlayer().AdminStickTarget = nil
         AdminStickIsOpen = false
     end
 
@@ -96,6 +98,7 @@ local function OpenReasonUI(tgt, cmd)
     fr:Center()
     function fr:OnClose()
         fr:Remove()
+        LocalPlayer().AdminStickTarget = nil
         AdminStickIsOpen = false
     end
 
@@ -129,6 +132,7 @@ local function OpenReasonUI(tgt, cmd)
         end
 
         fr:Remove()
+        LocalPlayer().AdminStickTarget = nil
         AdminStickIsOpen = false
     end
 


### PR DESCRIPTION
## Summary
- ensure AdminStickTarget gets cleared when closing model or reason dialogs

## Testing
- `true` (repo has no tests)


------
https://chatgpt.com/codex/tasks/task_e_6886b964ae788327b392260ea49d871f