### PR TITLE
Rename folder column to gamemode

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -663,9 +663,9 @@ function GM:LoadData()
         end
     end)
 
-    local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
+    local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
     local map = game.GetMap()
-    local condition = "schema = " .. lia.db.convertDataType(folder) .. " AND map = " .. lia.db.convertDataType(map)
+    local condition = "schema = " .. lia.db.convertDataType(gamemode) .. " AND map = " .. lia.db.convertDataType(map)
     lia.db.select({"_itemID", "_pos", "_angles"}, "saveditems", condition):next(function(res)
         local items = res.results or {}
         if #items > 0 then

--- a/gamemode/core/libraries/character.lua
+++ b/gamemode/core/libraries/character.lua
@@ -471,11 +471,12 @@ if SERVER then
     function lia.char.create(data, callback)
         local timeStamp = os.date("%Y-%m-%d %H:%M:%S", os.time())
         data.money = data.money or lia.config.get("DefaultMoney")
+        local gamemode = SCHEMA and SCHEMA.folder or "lilia"
         lia.db.insertTable({
             name = data.name or "",
             desc = data.desc or "",
             model = data.model or "models/error.mdl",
-            schema = SCHEMA and SCHEMA.folder or "lilia",
+            schema = gamemode,
             createTime = timeStamp,
             lastJoinTime = timeStamp,
             steamID = data.steamID,
@@ -516,7 +517,8 @@ if SERVER then
         end
 
         fields = table.concat(fields, ", ")
-        local condition = "schema = '" .. lia.db.escape(SCHEMA.folder) .. "' AND steamID = " .. steamID64
+        local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
+        local condition = "schema = '" .. lia.db.escape(gamemode) .. "' AND steamID = " .. steamID64
         if id then condition = condition .. " AND id = " .. id end
         local query = "SELECT " .. fields .. " FROM lia_characters WHERE " .. condition
         lia.db.query(query, function(data)

--- a/gamemode/core/libraries/config.lua
+++ b/gamemode/core/libraries/config.lua
@@ -67,8 +67,8 @@ end
 
 function lia.config.load()
     if SERVER then
-        local schema = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-        lia.db.select({"key", "value"}, "config", "schema = " .. lia.db.convertDataType(schema)):next(function(res)
+        local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
+        lia.db.select({"key", "value"}, "config", "schema = " .. lia.db.convertDataType(gamemode)):next(function(res)
             local rows = res.results or {}
             local existing = {}
             for _, row in ipairs(rows) do
@@ -142,10 +142,10 @@ if SERVER then
             }
         end
 
-        local schema = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-        local queries = {"DELETE FROM lia_config WHERE schema = " .. lia.db.convertDataType(schema)}
+        local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
+        local queries = {"DELETE FROM lia_config WHERE schema = " .. lia.db.convertDataType(gamemode)}
         for _, row in ipairs(rows) do
-            queries[#queries + 1] = "INSERT INTO lia_config (schema,key,value) VALUES (" .. lia.db.convertDataType(schema) .. ", " .. lia.db.convertDataType(row.key) .. ", " .. lia.db.convertDataType(row.value) .. ")"
+            queries[#queries + 1] = "INSERT INTO lia_config (schema,key,value) VALUES (" .. lia.db.convertDataType(gamemode) .. ", " .. lia.db.convertDataType(row.key) .. ", " .. lia.db.convertDataType(row.value) .. ")"
         end
 
         lia.db.transaction(queries)

--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -404,7 +404,7 @@ function lia.db.loadTables()
             );
 
             CREATE TABLE IF NOT EXISTS lia_doors (
-                folder TEXT,
+                gamemode TEXT,
                 map TEXT,
                 id INTEGER,
                 factions TEXT,
@@ -416,12 +416,12 @@ function lia.db.loadTables()
                 price INTEGER,
                 locked INTEGER,
                 children TEXT,
-                PRIMARY KEY (folder, map, id)
+                PRIMARY KEY (gamemode, map, id)
             );
 
             CREATE TABLE IF NOT EXISTS lia_persistence (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
-                folder TEXT,
+                gamemode TEXT,
                 map TEXT,
                 class TEXT,
                 pos TEXT,
@@ -540,7 +540,7 @@ function lia.db.loadTables()
             );
 
             CREATE TABLE IF NOT EXISTS `lia_doors` (
-                `folder` TEXT NULL,
+                `gamemode` TEXT NULL,
                 `map` TEXT NULL,
                 `id` INT NOT NULL,
                 `factions` TEXT NULL,
@@ -552,7 +552,7 @@ function lia.db.loadTables()
                 `price` INT NULL,
                 `locked` TINYINT(1) NULL,
                 `children` TEXT NULL,
-                PRIMARY KEY (`folder`, `map`, `id`)
+                PRIMARY KEY (`gamemode`, `map`, `id`)
             );
 
                 `schema` TEXT NULL,
@@ -562,15 +562,15 @@ function lia.db.loadTables()
             );
 
             CREATE TABLE IF NOT EXISTS `lia_data` (
-                `folder` TEXT NULL,
+                `gamemode` TEXT NULL,
                 `map` TEXT NULL,
                 `data` TEXT NULL,
-                PRIMARY KEY (`folder`, `map`)
+                PRIMARY KEY (`gamemode`, `map`)
             );
 
             CREATE TABLE IF NOT EXISTS `lia_persistence` (
                 `id` INT(12) NOT NULL AUTO_INCREMENT,
-                `folder` TEXT NULL,
+                `gamemode` TEXT NULL,
                 `map` TEXT NULL,
                 `class` TEXT NULL,
                 `pos` TEXT NULL,

--- a/gamemode/entities/entities/lia_item/init.lua
+++ b/gamemode/entities/entities/lia_item/init.lua
@@ -67,12 +67,12 @@ function ENT:setItem(itemID)
     end
 
     if not itemTable.temp then
-        local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
+        local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
         local map = game.GetMap()
-        local condition = "schema = " .. lia.db.convertDataType(folder) .. " AND map = " .. lia.db.convertDataType(map) .. " AND _itemID = " .. tonumber(itemID)
+        local condition = "schema = " .. lia.db.convertDataType(gamemode) .. " AND map = " .. lia.db.convertDataType(map) .. " AND _itemID = " .. tonumber(itemID)
         lia.db.delete("saveditems", condition):next(function()
             lia.db.insertTable({
-                schema = folder,
+                schema = gamemode,
                 map = map,
                 _itemID = itemID,
                 _pos = lia.data.encodetable(self:GetPos()),
@@ -104,9 +104,9 @@ function ENT:OnRemove()
 
     if not lia.shuttingDown and not self.liaIsSafe and self.liaItemID then lia.item.deleteByID(self.liaItemID) end
     if SERVER and not lia.shuttingDown and self.liaItemID then
-        local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
+        local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
         local map = game.GetMap()
-        local condition = "schema = " .. lia.db.convertDataType(folder) .. " AND map = " .. lia.db.convertDataType(map) .. " AND _itemID = " .. tonumber(self.liaItemID)
+        local condition = "schema = " .. lia.db.convertDataType(gamemode) .. " AND map = " .. lia.db.convertDataType(map) .. " AND _itemID = " .. tonumber(self.liaItemID)
         lia.db.delete("saveditems", condition)
     end
 end

--- a/gamemode/modules/chatbox/libraries/server.lua
+++ b/gamemode/modules/chatbox/libraries/server.lua
@@ -1,13 +1,13 @@
 ﻿local TABLE = "chatbox"
-local function buildCondition(folder, map)
-    return "schema = " .. lia.db.convertDataType(folder) .. " AND map = " .. lia.db.convertDataType(map)
+local function buildCondition(gamemode, map)
+    return "schema = " .. lia.db.convertDataType(gamemode) .. " AND map = " .. lia.db.convertDataType(map)
 end
 
 function MODULE:SaveData()
-    local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
+    local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
     local map = game.GetMap()
     lia.db.upsert({
-        schema = folder,
+        schema = gamemode,
         map = map,
         data = lia.data.serialize({
             bans = self.OOCBans
@@ -16,9 +16,9 @@ function MODULE:SaveData()
 end
 
 function MODULE:LoadData()
-    local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
+    local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
     local map = game.GetMap()
-    local condition = buildCondition(folder, map)
+    local condition = buildCondition(gamemode, map)
     lia.db.selectOne({"data"}, TABLE, condition):next(function(res)
         local data = res and lia.data.deserialize(res.data) or {}
         self.OOCBans = {}

--- a/gamemode/modules/doors/libraries/server.lua
+++ b/gamemode/modules/doors/libraries/server.lua
@@ -12,14 +12,14 @@
     end
 end
 
-local function buildCondition(folder, map)
-    return "folder = " .. lia.db.convertDataType(folder) .. " AND map = " .. lia.db.convertDataType(map)
+local function buildCondition(gamemode, map)
+    return "gamemode = " .. lia.db.convertDataType(gamemode) .. " AND map = " .. lia.db.convertDataType(map)
 end
 
 function MODULE:LoadData()
-    local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
+    local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
     local mapName = game.GetMap()
-    local condition = buildCondition(folder, mapName)
+    local condition = buildCondition(gamemode, mapName)
     local query = "SELECT * FROM lia_doors WHERE " .. condition
     lia.db.query(query):next(function(res)
         local rows = res.results or {}
@@ -56,13 +56,13 @@ function MODULE:LoadData()
 end
 
 function MODULE:SaveData()
-    local folder = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
+    local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
     local map = game.GetMap()
     local rows = {}
     for _, door in ipairs(ents.GetAll()) do
         if door:isDoor() then
             rows[#rows + 1] = {
-                gamemode = folder,
+                gamemode = gamemode,
                 map = map,
                 id = door:MapCreationID(),
                 factions = lia.data.serialize(door.liaFactions or {}),

--- a/gamemode/modules/teams/commands.lua
+++ b/gamemode/modules/teams/commands.lua
@@ -75,7 +75,8 @@ lia.command.add("roster", {
             return
         end
 
-        local condition = "lia_characters.schema = '" .. lia.db.escape(SCHEMA.folder) .. "' AND lia_characters.faction = " .. lia.db.convertDataType(faction.uniqueID)
+        local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
+        local condition = "lia_characters.schema = '" .. lia.db.escape(gamemode) .. "' AND lia_characters.faction = " .. lia.db.convertDataType(faction.uniqueID)
         local query = "SELECT " .. fields .. " FROM lia_characters LEFT JOIN lia_players ON lia_characters.steamID = lia_players.steamID WHERE " .. condition
         lia.db.query(query, function(data)
             local characters = {}
@@ -148,7 +149,8 @@ lia.command.add("factionmanagement", {
             end
         end
 
-        local condition = "lia_characters.schema = '" .. lia.db.escape(SCHEMA.folder) .. "' AND lia_characters.faction = " .. lia.db.convertDataType(faction.uniqueID)
+        local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
+        local condition = "lia_characters.schema = '" .. lia.db.escape(gamemode) .. "' AND lia_characters.faction = " .. lia.db.convertDataType(faction.uniqueID)
         local query = "SELECT " .. fields .. " FROM lia_characters LEFT JOIN lia_players ON lia_characters.steamID = lia_players.steamID WHERE " .. condition
         lia.db.query(query, function(data)
             local characters = {}


### PR DESCRIPTION
## Summary
- rename column name `folder` to `gamemode` in DB schema
- update code that queries or updates these columns
- rename local `folder` variables used for DB gamemode checks to `gamemode`
- replace leftover folder references in DB functions

## Testing
- `luacheck gamemode --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688949741d048327b197f592941cad86