### PR TITLE
Refactor spawns & sitrooms storage

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -264,10 +264,8 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS `lia_logs`;
     DROP TABLE IF EXISTS `lia_bans`;
     DROP TABLE IF EXISTS `lia_doors`;
-    DROP TABLE IF EXISTS `lia_spawns`;
     DROP TABLE IF EXISTS `lia_chatbox`;
     DROP TABLE IF EXISTS `lia_admingroups`;
-    DROP TABLE IF EXISTS `lia_sitrooms`;
     DROP TABLE IF EXISTS `lia_saveditems`;
     DROP TABLE IF EXISTS `lia_persistence`;
     DROP TABLE IF EXISTS `lia_warnings`;
@@ -298,10 +296,8 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS lia_logs;
     DROP TABLE IF EXISTS lia_bans;
     DROP TABLE IF EXISTS lia_doors;
-    DROP TABLE IF EXISTS lia_spawns;
     DROP TABLE IF EXISTS lia_chatbox;
     DROP TABLE IF EXISTS lia_admingroups;
-    DROP TABLE IF EXISTS lia_sitrooms;
     DROP TABLE IF EXISTS lia_saveditems;
     DROP TABLE IF EXISTS lia_persistence;
     DROP TABLE IF EXISTS lia_warnings;
@@ -447,35 +443,12 @@ function lia.db.loadTables()
                 PRIMARY KEY (_folder, _map, _id)
             );
 
-            CREATE TABLE IF NOT EXISTS lia_spawns (
-                _schema TEXT,
-                _map TEXT,
-                _data TEXT,
-                PRIMARY KEY (_schema, _map)
-            );
-
             CREATE TABLE IF NOT EXISTS lia_chatbox (
                 _schema TEXT,
                 _map TEXT,
                 _data TEXT,
                 PRIMARY KEY (_schema, _map)
             );
-
-            CREATE TABLE IF NOT EXISTS lia_sitrooms (
-                _folder TEXT,
-                _map TEXT,
-                _name TEXT,
-                _pos TEXT,
-                PRIMARY KEY (_folder, _map, _name)
-            );
-
-            CREATE TABLE IF NOT EXISTS lia_data (
-                _folder TEXT,
-                _map TEXT,
-                _data TEXT,
-                PRIMARY KEY (_folder, _map)
-            );
-
             CREATE TABLE IF NOT EXISTS lia_persistence (
                 _id INTEGER PRIMARY KEY AUTOINCREMENT,
                 _folder TEXT,
@@ -620,7 +593,6 @@ function lia.db.loadTables()
                 PRIMARY KEY (`_folder`, `_map`, `_id`)
             );
 
-            CREATE TABLE IF NOT EXISTS `lia_spawns` (
                 `_schema` TEXT NULL,
                 `_map` TEXT NULL,
                 `_data` TEXT NULL,
@@ -634,13 +606,6 @@ function lia.db.loadTables()
                 PRIMARY KEY (`_schema`, `_map`)
             );
 
-            CREATE TABLE IF NOT EXISTS `lia_sitrooms` (
-                `_folder` TEXT NULL,
-                `_map` TEXT NULL,
-                `_name` TEXT NULL,
-                `_pos` TEXT NULL,
-                PRIMARY KEY (`_folder`, `_map`, `_name`)
-            );
 
             CREATE TABLE IF NOT EXISTS `lia_data` (
                 `_folder` TEXT NULL,

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -40,19 +40,10 @@ lia.command.add("managesitrooms", {
     desc = "manageSitroomsDesc",
     onRun = function(client)
         if not client:hasPrivilege("Manage SitRooms") then return end
-        local mapName = game.GetMap()
-        local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-        local condition = "_folder = " .. lia.db.convertDataType(folder) .. " AND _map = " .. lia.db.convertDataType(mapName)
-        lia.db.select({"_name", "_pos"}, "sitrooms", condition):next(function(res)
-            local rooms = {}
-            for _, row in ipairs(res.results or {}) do
-                rooms[row._name] = lia.data.decodeVector(row._pos)
-            end
-
-            net.Start("managesitrooms")
-            net.WriteTable(rooms)
-            net.Send(client)
-        end)
+        local rooms = lia.data.get("sitrooms", {})
+        net.Start("managesitrooms")
+        net.WriteTable(rooms)
+        net.Send(client)
     end
 })
 
@@ -67,17 +58,12 @@ lia.command.add("addsitroom", {
                 return
             end
 
-            local mapName = game.GetMap()
-            local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-            lia.db.upsert({
-                _folder = folder,
-                _map = mapName,
-                _name = name,
-                _pos = lia.data.serialize(client:GetPos()),
-            }, "sitrooms")
+            local rooms = lia.data.get("sitrooms", {})
+            rooms[name] = client:GetPos()
+            lia.data.set("sitrooms", rooms)
 
             client:notifyLocalized("sitroomSet")
-            lia.log.add(client, "sitRoomSet", string.format("Map: %s | Name: %s | Position: %s", mapName, name, tostring(client:GetPos())), "Set the sitroom location")
+            lia.log.add(client, "sitRoomSet", string.format("Name: %s | Position: %s", name, tostring(client:GetPos())), "Set the sitroom location")
         end)
     end
 })
@@ -100,35 +86,28 @@ lia.command.add("sendtositroom", {
             return
         end
 
-        local mapName = game.GetMap()
-        local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-        local condition = "_folder = " .. lia.db.convertDataType(folder) .. " AND _map = " .. lia.db.convertDataType(mapName)
-        lia.db.select({"_name", "_pos"}, "sitrooms", condition):next(function(res)
-            local rooms = {}
-            local names = {}
-            for _, row in ipairs(res.results or {}) do
-                local pos = lia.data.decodeVector(row._pos)
-                rooms[row._name] = pos
-                names[#names + 1] = row._name
-            end
+        local rooms = lia.data.get("sitrooms", {})
+        local names = {}
+        for n in pairs(rooms) do
+            names[#names + 1] = n
+        end
 
-            if #names == 0 then
+        if #names == 0 then
+            client:notifyLocalized("sitroomNotSet")
+            return
+        end
+
+        client:requestDropdown(L("chooseSitroomTitle"), L("selectSitroomPrompt"), names, function(selection)
+            local pos = rooms[selection]
+            if not pos then
                 client:notifyLocalized("sitroomNotSet")
                 return
             end
 
-            client:requestDropdown(L("chooseSitroomTitle"), L("selectSitroomPrompt"), names, function(selection)
-                local pos = rooms[selection]
-                if not pos then
-                    client:notifyLocalized("sitroomNotSet")
-                    return
-                end
-
-                target:SetPos(pos)
-                client:notifyLocalized("sitroomTeleport", target:Nick())
-                target:notifyLocalized("sitroomArrive")
-                lia.log.add(client, "sendToSitRoom", target:Nick(), selection)
-            end)
+            target:SetPos(pos)
+            client:notifyLocalized("sitroomTeleport", target:Nick())
+            target:notifyLocalized("sitroomArrive")
+            lia.log.add(client, "sendToSitRoom", target:Nick(), selection)
         end)
     end
 })


### PR DESCRIPTION
## Summary
- use `lia_data` table for storing spawns and sitrooms
- remove dedicated `lia_spawns` and `lia_sitrooms` tables
- update commands and netcalls to read/write via `lia.data`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888e5a7e56c83279eceb088f677fa67