### PR TITLE
Fix command list size

### DIFF
--- a/gamemode/core/libraries/commands.lua
+++ b/gamemode/core/libraries/commands.lua
@@ -550,7 +550,7 @@ hook.Add("CreateInformationButtons", "liaInformationCommandsUnified", function(p
         drawFunc = function(parent)
             local sheet = vgui.Create("liaSheet", parent)
             sheet:SetPlaceholderText(L("searchCommands"))
-            local useList = false
+            local useList = true
             if useList then
                 local data = {}
                 for cmdName, cmdData in SortedPairs(lia.command.list) do


### PR DESCRIPTION
## Summary
- display commands in a list view instead of large text entries

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6889496ebe708327922630168d906f36