### PR TITLE
Add blacklist privileges

### DIFF
--- a/gamemode/modules/administration/libraries/shared.lua
+++ b/gamemode/modules/administration/libraries/shared.lua
@@ -32,14 +32,14 @@ properties.Add("ToggleCarBlacklist", {
     MenuLabel = L("ToggleCarBlacklist"),
     Order = 901,
     MenuIcon = "icon16/link.png",
-    Filter = function(_, ent, ply) return IsValid(ent) and (ent:IsVehicle() or ent:isSimfphysCar()) and ply:hasPrivilege("Manage Car Blacklist") end,
+    Filter = function(_, ent, ply) return IsValid(ent) and (ent:IsVehicle() or ent:isSimfphysCar()) and ply:hasPrivilege("Manage Vehicle Blacklist") end,
     Action = function(self, ent)
         self:MsgStart()
         net.WriteString(ent:GetModel())
         self:MsgEnd()
     end,
     Receive = function(_, _, ply)
-        if not ply:hasPrivilege("Manage Car Blacklist") then return end
+        if not ply:hasPrivilege("Manage Vehicle Blacklist") then return end
         local model = net.ReadString()
         local list = lia.data.get("carBlacklist", {})
         if table.HasValue(list, model) then

--- a/gamemode/modules/administration/module.lua
+++ b/gamemode/modules/administration/module.lua
@@ -9,6 +9,16 @@ MODULE.Privileges = {
         Category = "Blacklisting",
     },
     {
+        Name = "Manage Vehicle Blacklist",
+        MinAccess = "superadmin",
+        Category = "Blacklisting",
+    },
+    {
+        Name = "Manage Entity Blacklist",
+        MinAccess = "superadmin",
+        Category = "Blacklisting",
+    },
+    {
         Name = "Access Configuration Menu",
         MinAccess = "superadmin",
         Category = "Staff Permissions",

--- a/gamemode/modules/administration/submodules/permissions/module.lua
+++ b/gamemode/modules/administration/submodules/permissions/module.lua
@@ -64,7 +64,12 @@ MODULE.Privileges = {
         Category = "Staff Permissions",
     },
     {
-        Name = "Manage Car Blacklist",
+        Name = "Manage Vehicle Blacklist",
+        MinAccess = "superadmin",
+        Category = "Staff Permissions",
+    },
+    {
+        Name = "Manage Entity Blacklist",
         MinAccess = "superadmin",
         Category = "Staff Permissions",
     },


### PR DESCRIPTION
## Summary
- add privileges for props, vehicles and entities blacklists
- use the new vehicle blacklist privilege in the admin menu

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688933402d8883278722442487a773ab