### PR TITLE
Show admin groups immediately

### DIFF
--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -1031,6 +1031,10 @@ else
                 local pnl = vgui.Create("DPanel", sheet)
                 pnl:DockPadding(10, 10, 10, 10)
                 lia.gui.usergroups = pnl
+                -- draw with any groups we already know about
+                if lia and lia.administration and lia.administration.groups then
+                    buildGroupsUI(pnl, {}, lia.administration.groups)
+                end
                 net.Start("liaGroupsRequest")
                 net.SendToServer()
                 return pnl


### PR DESCRIPTION
## Summary
- populate Usergroups tab using any locally available group data while waiting on a network response

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886e5f34ad08327bf05b149baaf40b1