### PR TITLE
Fix usergroups admin tab

### DIFF
--- a/gamemode/modules/administration/netcalls/server.lua
+++ b/gamemode/modules/administration/netcalls/server.lua
@@ -180,9 +180,17 @@ local function getPrivList()
     return cats
 end
 
+local function sanitizeCAMIGroups(groups)
+    local t = {}
+    for name, info in pairs(groups or {}) do
+        t[name] = {Inherits = info.Inherits}
+    end
+    return t
+end
+
 local function payloadGroups()
     return {
-        cami = CAMI and CAMI.GetUsergroups and CAMI.GetUsergroups() or {},
+        cami = sanitizeCAMIGroups(CAMI and CAMI.GetUsergroups and CAMI.GetUsergroups() or {}),
         perms = lia.administration.groups or {},
         privCategories = getPrivList()
     }


### PR DESCRIPTION
## Summary
- sanitize CAMI usergroup data before sending it to clients

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886e2cdecac8327b4a05e3af9a2e751