### PR TITLE
Use player data for OOC bans

### DIFF
--- a/gamemode/modules/chatbox/commands.lua
+++ b/gamemode/modules/chatbox/commands.lua
@@ -1,5 +1,4 @@
 ﻿local MODULE = MODULE
-MODULE.OOCBans = MODULE.OOCBans or {}
 lia.command.add("banooc", {
     adminOnly = true,
     privilege = "Ban OOC",
@@ -18,9 +17,8 @@ lia.command.add("banooc", {
             return
         end
 
-        local id = target:SteamID64()
-        if not table.HasValue(MODULE.OOCBans, id) then table.insert(MODULE.OOCBans, id) end
-        MODULE:SaveData()
+        target:setLiliaData("oocBanned", true)
+        target:saveLiliaData()
         client:notifyLocalized("playerBannedFromOOC", target:Name())
         lia.log.add(client, "banOOC", target:Name(), target:SteamID64())
     end
@@ -44,9 +42,8 @@ lia.command.add("unbanooc", {
             return
         end
 
-        local id = target:SteamID64()
-        table.RemoveByValue(MODULE.OOCBans, id)
-        MODULE:SaveData()
+        target:setLiliaData("oocBanned", nil)
+        target:saveLiliaData()
         client:notifyLocalized("playerUnbannedFromOOC", target:Name())
         lia.log.add(client, "unbanOOC", target:Name(), target:SteamID64())
     end

--- a/gamemode/modules/chatbox/libraries/server.lua
+++ b/gamemode/modules/chatbox/libraries/server.lua
@@ -1,39 +1,3 @@
-﻿local TABLE = "chatbox"
-local function buildCondition(gamemode, map)
-    return "schema = " .. lia.db.convertDataType(gamemode) .. " AND map = " .. lia.db.convertDataType(map)
-end
-
-function MODULE:SaveData()
-    local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-    local map = game.GetMap()
-    lia.db.upsert({
-        schema = gamemode,
-        map = map,
-        data = lia.data.serialize({
-            bans = self.OOCBans
-        })
-    }, TABLE)
-end
-
-function MODULE:LoadData()
-    local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-    local map = game.GetMap()
-    local condition = buildCondition(gamemode, map)
-    lia.db.selectOne({"data"}, TABLE, condition):next(function(res)
-        local data = res and lia.data.deserialize(res.data) or {}
-        self.OOCBans = {}
-        if istable(data) and istable(data.bans) then
-            if data.bans[1] then
-                self.OOCBans = data.bans
-            else
-                for id, banned in pairs(data.bans) do
-                    if banned then table.insert(self.OOCBans, id) end
-                end
-            end
-        end
-    end)
-end
-
 function MODULE:InitializedModules()
     SetGlobalBool("oocblocked", false)
 end

--- a/gamemode/modules/chatbox/libraries/shared.lua
+++ b/gamemode/modules/chatbox/libraries/shared.lua
@@ -252,7 +252,7 @@ lia.chat.register("ooc", {
             return false
         end
 
-        if table.HasValue(MODULE.OOCBans, speaker:SteamID64()) then
+        if speaker:getLiliaData("oocBanned", false) then
             speaker:notifyLocalized("oocBanned")
             return false
         end


### PR DESCRIPTION
## Summary
- store and check OOC bans in player data
- remove unused chatbox DB storage

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688953d029c48327b898a441af0e69d9