### PR TITLE
Refactor logs UI with property sheet

### DIFF
--- a/gamemode/modules/administration/submodules/logging/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/logging/libraries/client.lua
@@ -1,77 +1,60 @@
-﻿local receivedChunks = {}
+local receivedChunks = {}
 local receivedPanel
 local function OpenLogsUI(panel, categorizedLogs)
     panel:Clear()
-    local sidebar = panel:Add("DScrollPanel")
-    sidebar:Dock(RIGHT)
-    sidebar:SetWide(200)
-    sidebar:DockMargin(0, 20, 20, 20)
-    local contentPanel = panel:Add("DPanel")
-    contentPanel:Dock(FILL)
-    contentPanel:DockMargin(10, 10, 10, 10)
-    local search = contentPanel:Add("DTextEntry")
-    search:Dock(TOP)
-    search:SetPlaceholderText(L("searchLogs"))
-    search:SetTextColor(Color(255, 255, 255))
-    local list = contentPanel:Add("DListView")
-    list:Dock(FILL)
-    list:SetMultiSelect(false)
-    list:AddColumn(L("timestamp")):SetFixedWidth(150)
-    list:AddColumn(L("logMessage"))
-    list:AddColumn(L("steamID")):SetFixedWidth(110)
-    local copyButton = contentPanel:Add("liaMediumButton")
-    copyButton:Dock(BOTTOM)
-    copyButton:SetText(L("copySelectedRow"))
-    copyButton:SetTall(40)
-    local currentLogs = {}
-    local selectedButton
+    local sheet = panel:Add("DPropertySheet")
+    sheet:Dock(FILL)
+    sheet:DockMargin(10, 10, 10, 10)
+
     for category, logs in pairs(categorizedLogs) do
-        local btn = sidebar:Add("liaMediumButton")
-        btn:Dock(TOP)
-        btn:DockMargin(0, 0, 0, 10)
-        btn:SetTall(40)
-        btn:SetText(category)
-        btn.DoClick = function()
-            if IsValid(selectedButton) then selectedButton:SetSelected(false) end
-            btn:SetSelected(true)
-            selectedButton = btn
+        local page = sheet:Add("DPanel")
+        page:Dock(FILL)
+        page:DockPadding(10, 10, 10, 10)
+
+        local search = page:Add("DTextEntry")
+        search:Dock(TOP)
+        search:SetPlaceholderText(L("searchLogs"))
+        search:SetTextColor(Color(255, 255, 255))
+
+        local list = page:Add("DListView")
+        list:Dock(FILL)
+        list:SetMultiSelect(false)
+        list:AddColumn(L("timestamp")):SetFixedWidth(150)
+        list:AddColumn(L("logMessage"))
+        list:AddColumn(L("steamID")):SetFixedWidth(110)
+
+        local copyButton = page:Add("liaMediumButton")
+        copyButton:Dock(BOTTOM)
+        copyButton:SetText(L("copySelectedRow"))
+        copyButton:SetTall(40)
+
+        local function populate(filter)
+            filter = string.lower(filter or "")
             list:Clear()
-            currentLogs = logs
             for _, log in ipairs(logs) do
-                list:AddLine(log.timestamp, log.message, log.steamID or "")
+                local msgMatch = string.find(string.lower(log.message), filter, 1, true)
+                local idMatch = log.steamID and string.find(string.lower(log.steamID), filter, 1, true)
+                if filter == "" or msgMatch or idMatch then
+                    list:AddLine(log.timestamp, log.message, log.steamID or "")
+                end
             end
         end
-    end
 
-    search.OnChange = function()
-        local query = string.lower(search:GetValue())
-        list:Clear()
-        for _, log in ipairs(currentLogs) do
-            local msgMatch = string.find(string.lower(log.message), query, 1, true)
-            local idMatch = log.steamID and string.find(string.lower(log.steamID), query, 1, true)
-            if query == "" or msgMatch or idMatch then list:AddLine(log.timestamp, log.message, log.steamID or "") end
-        end
-    end
+        search.OnChange = function() populate(search:GetValue()) end
 
-    copyButton.DoClick = function()
-        local sel = list:GetSelectedLine()
-        if sel then
-            local line = list:GetLine(sel)
-            local text = "[" .. line:GetColumnText(1) .. "] " .. line:GetColumnText(2)
-            local id = line:GetColumnText(3)
-            if id and id ~= "" then text = text .. " [" .. id .. "]" end
-            SetClipboardText(text)
-        end
-    end
-
-    local firstCategory = next(categorizedLogs)
-    if firstCategory then
-        for _, btn in ipairs(sidebar:GetChildren()) do
-            if btn:GetText() == firstCategory then
-                btn:DoClick()
-                break
+        copyButton.DoClick = function()
+            local sel = list:GetSelectedLine()
+            if sel then
+                local line = list:GetLine(sel)
+                local text = "[" .. line:GetColumnText(1) .. "] " .. line:GetColumnText(2)
+                local id = line:GetColumnText(3)
+                if id and id ~= "" then text = text .. " [" .. id .. "]" end
+                SetClipboardText(text)
             end
         end
+
+        populate("")
+        sheet:AddSheet(category, page)
     end
 end
 


### PR DESCRIPTION
## Summary
- rework logging interface
- use `DPropertySheet` tabs instead of sidebar buttons

## Testing
- `lua` not available, no tests run

------
https://chatgpt.com/codex/tasks/task_e_6889328633e08327b32f002cd9c2ac57