### PR TITLE
Sort tabs alphabetically

### DIFF
--- a/gamemode/modules/f1menu/libraries/client.lua
+++ b/gamemode/modules/f1menu/libraries/client.lua
@@ -86,6 +86,11 @@ function MODULE:CreateMenuButtons(tabs)
         local pages = {}
         hook.Run("CreateInformationButtons", pages)
         if not pages then return end
+        table.sort(pages, function(a, b)
+            local an = tostring(a.name):lower()
+            local bn = tostring(b.name):lower()
+            return an < bn
+        end)
         for _, page in ipairs(pages) do
             local panel = vgui.Create("DPanel")
             panel.Paint = function() end
@@ -111,6 +116,11 @@ function MODULE:CreateMenuButtons(tabs)
         local pages = {}
         hook.Run("PopulateConfigurationButtons", pages)
         if not pages then return end
+        table.sort(pages, function(a, b)
+            local an = tostring(a.name):lower()
+            local bn = tostring(b.name):lower()
+            return an < bn
+        end)
         for _, page in ipairs(pages) do
             local panel = sheet:Add("DPanel")
             panel:Dock(FILL)


### PR DESCRIPTION
## Summary
- alphabetize pages in Information tab
- alphabetize pages in Settings tab

## Testing
- `luacheck gamemode/modules/f1menu/libraries/client.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889591283e083279d486b26e137e241