### PR TITLE
Fix workshop description clipping

### DIFF
--- a/gamemode/core/derma/panels/sheet.lua
+++ b/gamemode/core/derma/panels/sheet.lua
@@ -77,6 +77,7 @@ function PANEL:AddTextRow(data)
             d = vgui.Create("DLabel", p)
             d:SetFont("liaSmallFont")
             d:SetWrap(true)
+            d:SetAutoStretchVertical(true)
             d:SetText(desc)
         end
 
@@ -130,6 +131,7 @@ function PANEL:AddPreviewRow(data)
             d = vgui.Create("DLabel", p)
             d:SetFont("liaSmallFont")
             d:SetWrap(true)
+            d:SetAutoStretchVertical(true)
             d:SetText(desc)
         end
 


### PR DESCRIPTION
## Summary
- ensure multi-line text rows expand vertically
- update preview rows to stretch description labels vertically

## Testing
- `luacheck gamemode/core/derma/panels/sheet.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68895dd45ba48327a22fbffcf7e22127