### PR TITLE
Fix commands tab refresh in info menu

### DIFF
--- a/gamemode/core/libraries/commands.lua
+++ b/gamemode/core/libraries/commands.lua
@@ -589,7 +589,9 @@ hook.Add("CreateInformationButtons", "liaInformationCommandsUnified", function(p
             end
 
             sheet:Refresh()
-        end
+            parent.refreshSheet = function() if IsValid(sheet) then sheet:Refresh() end end
+        end,
+        onSelect = function(pnl) if pnl.refreshSheet then pnl.refreshSheet() end end
     })
 end)
 

--- a/gamemode/modules/f1menu/libraries/client.lua
+++ b/gamemode/modules/f1menu/libraries/client.lua
@@ -91,7 +91,16 @@ function MODULE:CreateMenuButtons(tabs)
             panel.Paint = function() end
             panel:DockPadding(10, 10, 10, 10)
             page.drawFunc(panel)
-            sheet:AddSheet(page.name, panel)
+            local sheetData = sheet:AddSheet(page.name, panel)
+            if page.onSelect then
+                sheetData.Tab.liaPagePanel = panel
+                sheetData.Tab.liaOnSelect = page.onSelect
+            end
+        end
+        function sheet:OnActiveTabChanged(oldTab, newTab)
+            if IsValid(newTab) and newTab.liaOnSelect then
+                newTab.liaOnSelect(newTab.liaPagePanel)
+            end
         end
     end
 


### PR DESCRIPTION
## Summary
- refresh commands list each time the tab is selected
- hook property sheet tab changes

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68895072fc0883278d98f006ace9fbda