### PR TITLE
Fix admin stick target lingering on invalid item

### DIFF
--- a/gamemode/modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua
+++ b/gamemode/modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua
@@ -4,7 +4,9 @@ function SWEP:PrimaryAttack()
     local client = LocalPlayer()
     if IsValid(target) then
         client.AdminStickTarget = target
-        MODULE:OpenAdminStickUI(target)
+        if not MODULE:OpenAdminStickUI(target) then
+            client.AdminStickTarget = nil
+        end
     end
 end
 
@@ -109,6 +111,8 @@ function SWEP:Reload()
     local client = LocalPlayer()
     if client:KeyDown(IN_SPEED) then
         client.AdminStickTarget = client
-        MODULE:OpenAdminStickUI(client)
+        if not MODULE:OpenAdminStickUI(client) then
+            client.AdminStickTarget = nil
+        end
     end
 end

--- a/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
@@ -406,7 +406,7 @@ end
 
 function MODULE:OpenAdminStickUI(tgt)
     local cl = LocalPlayer()
-    if not IsValid(tgt) or not tgt:isDoor() and not tgt:IsPlayer() and not hasAdminStickTargetClass(tgt:GetClass()) then return end
+    if not IsValid(tgt) or not tgt:isDoor() and not tgt:IsPlayer() and not hasAdminStickTargetClass(tgt:GetClass()) then return false end
     AdminStickIsOpen = true
     local menu = DermaMenu()
     menu:Center()
@@ -503,4 +503,5 @@ function MODULE:OpenAdminStickUI(tgt)
     end
 
     menu:Open()
+    return true
 end


### PR DESCRIPTION
## Summary
- reset admin stick target if UI fails to open
- return boolean from `OpenAdminStickUI` to indicate success

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886c5f407808327b223ed39fd5cd7a6