### PR TITLE
Add missing localization

### DIFF
--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -740,6 +740,7 @@ LANGUAGE = {
     noWarnings = "%s n’a aucun avertissement.",
     id = "ID",
     timestamp = "Horodatage",
+    shortAdmin = "Admin",
     admin = "Administrateur",
     noSound = "Vous devez spécifier un son.",
     removeWarning = "Retirer un avertissement",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -740,6 +740,7 @@ LANGUAGE = {
     noWarnings = "%s non ha warning.",
     id = "ID",
     timestamp = "Timestamp",
+    shortAdmin = "Admin",
     admin = "Amministratore",
     noSound = "Devi specificare un path o nome suono.",
     removeWarning = "Rimuovi Warning",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -740,6 +740,7 @@ LANGUAGE = {
     noWarnings = "%s sem advertências.",
     id = "ID",
     timestamp = "Data-hora",
+    shortAdmin = "Admin",
     admin = "Administrador",
     noSound = "Deves especificar som.",
     removeWarning = "Remover Advertência",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -740,6 +740,7 @@ LANGUAGE = {
     noWarnings = "У %s нет предупреждений.",
     id = "ID",
     timestamp = "Время",
+    shortAdmin = "Админ",
     admin = "Администратор",
     noSound = "Нужно указать звук.",
     removeWarning = "Удалить предупреждение",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -740,6 +740,7 @@ LANGUAGE = {
     noWarnings = "%s sin advertencias.",
     id = "ID",
     timestamp = "Fecha",
+    shortAdmin = "Admin",
     admin = "Administrador",
     noSound = "Debes especificar sonido.",
     removeWarning = "Quitar advertencia",


### PR DESCRIPTION
## Summary
- add `shortAdmin` to all non-English localization files

## Testing
- `python3` script to check for missing keys

------
https://chatgpt.com/codex/tasks/task_e_6886dfa761e08327b1d0c6a19250f0cd