### PR TITLE
Add joinable classes retrieval

### DIFF
--- a/gamemode/core/libraries/classes.lua
+++ b/gamemode/core/libraries/classes.lua
@@ -83,3 +83,15 @@ function lia.class.hasWhitelist(class)
     if info.isDefault then return false end
     return info.isWhitelisted
 end
+
+function lia.class.retrieveJoinable(client)
+    client = client or (CLIENT and LocalPlayer() or nil)
+    if not IsValid(client) then return {} end
+    local classes = {}
+    for _, class in pairs(lia.class.list) do
+        if lia.class.canBe(client, class.index) then
+            classes[#classes + 1] = class
+        end
+    end
+    return classes
+end

--- a/gamemode/modules/teams/libraries/client.lua
+++ b/gamemode/modules/teams/libraries/client.lua
@@ -20,5 +20,8 @@ function MODULE:DrawCharInfo(client, _, info)
 end
 
 function MODULE:CreateMenuButtons(tabs)
-    tabs["classes"] = function(panel) panel:Add("liaClasses") end
+    local joinable = lia.class.retrieveJoinable(LocalPlayer())
+    if #joinable > 1 then
+        tabs["classes"] = function(panel) panel:Add("liaClasses") end
+    end
 end


### PR DESCRIPTION
## Summary
- add `lia.class.retrieveJoinable` to gather joinable classes for a player
- only show the "classes" menu when more than one joinable class is available

## Testing
- `luacheck` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688910a16b9c832796e437ba2fbcd674