### PR TITLE
Ensure QuickPanel uses gamemode UI skin

### DIFF
--- a/gamemode/core/derma/panels/panels.lua
+++ b/gamemode/core/derma/panels/panels.lua
@@ -126,6 +126,7 @@ local QuickPanel = {}
 function QuickPanel:Init()
     if IsValid(lia.gui.quick) then lia.gui.quick:Remove() end
     lia.gui.quick = self
+    self:SetSkin(lia.config.get("DermaSkin", "Lilia Skin"))
     self:SetSize(400, 36)
     self:SetPos(ScrW() - 36, -36)
     self:MakePopup()


### PR DESCRIPTION
## Summary
- set QuickPanel to use the configured Derma skin so the menu theme matches the rest of the gamemode

## Testing
- `apt-get update -y` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68895209852883279e4ac4fdcb13c21c