### PR TITLE
Tie flags to player data

### DIFF
--- a/gamemode/core/hooks/client.lua
+++ b/gamemode/core/hooks/client.lua
@@ -445,7 +445,7 @@ end
 
 function GM:SpawnMenuOpen()
     local client = LocalPlayer()
-    if lia.config.get("SpawnMenuLimit", false) and not (client:getChar():hasFlags("pet") or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn Props")) then return end
+    if lia.config.get("SpawnMenuLimit", false) and not (client:hasFlags("pet") or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn Props")) then return end
     return true
 end
 

--- a/gamemode/core/libraries/flags.lua
+++ b/gamemode/core/libraries/flags.lua
@@ -10,13 +10,11 @@ end
 
 if SERVER then
     function lia.flag.onSpawn(client)
-        if client:getChar() then
-            local flags = client:getChar():getFlags()
-            for i = 1, #flags do
-                local flag = flags:sub(i, i)
-                local info = lia.flag.list[flag]
-                if info and info.callback then info.callback(client, true) end
-            end
+        local flags = client:getFlags()
+        for i = 1, #flags do
+            local flag = flags:sub(i, i)
+            local info = lia.flag.list[flag]
+            if info and info.callback then info.callback(client, true) end
         end
     end
 end
@@ -75,7 +73,7 @@ hook.Add("CreateInformationButtons", "liaInformationFlags", function(pages)
                     flagPanel:DockMargin(10, 5, 10, 0)
                     flagPanel:SetTall(height)
                     flagPanel.Paint = function(pnl, w, h)
-                        local hasFlag = client:getChar():hasFlags(flagName)
+                    local hasFlag = client:hasFlags(flagName)
                         derma.SkinHook("Paint", "Panel", pnl, w, h)
                         draw.SimpleText(L("flagLabel", flagName), "liaMediumFont", 20, 10, color_white, TEXT_ALIGN_LEFT, TEXT_ALIGN_TOP)
                         local icon = hasFlag and "checkbox.png" or "unchecked.png"

--- a/gamemode/core/meta/character.lua
+++ b/gamemode/core/meta/character.lua
@@ -53,14 +53,15 @@ function characterMeta:hasMoney(amount)
 end
 
 function characterMeta:getFlags()
-    return self:getData("f", "")
+    local ply = self:getPlayer()
+    if IsValid(ply) then return ply:getFlags() end
+    return ""
 end
 
 function characterMeta:hasFlags(flags)
-    for i = 1, #flags do
-        if self:getFlags():find(flags:sub(i, i), 1, true) then return true end
-    end
-    return hook.Run("CharHasFlags", self, flags) or false
+    local ply = self:getPlayer()
+    if IsValid(ply) then return ply:hasFlags(flags) end
+    return false
 end
 
 function characterMeta:getItemWeapon(requireEquip)
@@ -340,34 +341,18 @@ if SERVER then
     end
 
     function characterMeta:setFlags(flags)
-        self:setData("f", flags)
+        local ply = self:getPlayer()
+        if IsValid(ply) then ply:setFlags(flags) end
     end
 
     function characterMeta:giveFlags(flags)
-        local addedFlags = ""
-        for i = 1, #flags do
-            local flag = flags:sub(i, i)
-            local info = lia.flag.list[flag]
-            if info then
-                if not self:hasFlags(flag) then addedFlags = addedFlags .. flag end
-                if info.callback then info.callback(self:getPlayer(), true) end
-            end
-        end
-
-        if addedFlags ~= "" then self:setFlags(self:getFlags() .. addedFlags) end
+        local ply = self:getPlayer()
+        if IsValid(ply) then ply:giveFlags(flags) end
     end
 
     function characterMeta:takeFlags(flags)
-        local oldFlags = self:getFlags()
-        local newFlags = oldFlags
-        for i = 1, #flags do
-            local flag = flags:sub(i, i)
-            local info = lia.flag.list[flag]
-            if info and info.callback then info.callback(self:getPlayer(), false) end
-            newFlags = newFlags:gsub(flag, "")
-        end
-
-        if newFlags ~= oldFlags then self:setFlags(newFlags) end
+        local ply = self:getPlayer()
+        if IsValid(ply) then ply:takeFlags(flags) end
     end
 
     function characterMeta:save(callback)

--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -502,6 +502,49 @@ if SERVER then
         return self.liaData
     end
 
+    function playerMeta:getFlags()
+        return self:getLiliaData("flags", "")
+    end
+
+    function playerMeta:hasFlags(flags)
+        for i = 1, #flags do
+            if self:getFlags():find(flags:sub(i, i), 1, true) then return true end
+        end
+
+        return hook.Run("CharHasFlags", self, flags) or false
+    end
+
+    function playerMeta:setFlags(flags)
+        self:setLiliaData("flags", flags)
+    end
+
+    function playerMeta:giveFlags(flags)
+        local addedFlags = ""
+        for i = 1, #flags do
+            local flag = flags:sub(i, i)
+            local info = lia.flag.list[flag]
+            if info then
+                if not self:hasFlags(flag) then addedFlags = addedFlags .. flag end
+                if info.callback then info.callback(self, true) end
+            end
+        end
+
+        if addedFlags ~= "" then self:setFlags(self:getFlags() .. addedFlags) end
+    end
+
+    function playerMeta:takeFlags(flags)
+        local oldFlags = self:getFlags()
+        local newFlags = oldFlags
+        for i = 1, #flags do
+            local flag = flags:sub(i, i)
+            local info = lia.flag.list[flag]
+            if info and info.callback then info.callback(self, false) end
+            newFlags = newFlags:gsub(flag, "")
+        end
+
+        if newFlags ~= oldFlags then self:setFlags(newFlags) end
+    end
+
     function playerMeta:setRagdoll(entity)
         self.liaRagdoll = entity
     end
@@ -967,6 +1010,18 @@ else
     function playerMeta:getAllLiliaData()
         lia.localData = lia.localData or {}
         return lia.localData
+    end
+
+    function playerMeta:getFlags()
+        return self:getLiliaData("flags", "")
+    end
+
+    function playerMeta:hasFlags(flags)
+        for i = 1, #flags do
+            if self:getFlags():find(flags:sub(i, i), 1, true) then return true end
+        end
+
+        return hook.Run("CharHasFlags", self, flags) or false
     end
 
     function playerMeta:NetworkAnimation(active, boneData)

--- a/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
@@ -342,7 +342,7 @@ local function IncludeFlagManagement(tgt, menu, stores)
     local take = GetOrCreateSubMenu(fm, "takeFlagsMenu", stores)
     local toGive, toTake = {}, {}
     for fl in pairs(lia.flag.list) do
-        if not tgt:getChar():hasFlags(fl) then
+        if not tgt:hasFlags(fl) then
             table.insert(toGive, {
                 name = L("giveFlagFormat", fl),
                 cmd = 'say /giveflag ' .. QuoteArgs(GetIdentifier(tgt), fl),

--- a/gamemode/modules/administration/submodules/permissions/commands.lua
+++ b/gamemode/modules/administration/submodules/permissions/commands.lua
@@ -471,7 +471,7 @@ lia.command.add("flaggive", {
         if not flags then
             local available = ""
             for k in SortedPairs(lia.flag.list) do
-                if not target:getChar():hasFlags(k) then available = available .. k .. " " end
+                if not target:hasFlags(k) then available = available .. k .. " " end
             end
 
             available = available:Trim()
@@ -482,7 +482,7 @@ lia.command.add("flaggive", {
             return client:requestString(L("giveFlagsMenu"), L("flagGiveDesc"), function(text) lia.command.run(client, "flaggive", {target:Name(), text}) end, available)
         end
 
-        target:getChar():giveFlags(flags)
+        target:giveFlags(flags)
         client:notifyLocalized("flagGive", client:Name(), flags, target:Name())
         lia.log.add(client, "flagGive", target:Name(), flags)
     end,
@@ -507,9 +507,8 @@ lia.command.add("flaggiveall", {
             return
         end
 
-        local character = target:getChar()
         for k, _ in SortedPairs(lia.flag.list) do
-            if not character:hasFlags(k) then character:giveFlags(k) end
+            if not target:hasFlags(k) then target:giveFlags(k) end
         end
 
         client:notifyLocalized("gaveAllFlags")
@@ -535,14 +534,13 @@ lia.command.add("flagtakeall", {
             return
         end
 
-        local character = target:getChar()
-        if not character then
+        if not target:getChar() then
             client:notifyLocalized("invalidTarget")
             return
         end
 
         for k, _ in SortedPairs(lia.flag.list) do
-            if character:hasFlags(k) then character:takeFlags(k) end
+            if target:hasFlags(k) then target:takeFlags(k) end
         end
 
         client:notifyLocalized("tookAllFlags")
@@ -564,11 +562,11 @@ lia.command.add("flagtake", {
 
         local flags = arguments[2]
         if not flags then
-            local currentFlags = target:getChar():getFlags()
+            local currentFlags = target:getFlags()
             return client:requestString(L("takeFlagsMenu"), L("flagTakeDesc"), function(text) lia.command.run(client, "flagtake", {target:Name(), text}) end, table.concat(currentFlags, ", "))
         end
 
-        target:getChar():takeFlags(flags)
+        target:takeFlags(flags)
         client:notifyLocalized("flagTake", client:Name(), flags, target:Name())
         lia.log.add(client, "flagTake", target:Name(), flags)
     end,
@@ -1407,7 +1405,7 @@ lia.command.add("checkflags", {
             return
         end
 
-        local flags = target:getChar():getFlags()
+        local flags = target:getFlags()
         if flags and #flags > 0 then
             client:ChatPrint(L("charFlags", target:Name(), table.concat(flags, ", ")))
         else

--- a/gamemode/modules/administration/submodules/permissions/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/server.lua
@@ -14,7 +14,7 @@ function GM:PlayerSpawnProp(client, model)
         return false
     end
 
-    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn Props") or client:getChar():hasFlags("e")
+    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn Props") or client:hasFlags("e")
     if not canSpawn then
         lia.log.add(client, "spawnDenied", "prop", model)
         client:notifyLocalized("noSpawnPropsPerm")
@@ -99,7 +99,7 @@ function GM:PlayerSpawnVehicle(client, model)
         return false
     end
 
-    local canSpawn = client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn Cars") or client:getChar():hasFlags("C")
+    local canSpawn = client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn Cars") or client:hasFlags("C")
     if not canSpawn then
         lia.log.add(client, "spawnDenied", "vehicle", model)
         client:notifyLocalized("noSpawnVehicles")
@@ -122,7 +122,7 @@ function GM:PlayerNoClip(ply, enabled)
 end
 
 function GM:PlayerSpawnEffect(client)
-    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn Effects") or client:getChar():hasFlags("L")
+    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn Effects") or client:hasFlags("L")
     if not canSpawn then
         lia.log.add(client, "spawnDenied", "effect")
         client:notifyLocalized("noSpawnEffects")
@@ -131,7 +131,7 @@ function GM:PlayerSpawnEffect(client)
 end
 
 function GM:PlayerSpawnNPC(client)
-    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn NPCs") or client:getChar():hasFlags("n")
+    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn NPCs") or client:hasFlags("n")
     if not canSpawn then
         lia.log.add(client, "spawnDenied", "npc")
         client:notifyLocalized("noSpawnNPCs")
@@ -140,7 +140,7 @@ function GM:PlayerSpawnNPC(client)
 end
 
 function GM:PlayerSpawnRagdoll(client)
-    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn Ragdolls") or client:getChar():hasFlags("r")
+    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn Ragdolls") or client:hasFlags("r")
     if not canSpawn then
         lia.log.add(client, "spawnDenied", "ragdoll")
         client:notifyLocalized("noSpawnRagdolls")
@@ -149,7 +149,7 @@ function GM:PlayerSpawnRagdoll(client)
 end
 
 function GM:PlayerSpawnSENT(client)
-    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn SENTs") or client:getChar():hasFlags("E")
+    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn SENTs") or client:hasFlags("E")
     if not canSpawn then
         lia.log.add(client, "spawnDenied", "sent")
         client:notifyLocalized("noSpawnSents")
@@ -158,7 +158,7 @@ function GM:PlayerSpawnSENT(client)
 end
 
 function GM:PlayerSpawnSWEP(client)
-    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn SWEPs") or client:getChar():hasFlags("z")
+    local canSpawn = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn SWEPs") or client:hasFlags("z")
     if not canSpawn then
         lia.log.add(client, "spawnDenied", "swep", tostring(swep))
         client:notifyLocalized("noSpawnSweps")
@@ -167,7 +167,7 @@ function GM:PlayerSpawnSWEP(client)
 end
 
 function GM:PlayerGiveSWEP(client)
-    local canGive = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn SWEPs") or client:getChar():hasFlags("W")
+    local canGive = client:IsSuperAdmin() or client:isStaffOnDuty() or client:hasPrivilege("Spawn Permissions - Can Spawn SWEPs") or client:hasFlags("W")
     if not canGive then
         lia.log.add(client, "permissionDenied", "give swep")
         client:notifyLocalized("noGiveSweps")
@@ -217,7 +217,7 @@ function GM:CanTool(client, _, tool)
 
     local privilege = "Staff Permissions - Access Tool " .. tool:gsub("^%l", string.upper)
     local isSuperAdmin = client:IsSuperAdmin()
-    local isStaffOrFlagged = client:isStaffOnDuty() or client:getChar():hasFlags("t")
+    local isStaffOrFlagged = client:isStaffOnDuty() or client:hasFlags("t")
     local hasPriv = client:hasPrivilege(privilege)
     if not isSuperAdmin and not (isStaffOrFlagged and hasPriv) then
         local reasons = {}

--- a/gamemode/modules/inventory/submodules/vendor/libraries/server.lua
+++ b/gamemode/modules/inventory/submodules/vendor/libraries/server.lua
@@ -13,7 +13,7 @@ function MODULE:CanPlayerAccessVendor(client, vendor)
     if client:CanEditVendor(vendor) then return true end
     if vendor:isClassAllowed(character:getClass()) then return true end
     if vendor:isFactionAllowed(client:Team()) then return true end
-    if flag and string.len(flag) == 1 and client:getChar():hasFlags(flag) then return true end
+    if flag and string.len(flag) == 1 and client:hasFlags(flag) then return true end
 end
 
 function MODULE:CanPlayerTradeWithVendor(client, vendor, itemType, isSellingToVendor)
@@ -68,7 +68,7 @@ function MODULE:CanPlayerTradeWithVendor(client, vendor, itemType, isSellingToVe
         end
     end
 
-    if flag and not client:getChar():hasFlags(flag) then return false, L("vendorTradeRestrictedFlag") end
+    if flag and not client:hasFlags(flag) then return false, L("vendorTradeRestrictedFlag") end
     return true, nil, isWhitelisted
 end
 


### PR DESCRIPTION
## Summary
- store flags on player data
- delegate character flag functions to player
- adjust spawn logic and commands for player flags

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688908ed8a04832789dac3595b60e817