### PR TITLE
Fix F1 menu tab width initialization

### DIFF
--- a/gamemode/core/derma/f1menu/cl_menu.lua
+++ b/gamemode/core/derma/f1menu/cl_menu.lua
@@ -11,6 +11,7 @@ function PANEL:Init()
     self.anchorMode = true
     self.invKey = lia.keybind.get("Open Inventory", KEY_I)
     local baseBtnW, btnH, spacing = 150, 40, 20
+    self.baseBtnW = baseBtnW
     local topBar = self:Add("DPanel")
     topBar:Dock(TOP)
     topBar:SetTall(70)
@@ -168,7 +169,7 @@ function PANEL:addTab(name, callback)
     tab:SetFont("liaMediumFont")
     surface.SetFont(tab:GetFont())
     local tw = select(1, surface.GetTextSize(tab:GetText()))
-    tab.calcW = math.max(baseBtnW, tw + 20)
+    tab.calcW = math.max(self.baseBtnW or 150, tw + 20)
     tab:SetTextColor(colors.text)
     tab:SetExpensiveShadow(1, Color(0, 0, 0, 100))
     tab:SetContentAlignment(5)


### PR DESCRIPTION
## Summary
- store `baseBtnW` as a panel field during initialization
- use panel field when calculating tab width

## Testing
- `luacheck gamemode/core/derma/f1menu/cl_menu.lua` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6889585916b88327a0cd1e7e5f781160