### PR TITLE
Move roster to information tab

### DIFF
--- a/gamemode/modules/teams/libraries/shared.lua
+++ b/gamemode/modules/teams/libraries/shared.lua
@@ -202,19 +202,24 @@ else
         built = true
     end
 
-    function MODULE:CreateMenuButtons(tabs)
+    -- move the roster display under the Information tab instead of creating a
+    -- dedicated menu button
+    hook.Add("CreateInformationButtons", "liaRosterInformation", function(pages)
         local ply = LocalPlayer()
         if not IsValid(ply) then return end
         local char = ply:getChar()
         if not char then return end
         if not (ply:IsSuperAdmin() or char:hasFlags("V")) then return end
-        tabs[L("roster")] = function(panel)
-            rosterRows = {}
-            lists = {}
-            built = false
-            buildRoster(panel)
-        end
-    end
+        table.insert(pages, {
+            name = L("roster"),
+            drawFunc = function(panel)
+                rosterRows = {}
+                lists = {}
+                built = false
+                buildRoster(panel)
+            end
+        })
+    end)
 
     hook.Add("liaAdminRegisterTab", "AdminTabFactions", function(tabs)
         local ply = LocalPlayer()


### PR DESCRIPTION
## Summary
- show the faction roster inside the Information section rather than as its own menu tab

## Testing
- `luacheck gamemode --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886e5dde1908327a8683ed6ffc2dbd0