### PR TITLE
Add privilege categories

### DIFF
--- a/gamemode/core/libraries/commands.lua
+++ b/gamemode/core/libraries/commands.lua
@@ -15,7 +15,8 @@ function lia.command.add(command, data)
         if not CAMI.GetPrivilege(privilegeName) then
             lia.admin.registerPrivilege({
                 Name = privilegeName,
-                MinAccess = superAdminOnly and "superadmin" or "admin"
+                MinAccess = superAdminOnly and "superadmin" or "admin",
+                Category = "Commands"
             })
         end
     end

--- a/gamemode/core/libraries/compatibility/pac.lua
+++ b/gamemode/core/libraries/compatibility/pac.lua
@@ -240,7 +240,8 @@ lia.config.add("BlockPackURLoad", "Block Pack URL Load", true, nil, {
 
 lia.admin.registerPrivilege({
     Name = "Staff Permissions - Can Use PAC3",
-    MinAccess = "admin"
+    MinAccess = "admin",
+    Category = "PAC3"
 })
 
 lia.flag.add("P", "Access to PAC3.")

--- a/gamemode/core/libraries/compatibility/sam.lua
+++ b/gamemode/core/libraries/compatibility/sam.lua
@@ -229,12 +229,14 @@ lia.command.add("plygetplaytime", {
 
 lia.admin.registerPrivilege({
     Name = "Staff Permissions - Can See SAM Notifications Outside Staff Character",
-    MinAccess = "superadmin"
+    MinAccess = "superadmin",
+    Category = "SAM"
 })
 
 lia.admin.registerPrivilege({
     Name = "Staff Permissions - Can Bypass Staff Faction SAM Command whitelist",
-    MinAccess = "superadmin"
+    MinAccess = "superadmin",
+    Category = "SAM"
 })
 
 lia.config.add("AdminOnlyNotification", "Admin Only Notifications", true, nil, {

--- a/gamemode/core/libraries/compatibility/simfphys.lua
+++ b/gamemode/core/libraries/compatibility/simfphys.lua
@@ -71,7 +71,8 @@ lia.config.add("TimeToEnterVehicle", "Time To Enter Vehicle", 4, nil, {
 
 lia.admin.registerPrivilege({
     Name = "Staff Permissions - Can Edit Simfphys Cars",
-    MinAccess = "superadmin"
+    MinAccess = "superadmin",
+    Category = "Simfphys"
 })
 
 hook.Add("simfphysPhysicsCollide", "SIMFPHYS_simfphysPhysicsCollide", function() return true end)

--- a/gamemode/core/libraries/modularity.lua
+++ b/gamemode/core/libraries/modularity.lua
@@ -9,7 +9,8 @@ local function loadPermissions(Privileges)
         if not CAMI.GetPrivilege(privilegeName) then
             lia.admin.registerPrivilege({
                 Name = privilegeName,
-                MinAccess = privilegeData.MinAccess or "admin"
+                MinAccess = privilegeData.MinAccess or "admin",
+                Category = privilegeData.Category or MODULE.name
             })
         end
     end

--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -6,17 +6,21 @@ MODULE.Privileges = {
     {
         Name = "Staff Permissions - Can Remove Warns",
         MinAccess = "superadmin"
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - Manage Prop Blacklist",
         MinAccess = "superadmin"
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - Access Configuration Menu",
         MinAccess = "superadmin"
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - Access Edit Configuration Menu",
         MinAccess = "superadmin"
+        Category = MODULE.name,
     },
 }

--- a/gamemode/modules/administration/submodules/adminstick/module.lua
+++ b/gamemode/modules/administration/submodules/adminstick/module.lua
@@ -6,5 +6,6 @@ MODULE.Privileges = {
     {
         Name = "Staff Permissions - Use Admin Stick",
         MinAccess = "superadmin"
+        Category = MODULE.name,
     },
 }

--- a/gamemode/modules/administration/submodules/itemspawner/module.lua
+++ b/gamemode/modules/administration/submodules/itemspawner/module.lua
@@ -6,5 +6,6 @@ MODULE.Privileges = {
     {
         Name = "Staff Permissions - Can Use Item Spawner",
         MinAccess = "admin"
+        Category = MODULE.name,
     }
 }

--- a/gamemode/modules/administration/submodules/logging/module.lua
+++ b/gamemode/modules/administration/submodules/logging/module.lua
@@ -6,5 +6,6 @@ MODULE.Privileges = {
     {
         Name = "Staff Permissions - Can See Logs",
         MinAccess = "superadmin"
+        Category = MODULE.name,
     }
 }

--- a/gamemode/modules/administration/submodules/permissions/libraries/shared.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/shared.lua
@@ -10,7 +10,8 @@ function MODULE:InitializedModules()
                 if not CAMI.GetPrivilege(privilege) then
                     lia.admin.registerPrivilege({
                         Name = privilege,
-                        MinAccess = "admin"
+                        MinAccess = "admin",
+                        Category = MODULE.name
                     })
                 end
             end
@@ -24,7 +25,8 @@ function MODULE:InitializedModules()
                 if not CAMI.GetPrivilege(privilege) then
                     lia.admin.registerPrivilege({
                         Name = privilege,
-                        MinAccess = defaultUserTools[string.lower(tool)] and "user" or "admin"
+                        MinAccess = defaultUserTools[string.lower(tool)] and "user" or "admin",
+                        Category = MODULE.name
                     })
                 end
             end

--- a/gamemode/modules/administration/submodules/permissions/module.lua
+++ b/gamemode/modules/administration/submodules/permissions/module.lua
@@ -6,117 +6,146 @@ MODULE.Privileges = {
     {
         Name = "Staff Permissions - Can Bypass Character Lock",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - Can Grab World Props",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - Can Grab Players",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - Physgun Pickup",
         MinAccess = "admin",
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - Can Access Item Informations",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - Physgun Pickup on Restricted Entities",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - Physgun Pickup on Vehicles",
         MinAccess = "admin",
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - Can't be Grabbed with PhysGun",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - Can Physgun Reload",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - No Clip Outside Staff Character",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - No Clip ESP Outside Staff Character",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - Can Property World Entities",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - Manage Car Blacklist",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Spawn Permissions - Can Spawn Ragdolls",
         MinAccess = "admin",
+        Category = MODULE.name,
     },
     {
         Name = "Spawn Permissions - Can Spawn SWEPs",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Spawn Permissions - Can Spawn Effects",
         MinAccess = "admin",
+        Category = MODULE.name,
     },
     {
         Name = "Spawn Permissions - Can Spawn Props",
         MinAccess = "admin",
+        Category = MODULE.name,
     },
     {
         Name = "Spawn Permissions - Can Spawn Blacklisted Props",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Spawn Permissions - Can Spawn NPCs",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Spawn Permissions - No Car Spawn Delay",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Spawn Permissions - No Spawn Delay",
         MinAccess = "admin",
+        Category = MODULE.name,
     },
     {
         Name = "Spawn Permissions - Can Spawn Cars",
         MinAccess = "admin",
+        Category = MODULE.name,
     },
     {
         Name = "Spawn Permissions - Can Spawn Blacklisted Cars",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Spawn Permissions - Can Spawn SENTs",
         MinAccess = "admin",
+        Category = MODULE.name,
     },
     {
         Name = "UserGroups - Staff Group",
         MinAccess = "admin",
+        Category = MODULE.name,
     },
     {
         Name = "UserGroups - VIP Group",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - List Entities",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - Can Remove Blocked Entities",
         MinAccess = "admin",
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - Can Remove World Entities",
         MinAccess = "superadmin",
+        Category = MODULE.name,
     },
 }

--- a/gamemode/modules/administration/submodules/tickets/module.lua
+++ b/gamemode/modules/administration/submodules/tickets/module.lua
@@ -7,5 +7,6 @@ MODULE.Privileges = {
     {
         Name = "Staff Permissions - Always See Tickets",
         MinAccess = "superadmin"
+        Category = MODULE.name,
     },
 }

--- a/gamemode/modules/administration/submodules/usergroups/module.lua
+++ b/gamemode/modules/administration/submodules/usergroups/module.lua
@@ -6,6 +6,7 @@ MODULE.Privileges = {
     {
         Name = "Staff Permissions - Manage UserGroups",
         MinAccess = "superadmin"
+        Category = MODULE.name,
     }
 }
 
@@ -14,6 +15,7 @@ local function buildDefaultTable(g)
     local t = {}
     for _, v in ipairs(CAMI.GetPrivileges() or {}) do
         if CAMI.UsergroupInherits(g, v.MinAccess or "user") then t[v.Name] = true end
+        Category = MODULE.name,
     end
     return t
 end
@@ -49,6 +51,7 @@ if SERVER then
             lia.admin.privileges[v.Name] = {
                 Name = v.Name,
                 MinAccess = v.MinAccess or "user"
+        Category = MODULE.name,
             }
         end
 
@@ -490,10 +493,12 @@ hook.Add("CAMI.OnPrivilegeRegistered", "liaSyncAdminPrivilegeAdd", function(pv)
     lia.admin.privileges[pv.Name] = {
         Name = pv.Name,
         MinAccess = pv.MinAccess or "user"
+        Category = MODULE.name,
     }
 
     for g in pairs(lia.admin.groups) do
         if CAMI.UsergroupInherits(g, pv.MinAccess or "user") then lia.admin.groups[g][pv.Name] = true end
+        Category = MODULE.name,
     end
 
     if SERVER then lia.admin.save(true) end

--- a/gamemode/modules/chatbox/module.lua
+++ b/gamemode/modules/chatbox/module.lua
@@ -6,21 +6,26 @@ MODULE.Privileges = {
     {
         Name = "Staff Permissions - No OOC Cooldown",
         MinAccess = "admin"
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - Admin Chat",
         MinAccess = "admin"
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - Local Event Chat",
         MinAccess = "admin"
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - Event Chat",
         MinAccess = "admin"
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - Always Have Access to Help Chat",
         MinAccess = "superadmin"
+        Category = MODULE.name,
     },
 }

--- a/gamemode/modules/f1menu/module.lua
+++ b/gamemode/modules/f1menu/module.lua
@@ -6,22 +6,27 @@ MODULE.Privileges = {
     {
         Name = "Staff Permission — Access Entity List",
         MinAccess = "admin"
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permission — Teleport to Entity",
         MinAccess = "admin"
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permission — Teleport to Entity (Entity Tab)",
         MinAccess = "admin"
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permission — View Entity (Entity Tab)",
         MinAccess = "admin"
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permission — Access Module List",
         MinAccess = "user"
+        Category = MODULE.name,
     }
 }
 

--- a/gamemode/modules/inventory/submodules/storage/module.lua
+++ b/gamemode/modules/inventory/submodules/storage/module.lua
@@ -6,5 +6,6 @@ MODULE.Privileges = {
     {
         Name = "Staff Permissions - Can Spawn Storage",
         MinAccess = "superadmin"
+        Category = MODULE.name,
     }
 }

--- a/gamemode/modules/inventory/submodules/vendor/module.lua
+++ b/gamemode/modules/inventory/submodules/vendor/module.lua
@@ -6,6 +6,7 @@ MODULE.Privileges = {
     {
         Name = "Staff Permissions - Can Edit Vendors",
         MinAccess = "admin"
+        Category = MODULE.name,
     },
 }
 

--- a/gamemode/modules/protection/module.lua
+++ b/gamemode/modules/protection/module.lua
@@ -6,5 +6,6 @@ MODULE.Privileges = {
     {
         Name = "Staff Permissions - Can See Alting Notifications",
         MinAccess = "admin"
+        Category = MODULE.name,
     },
 }

--- a/gamemode/modules/scoreboard/module.lua
+++ b/gamemode/modules/scoreboard/module.lua
@@ -6,9 +6,11 @@ MODULE.Privileges = {
     {
         Name = "Staff Permissions - Can Access Scoreboard Admin Options",
         MinAccess = "admin"
+        Category = MODULE.name,
     },
     {
         Name = "Staff Permissions - Can Access Scoreboard Info Out Of Staff",
         MinAccess = "admin"
+        Category = MODULE.name,
     },
 }


### PR DESCRIPTION
## Summary
- add `Category` to privilege registration
- default privilege category to module name
- categorize dynamic privileges from commands and compatibility libraries

## Testing
- `lua` not available; unable to run tests

------
https://chatgpt.com/codex/tasks/task_e_6888e25df0e483278a966c071e0bd2bc