### PR TITLE
Add whitelist management to admin stick

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -559,6 +559,7 @@ LANGUAGE = {
     adminStickUpdateInvSizeName = "Update Inventory Size",
     adminStickSetInvSizeName = "Set Inventory Size",
     adminStickTransferName = "Transfer Player",
+    adminStickFactionWhitelistName = "Faction Whitelist",
     adminStickUnwhitelistName = "Unwhitelist Player",
     adminStickClassWhitelistName = "Class Whitelist",
     adminStickClassUnwhitelistName = "Class Unwhitelist",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -559,6 +559,7 @@ LANGUAGE = {
     adminStickUpdateInvSizeName = "Maj taille inv.",
     adminStickSetInvSizeName = "Définir taille inv.",
     adminStickTransferName = "Transférer joueur",
+    adminStickFactionWhitelistName = "Whitelist faction",
     adminStickUnwhitelistName = "Retirer whitelist",
     adminStickClassWhitelistName = "Whitelist classe",
     adminStickClassUnwhitelistName = "Unwhitelist classe",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -559,6 +559,7 @@ LANGUAGE = {
     adminStickUpdateInvSizeName = "Aggiorna Dimensione Inventario",
     adminStickSetInvSizeName = "Imposta Dimensione Inventario",
     adminStickTransferName = "Trasferisci Giocatore",
+    adminStickFactionWhitelistName = "Whitelist Fazione",
     adminStickUnwhitelistName = "Rimuovi Whitelist",
     adminStickClassWhitelistName = "Whitelist Classe",
     adminStickClassUnwhitelistName = "Unwhitelist Classe",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -559,6 +559,7 @@ LANGUAGE = {
     adminStickUpdateInvSizeName = "Actualizar Tamanho Inv",
     adminStickSetInvSizeName = "Definir Tamanho Inv",
     adminStickTransferName = "Transferir Jogador",
+    adminStickFactionWhitelistName = "Whitelist Faccao",
     adminStickUnwhitelistName = "Remover Whitelist",
     adminStickClassWhitelistName = "Whitelist Classe",
     adminStickClassUnwhitelistName = "Remover Whitelist Classe",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -559,6 +559,7 @@ LANGUAGE = {
     adminStickUpdateInvSizeName = "Обновить размер инв.",
     adminStickSetInvSizeName = "Установить размер инв.",
     adminStickTransferName = "Перевести игрока",
+    adminStickFactionWhitelistName = "Вайтлист фракции",
     adminStickUnwhitelistName = "Снять вайтлист",
     adminStickClassWhitelistName = "Вайтлист класса",
     adminStickClassUnwhitelistName = "Снять вайтлист класса",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -559,6 +559,7 @@ LANGUAGE = {
     adminStickUpdateInvSizeName = "Actualizar inventario",
     adminStickSetInvSizeName = "Fijar inventario",
     adminStickTransferName = "Transferir jugador",
+    adminStickFactionWhitelistName = "Whitelist facción",
     adminStickUnwhitelistName = "Quitar whitelist",
     adminStickClassWhitelistName = "Whitelist de clase",
     adminStickClassUnwhitelistName = "Quitar whitelist clase",

--- a/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
@@ -271,35 +271,38 @@ local function IncludeCharacterManagement(tgt, menu, stores)
     local cl = LocalPlayer()
     local canFaction = cl:hasPrivilege("Commands - Manage Transfers")
     local canClass = cl:hasPrivilege("Commands - Manage Classes")
+    local canWhitelist = cl:hasPrivilege("Commands - Manage Whitelists")
     local charMenu = GetOrCreateSubMenu(menu, "characterManagement", stores)
     local char = tgt:getChar()
-    if char and canFaction then
+    if char then
         local facID = char:getFaction()
         local curName = L("unknown")
-        local facOptions = {}
         if facID then
-            for _, f in pairs(lia.faction.teams) do
-                if f.index == facID then
-                    curName = f.name
-                    for _, v in pairs(lia.faction.teams) do
-                        table.insert(facOptions, {
-                            name = v.name,
-                            cmd = 'say /plytransfer ' .. QuoteArgs(GetIdentifier(tgt), v.name)
-                        })
+            if canFaction then
+                local facOptions = {}
+                for _, f in pairs(lia.faction.teams) do
+                    if f.index == facID then
+                        curName = f.name
+                        for _, v in pairs(lia.faction.teams) do
+                            table.insert(facOptions, {
+                                name = v.name,
+                                cmd = 'say /plytransfer ' .. QuoteArgs(GetIdentifier(tgt), v.name)
+                            })
+                        end
+
+                        break
                     end
-
-                    break
                 end
-            end
 
-            table.sort(facOptions, function(a, b) return a.name < b.name end)
-            if #facOptions > 0 then
-                local fm = GetOrCreateSubMenu(charMenu, L("setFactionTitle", curName), stores)
-                for _, o in ipairs(facOptions) do
-                    fm:AddOption(L(o.name), function()
-                        cl:ConCommand(o.cmd)
-                        AdminStickIsOpen = false
-                    end):SetIcon("icon16/group.png")
+                table.sort(facOptions, function(a, b) return a.name < b.name end)
+                if #facOptions > 0 then
+                    local fm = GetOrCreateSubMenu(charMenu, L("setFactionTitle", curName), stores)
+                    for _, o in ipairs(facOptions) do
+                        fm:AddOption(L(o.name), function()
+                            cl:ConCommand(o.cmd)
+                            AdminStickIsOpen = false
+                        end):SetIcon("icon16/group.png")
+                    end
                 end
             end
 
@@ -320,6 +323,70 @@ local function IncludeCharacterManagement(tgt, menu, stores)
                         cl:ConCommand(o.cmd)
                         AdminStickIsOpen = false
                     end):SetIcon("icon16/user.png")
+                end
+            end
+
+            if canWhitelist then
+                local facAdd, facRemove = {}, {}
+                for _, v in pairs(lia.faction.teams) do
+                    table.insert(facAdd, {
+                        name = v.name,
+                        cmd = 'say /plywhitelist ' .. QuoteArgs(GetIdentifier(tgt), v.name)
+                    })
+                    table.insert(facRemove, {
+                        name = v.name,
+                        cmd = 'say /plyunwhitelist ' .. QuoteArgs(GetIdentifier(tgt), v.name)
+                    })
+                end
+
+                table.sort(facAdd, function(a, b) return a.name < b.name end)
+                table.sort(facRemove, function(a, b) return a.name < b.name end)
+                local fw = GetOrCreateSubMenu(charMenu, "adminStickFactionWhitelistName", stores)
+                for _, o in ipairs(facAdd) do
+                    fw:AddOption(L(o.name), function()
+                        cl:ConCommand(o.cmd)
+                        AdminStickIsOpen = false
+                    end):SetIcon("icon16/group_add.png")
+                end
+
+                local fu = GetOrCreateSubMenu(charMenu, "adminStickUnwhitelistName", stores)
+                for _, o in ipairs(facRemove) do
+                    fu:AddOption(L(o.name), function()
+                        cl:ConCommand(o.cmd)
+                        AdminStickIsOpen = false
+                    end):SetIcon("icon16/group_delete.png")
+                end
+
+                if classes and #classes > 0 then
+                    local cw, cu = {}, {}
+                    for _, c in ipairs(classes) do
+                        table.insert(cw, {
+                            name = c.name,
+                            cmd = 'say /classwhitelist ' .. QuoteArgs(GetIdentifier(tgt), c.uniqueID)
+                        })
+                        table.insert(cu, {
+                            name = c.name,
+                            cmd = 'say /classunwhitelist ' .. QuoteArgs(GetIdentifier(tgt), c.uniqueID)
+                        })
+                    end
+
+                    table.sort(cw, function(a, b) return a.name < b.name end)
+                    table.sort(cu, function(a, b) return a.name < b.name end)
+                    local cwm = GetOrCreateSubMenu(charMenu, "adminStickClassWhitelistName", stores)
+                    for _, o in ipairs(cw) do
+                        cwm:AddOption(L(o.name), function()
+                            cl:ConCommand(o.cmd)
+                            AdminStickIsOpen = false
+                        end):SetIcon("icon16/user_add.png")
+                    end
+
+                    local cum = GetOrCreateSubMenu(charMenu, "adminStickClassUnwhitelistName", stores)
+                    for _, o in ipairs(cu) do
+                        cum:AddOption(L(o.name), function()
+                            cl:ConCommand(o.cmd)
+                            AdminStickIsOpen = false
+                        end):SetIcon("icon16/user_delete.png")
+                    end
                 end
             end
         end

--- a/gamemode/modules/teams/commands.lua
+++ b/gamemode/modules/teams/commands.lua
@@ -194,6 +194,12 @@ lia.command.add("plywhitelist", {
     privilege = "Manage Whitelists",
     desc = "plyWhitelistDesc",
     syntax = "[player Name] [faction Faction]",
+    AdminStick = {
+        Name = "adminStickFactionWhitelistName",
+        Category = "characterManagement",
+        SubCategory = "adminStickSubCategorySetInfos",
+        Icon = "icon16/group_add.png"
+    },
     alias = {"factionwhitelist"},
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
@@ -218,6 +224,12 @@ lia.command.add("plyunwhitelist", {
     privilege = "Manage Whitelists",
     desc = "plyUnwhitelistDesc",
     syntax = "[player Name] [faction Faction]",
+    AdminStick = {
+        Name = "adminStickUnwhitelistName",
+        Category = "characterManagement",
+        SubCategory = "adminStickSubCategorySetInfos",
+        Icon = "icon16/group_delete.png"
+    },
     alias = {"factionunwhitelist"},
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])


### PR DESCRIPTION
## Summary
- allow faction/class whitelist management from the admin stick
- provide translations for `adminStickFactionWhitelistName`
- add AdminStick metadata to plywhitelist and plyunwhitelist commands

## Testing
- `luacheck gamemode` *(fails: luacheck not found)*

------
https://chatgpt.com/codex/tasks/task_e_68890e56d2108327a6d511f2874f75cb