### PR TITLE
Update ban storage

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -321,6 +321,9 @@ function lia.db.loadTables()
         lia.db.fieldExists("lia_players", "_lastIP"):next(function(exists) if not exists then lia.db.query("ALTER TABLE lia_players ADD COLUMN _lastIP VARCHAR(64)"):catch(ignore) end end)
         lia.db.fieldExists("lia_players", "_lastOnline"):next(function(exists) if not exists then lia.db.query("ALTER TABLE lia_players ADD COLUMN _lastOnline INTEGER"):catch(ignore) end end)
         lia.db.fieldExists("lia_players", "_totalOnlineTime"):next(function(exists) if not exists then lia.db.query("ALTER TABLE lia_players ADD COLUMN _totalOnlineTime FLOAT"):catch(ignore) end end)
+        lia.db.fieldExists("lia_players", "_banStart"):next(function(exists) if not exists then lia.db.query("ALTER TABLE lia_players ADD COLUMN _banStart INTEGER"):catch(ignore) end end)
+        lia.db.fieldExists("lia_players", "_banDuration"):next(function(exists) if not exists then lia.db.query("ALTER TABLE lia_players ADD COLUMN _banDuration INTEGER"):catch(ignore) end end)
+        lia.db.fieldExists("lia_players", "_banReason"):next(function(exists) if not exists then lia.db.query("ALTER TABLE lia_players ADD COLUMN _banReason TEXT"):catch(ignore) end end)
         lia.db.fieldExists("lia_items", "_quantity"):next(function(exists) if not exists then lia.db.query("ALTER TABLE lia_items ADD COLUMN _quantity INTEGER"):catch(ignore) end end)
         lia.db.fieldExists("lia_data", "_data"):next(function(exists) if not exists then lia.db.query("ALTER TABLE lia_data ADD COLUMN _data TEXT"):catch(ignore) end end)
         lia.db.addDatabaseFields()
@@ -339,7 +342,10 @@ function lia.db.loadTables()
                 _data varchar,
                 _lastIP varchar,
                 _lastOnline integer,
-                _totalOnlineTime float
+                _totalOnlineTime float,
+                _banStart integer,
+                _banDuration integer,
+                _banReason text
             );
             CREATE TABLE IF NOT EXISTS lia_chardata (
                 _charID INTEGER NOT NULL,
@@ -518,6 +524,9 @@ function lia.db.loadTables()
                 `_lastIP` VARCHAR(64) NULL DEFAULT NULL COLLATE 'utf8mb4_general_ci',
                 `_lastOnline` INT(32) NULL DEFAULT 0,
                 `_totalOnlineTime` FLOAT NULL DEFAULT 0,
+                `_banStart` INT(32) NULL DEFAULT NULL,
+                `_banDuration` INT(32) NULL DEFAULT 0,
+                `_banReason` TEXT NULL COLLATE 'utf8mb4_general_ci',
                 PRIMARY KEY (`_steamID`)
             );
 

--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -513,7 +513,13 @@ if SERVER then
     end
 
     function playerMeta:banPlayer(reason, duration)
-        lia.admin.addBan(self:SteamID64(), reason, duration)
+        local steam64 = self:SteamID64()
+        local banStart = os.time()
+        lia.db.updateTable({
+            _banStart = banStart,
+            _banDuration = (duration or 0) * 60,
+            _banReason = reason or L("genericReason")
+        }, nil, "players", "_steamID = " .. steam64)
         self:Kick(L("banMessage", self, duration or 0, reason or L("genericReason", self)))
     end
 

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -247,7 +247,11 @@ lia.command.add("plyunban", {
     onRun = function(client, arguments)
         local steamid = arguments[1]
         if steamid and steamid ~= "" then
-            lia.admin.removeBan(steamid)
+            lia.db.updateTable({
+                _banStart = nil,
+                _banDuration = 0,
+                _banReason = ""
+            }, nil, "players", "_steamID = " .. steamid)
             client:notify("Player unbanned")
             lia.log.add(client, "plyUnban", steamid)
         end


### PR DESCRIPTION
## Summary
- store ban details on `lia_players` table
- remove old ban API functions and references
- handle bans via database queries

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888e0d49cd883278b639abe9bf278f8