### PR TITLE
Add roster info tab

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -1026,3 +1026,4 @@ local networkStrings = {"actBar", "AdminModeSwapCharacter", "AnimationStatus", "
 for _, netString in ipairs(networkStrings) do
     util.AddNetworkString(netString)
 end
+util.AddNetworkString("RequestRoster")

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -174,6 +174,7 @@ LANGUAGE = {
     searchEntities = "Search Entities...",
     searchOptions = "Search Options...",
     commands = "Commands",
+    roster = "Roster",
     classes = "Classes",
     searchFlags = "Search Flags…",
     searchCommands = "Search Commands…",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -174,6 +174,7 @@ LANGUAGE = {
     searchEntities = "Chercher des entités...",
     searchOptions = "Chercher des options...",
     commands = "Commandes",
+    roster = "Roster",
     classes = "Classes",
     searchFlags = "Chercher des drapeaux…",
     searchCommands = "Chercher des commandes…",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -174,6 +174,7 @@ LANGUAGE = {
     searchEntities = "Cerca Entità...",
     searchOptions = "Cerca Opzioni...",
     commands = "Comandi",
+    roster = "Roster",
     classes = "Classi",
     searchFlags = "Cerca Flag…",
     searchCommands = "Cerca Comandi…",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -174,6 +174,7 @@ LANGUAGE = {
     searchEntities = "Pesquisar entidades...",
     searchOptions = "Pesquisar opções...",
     commands = "Comandos",
+    roster = "Roster",
     classes = "Classes",
     searchFlags = "Pesquisar flags…",
     searchCommands = "Pesquisar comandos…",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -174,6 +174,7 @@ LANGUAGE = {
     searchEntities = "Поиск сущностей...",
     searchOptions = "Поиск опций...",
     commands = "Команды",
+    roster = "Roster",
     classes = "Классы",
     searchFlags = "Поиск флагов…",
     searchCommands = "Поиск команд…",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -174,6 +174,7 @@ LANGUAGE = {
     searchEntities = "Buscar entidades...",
     searchOptions = "Buscar opciones...",
     commands = "Comandos",
+    roster = "Roster",
     classes = "Clases",
     searchFlags = "Buscar flags…",
     searchCommands = "Buscar comandos…",

--- a/gamemode/modules/teams/libraries/client.lua
+++ b/gamemode/modules/teams/libraries/client.lua
@@ -25,3 +25,27 @@ function MODULE:CreateMenuButtons(tabs)
         tabs["classes"] = function(panel) panel:Add("liaClasses") end
     end
 end
+
+function MODULE:CreateInformationButtons(pages)
+    local client = LocalPlayer()
+    local character = client:getChar()
+    if not character then return end
+    local isLeader = client:IsSuperAdmin() or character:hasFlags("V")
+    if not isLeader then return end
+
+    table.insert(pages, {
+        name = L("roster"),
+        drawFunc = function(parent)
+            local sheet = vgui.Create("liaSheet", parent)
+            sheet:SetPlaceholderText(L("search"))
+            lia.gui.rosterSheet = sheet
+
+            net.Start("RequestRoster")
+            net.SendToServer()
+        end
+    })
+end
+
+hook.Add("F1MenuClosed", "liaRosterSheetCleanup", function()
+    lia.gui.rosterSheet = nil
+end)

--- a/gamemode/modules/teams/netcalls/client.lua
+++ b/gamemode/modules/teams/netcalls/client.lua
@@ -16,8 +16,72 @@ net.Receive("CharacterInfo", function()
     local factionID = net.ReadString()
     local characterData = net.ReadTable()
     local character = LocalPlayer():getChar()
-    local isLeader = LocalPlayer():IsSuperAdmin() or character:hasFlags("V")
+    local isLeader = LocalPlayer():IsSuperAdmin() or (character and character:hasFlags("V"))
     if not isLeader then return end
+
+    if IsValid(lia.gui.rosterSheet) then
+        local sheet = lia.gui.rosterSheet
+        sheet:Clear()
+        local rows = {}
+        local originals = {}
+        for _, data in ipairs(characterData) do
+            if data.faction == factionID and data.id ~= character:getID() then
+                rows[#rows + 1] = {data.id, data.name, data.lastOnline, data.hoursPlayed}
+                originals[#originals + 1] = data
+            end
+        end
+
+        local row = sheet:AddListViewRow({
+            columns = {"ID", "Name", "Last Online", "Hours Played"},
+            data = rows,
+            height = 300,
+            getLineText = function(line)
+                local s = ""
+                for i = 1, 4 do
+                    local v = line:GetValue(i)
+                    if v then s = s .. " " .. tostring(v) end
+                end
+                return s
+            end
+        })
+
+        if row and row.widget then
+            for i, line in ipairs(row.widget:GetLines() or {}) do
+                line.rowData = originals[i]
+            end
+
+            row.widget.OnRowRightClick = function(_, _, line)
+                if not IsValid(line) or not line.rowData then return end
+                local rowData = line.rowData
+                local menu = DermaMenu()
+                menu:AddOption("Kick", function()
+                    Derma_Query("Are you sure you want to kick this player?", "Confirm", "Yes", function()
+                        net.Start("KickCharacter")
+                        net.WriteInt(tonumber(rowData.id), 32)
+                        net.SendToServer()
+                    end, "No")
+                end)
+
+                menu:AddOption("View Character List", function() LocalPlayer():ConCommand("say /charlist " .. rowData.steamID) end)
+                menu:AddOption(L("copyRow"), function()
+                    local rowString = ""
+                    for key, value in pairs(rowData) do
+                        value = tostring(value or L("na"))
+                        rowString = rowString .. key:gsub("^%l", string.upper) .. ": " .. value .. " | "
+                    end
+
+                    rowString = rowString:sub(1, -4)
+                    SetClipboardText(rowString)
+                end)
+
+                menu:Open()
+            end
+        end
+
+        sheet:Refresh()
+        return
+    end
+
     if IsValid(characterPanel) then characterPanel:Remove() end
     local rows = {}
     for _, data in ipairs(characterData) do
@@ -25,29 +89,14 @@ net.Receive("CharacterInfo", function()
     end
 
     local columns = {
-        {
-            name = "ID",
-            field = "id"
-        },
-        {
-            name = "Name",
-            field = "name"
-        },
-        {
-            name = "Last Online",
-            field = "lastOnline"
-        },
-        {
-            name = "Hours Played",
-            field = "hoursPlayed"
-        }
+        {name = "ID", field = "id"},
+        {name = "Name", field = "name"},
+        {name = "Last Online", field = "lastOnline"},
+        {name = "Hours Played", field = "hoursPlayed"}
     }
 
     local frame, list = lia.util.CreateTableUI("Character Information", columns, rows, {
-        {
-            name = "Kick",
-            net = "KickCharacter"
-        }
+        {name = "Kick", net = "KickCharacter"}
     })
 
     if IsValid(list) then

--- a/gamemode/modules/teams/netcalls/server.lua
+++ b/gamemode/modules/teams/netcalls/server.lua
@@ -1,0 +1,58 @@
+local function formatDHM(seconds)
+    seconds = math.max(seconds or 0, 0)
+    local days = math.floor(seconds / 86400)
+    seconds = seconds % 86400
+    local hours = math.floor(seconds / 3600)
+    seconds = seconds % 3600
+    local minutes = math.floor(seconds / 60)
+    return string.format("%dd %dh %dm", days, hours, minutes)
+end
+
+net.Receive("RequestRoster", function(_, client)
+    local character = client:getChar()
+    if not character then return end
+    local isLeader = client:IsSuperAdmin() or character:hasFlags("V")
+    if not isLeader then return end
+
+    local fields = "lia_characters.name, lia_characters.faction, lia_characters.id, lia_characters.steamID, lia_characters.lastJoinTime, lia_players.totalOnlineTime, lia_players.lastOnline"
+    local factionIndex = character:getFaction()
+    if not factionIndex then return end
+    local faction = lia.faction.indices[factionIndex]
+    if not faction then return end
+    local condition = "lia_characters.schema = '" .. lia.db.escape(SCHEMA.folder) .. "' AND lia_characters.faction = " .. lia.db.convertDataType(faction.uniqueID)
+    local query = "SELECT " .. fields .. " FROM lia_characters LEFT JOIN lia_players ON lia_characters.steamID = lia_players.steamID WHERE " .. condition
+    lia.db.query(query, function(data)
+        local characters = {}
+        if data then
+            for _, v in ipairs(data) do
+                local charID = tonumber(v.id)
+                local isOnline = lia.char.loaded[charID] ~= nil
+                local lastOnlineText
+                if isOnline then
+                    lastOnlineText = L("onlineNow")
+                else
+                    local last = tonumber(v.lastOnline)
+                    if not isnumber(last) then last = os.time(lia.time.toNumber(v.lastJoinTime)) end
+                    local lastDiff = os.time() - last
+                    local timeSince = lia.time.TimeSince(last)
+                    local timeStripped = timeSince:match("^(.-)%sago$") or timeSince
+                    lastOnlineText = string.format("%s (%s) ago", timeStripped, formatDHM(lastDiff))
+                end
+
+                table.insert(characters, {
+                    id = charID,
+                    name = v.name,
+                    faction = v.faction,
+                    steamID = v.steamID,
+                    lastOnline = lastOnlineText,
+                    hoursPlayed = formatDHM(tonumber(v.totalOnlineTime) or 0)
+                })
+            end
+        end
+
+        net.Start("CharacterInfo")
+        net.WriteString(faction.uniqueID)
+        net.WriteTable(characters)
+        net.Send(client)
+    end)
+end)


### PR DESCRIPTION
## Summary
- add translations for `roster`
- expose roster info through F1 menu
- allow F1 roster page to request data from the server
- display roster data in a built-in liasheet

## Testing
- `ls`

------
https://chatgpt.com/codex/tasks/task_e_68894c167cf48327835d283d555ba06f