### PR TITLE
Adjust keybind reset button position

### DIFF
--- a/gamemode/core/libraries/keybind.lua
+++ b/gamemode/core/libraries/keybind.lua
@@ -300,8 +300,8 @@ hook.Add("PopulateConfigurationButtons", "PopulateKeybinds", function(pages)
         end
 
         if allowEdit then
-            local resetAllBtn = container:Add("DButton")
-            resetAllBtn:Dock(TOP)
+            local resetAllBtn = container:Add("liaMediumButton")
+            resetAllBtn:Dock(BOTTOM)
             resetAllBtn:SetTall(30)
             resetAllBtn:SetText(L("resetAllKeybinds"))
             resetAllBtn.DoClick = function()


### PR DESCRIPTION
## Summary
- use `liaMediumButton` for the keybind reset button
- dock the reset button at the bottom of the keybinds panel

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68892da9e2208327b64d64e6dc239f6a