### PR TITLE
Fix F1 menu order

### DIFF
--- a/gamemode/core/derma/f1menu/cl_menu.lua
+++ b/gamemode/core/derma/f1menu/cl_menu.lua
@@ -110,7 +110,10 @@ function PANEL:Init()
         tabKeys[#tabKeys + 1] = k
     end
 
-    table.sort(tabKeys, function(a, b) return #L(a) < #L(b) end)
+    table.sort(tabKeys, function(a, b)
+        local aName, bName = tostring(L(a)):lower(), tostring(L(b)):lower()
+        return aName < bName
+    end)
     self.tabList = {}
     for _, key in ipairs(tabKeys) do
         local cb = btnDefs[key]


### PR DESCRIPTION
## Summary
- sort F1 menu buttons alphabetically

## Testing
- `lua -v` *(fails: command not found)*
- `luajit -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688933737a34832796de9670b56ed109