### PR TITLE
Add registration helpers for factions and classes

### DIFF
--- a/gamemode/core/libraries/classes.lua
+++ b/gamemode/core/libraries/classes.lua
@@ -1,5 +1,42 @@
-﻿lia.class = lia.class or {}
+lia.class = lia.class or {}
 lia.class.list = lia.class.list or {}
+function lia.class.register(uniqueID, data)
+    assert(isstring(uniqueID), "uniqueID must be a string")
+    assert(istable(data), "data must be a table")
+
+    local index = #lia.class.list + 1
+    local existing
+    for i, v in ipairs(lia.class.list) do
+        if v.uniqueID == uniqueID then
+            index = i
+            existing = v
+            break
+        end
+    end
+
+    local class = existing or { index = index }
+    for k, v in pairs(data) do
+        class[k] = v
+    end
+
+    class.uniqueID = uniqueID
+    class.name = class.name or L("unknown")
+    class.desc = class.desc or L("noDesc")
+    class.limit = class.limit or 0
+
+    if not class.faction or not team.Valid(class.faction) then
+        lia.error("Class '" .. uniqueID .. "' does not have a valid faction!\n")
+        return
+    end
+
+    if not class.OnCanBe then
+        class.OnCanBe = function() return true end
+    end
+
+    lia.class.list[index] = class
+
+    return class
+end
 function lia.class.loadFromDir(directory)
     for _, v in ipairs(file.Find(directory .. "/*.lua", "LUA")) do
         local index = #lia.class.list + 1

--- a/gamemode/core/libraries/factions.lua
+++ b/gamemode/core/libraries/factions.lua
@@ -1,7 +1,45 @@
-﻿lia.faction = lia.faction or {}
+lia.faction = lia.faction or {}
 lia.faction.indices = lia.faction.indices or {}
 lia.faction.teams = lia.faction.teams or {}
 local DefaultModels = {"models/player/barney.mdl", "models/player/alyx.mdl", "models/player/breen.mdl", "models/player/p2_chell.mdl"}
+
+function lia.faction.register(uniqueID, data)
+    assert(isstring(uniqueID), "uniqueID must be a string")
+    assert(istable(data), "data must be a table")
+
+    local faction = lia.faction.teams[uniqueID] or {
+        index = table.Count(lia.faction.teams) + 1,
+        isDefault = true
+    }
+
+    for k, v in pairs(data) do
+        faction[k] = v
+    end
+
+    faction.name = faction.name or "unknown"
+    faction.desc = faction.desc or "noDesc"
+    faction.color = faction.color or Color(150, 150, 150)
+    faction.models = faction.models or DefaultModels
+    faction.uniqueID = uniqueID
+
+    faction.name = L(faction.name)
+    faction.desc = L(faction.desc)
+
+    team.SetUp(faction.index, faction.name or L("unknown"), faction.color or Color(125, 125, 125))
+
+    for _, modelData in pairs(faction.models) do
+        if isstring(modelData) then
+            util.PrecacheModel(modelData)
+        elseif istable(modelData) then
+            util.PrecacheModel(modelData[1])
+        end
+    end
+
+    lia.faction.indices[faction.index] = faction
+    lia.faction.teams[uniqueID] = faction
+
+    return faction
+end
 function lia.faction.loadFromDir(directory)
     for _, v in ipairs(file.Find(directory .. "/*.lua", "LUA")) do
         local niceName

--- a/gamemode/modules/administration/submodules/permissions/factions/staff.lua
+++ b/gamemode/modules/administration/submodules/permissions/factions/staff.lua
@@ -1,7 +1,16 @@
-﻿FACTION.name = "factionStaffName"
-FACTION.desc = "factionStaffDesc"
-FACTION.color = Color(255, 56, 252)
-FACTION.isDefault = false
-FACTION.models = {"models/Humans/Group02/male_07.mdl", "models/Humans/Group02/male_07.mdl", "models/Humans/Group02/male_07.mdl", "models/Humans/Group02/male_07.mdl", "models/Humans/Group02/male_07.mdl"}
-FACTION.weapons = {"weapon_physgun", "gmod_tool"}
+local FACTION = lia.faction.register("staff", {
+    name = "factionStaffName",
+    desc = "factionStaffDesc",
+    color = Color(255, 56, 252),
+    isDefault = false,
+    models = {
+        "models/Humans/Group02/male_07.mdl",
+        "models/Humans/Group02/male_07.mdl",
+        "models/Humans/Group02/male_07.mdl",
+        "models/Humans/Group02/male_07.mdl",
+        "models/Humans/Group02/male_07.mdl",
+    },
+    weapons = {"weapon_physgun", "gmod_tool"}
+})
+
 FACTION_STAFF = FACTION.index


### PR DESCRIPTION
## Summary
- add `lia.faction.register` to create factions programmatically
- add `lia.class.register` to create classes programmatically
- use `lia.faction.register` for the staff faction definition

## Testing
- `luacheck gamemode --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68893893a4e883278d04c5337573e62c