### PR TITLE
Fix default faction/class unwhitelists

### DIFF
--- a/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
@@ -329,16 +329,18 @@ local function IncludeCharacterManagement(tgt, menu, stores)
             if canWhitelist then
                 local facAdd, facRemove = {}, {}
                 for _, v in pairs(lia.faction.teams) do
-                    if not tgt:hasWhitelist(v.index) then
-                        table.insert(facAdd, {
-                            name = v.name,
-                            cmd = 'say /plywhitelist ' .. QuoteArgs(GetIdentifier(tgt), v.name)
-                        })
-                    else
-                        table.insert(facRemove, {
-                            name = v.name,
-                            cmd = 'say /plyunwhitelist ' .. QuoteArgs(GetIdentifier(tgt), v.name)
-                        })
+                    if not v.isDefault then
+                        if not tgt:hasWhitelist(v.index) then
+                            table.insert(facAdd, {
+                                name = v.name,
+                                cmd = 'say /plywhitelist ' .. QuoteArgs(GetIdentifier(tgt), v.name)
+                            })
+                        else
+                            table.insert(facRemove, {
+                                name = v.name,
+                                cmd = 'say /plyunwhitelist ' .. QuoteArgs(GetIdentifier(tgt), v.name)
+                            })
+                        end
                     end
                 end
 
@@ -363,16 +365,18 @@ local function IncludeCharacterManagement(tgt, menu, stores)
                 if classes and #classes > 0 then
                     local cw, cu = {}, {}
                     for _, c in ipairs(classes) do
-                        if not tgt:hasClassWhitelist(c.index) then
-                            table.insert(cw, {
-                                name = c.name,
-                                cmd = 'say /classwhitelist ' .. QuoteArgs(GetIdentifier(tgt), c.uniqueID)
-                            })
-                        else
-                            table.insert(cu, {
-                                name = c.name,
-                                cmd = 'say /classunwhitelist ' .. QuoteArgs(GetIdentifier(tgt), c.uniqueID)
-                            })
+                        if lia.class.hasWhitelist(c.index) then
+                            if not tgt:hasClassWhitelist(c.index) then
+                                table.insert(cw, {
+                                    name = c.name,
+                                    cmd = 'say /classwhitelist ' .. QuoteArgs(GetIdentifier(tgt), c.uniqueID)
+                                })
+                            else
+                                table.insert(cu, {
+                                    name = c.name,
+                                    cmd = 'say /classunwhitelist ' .. QuoteArgs(GetIdentifier(tgt), c.uniqueID)
+                                })
+                            end
                         end
                     end
 

--- a/gamemode/modules/teams/commands.lua
+++ b/gamemode/modules/teams/commands.lua
@@ -229,12 +229,14 @@ lia.command.add("plyunwhitelist", {
         end
 
         local faction = lia.util.findFaction(client, table.concat(arguments, " ", 2))
-        if faction and target:setWhitelisted(faction.index, false) then
+        if faction and not faction.isDefault and target:setWhitelisted(faction.index, false) then
             for _, v in player.Iterator() do
                 v:notifyLocalized("unwhitelist", client:Name(), target:Name(), L(faction.name, v))
             end
 
             lia.log.add(client, "plyUnwhitelist", target:Name(), faction.name)
+        else
+            client:notifyLocalized("invalidFaction")
         end
     end
 })


### PR DESCRIPTION
## Summary
- filter default factions out of the admin stick unwhitelist menu
- filter default classes out of the admin stick unwhitelist menu
- prevent plyunwhitelist from unwhitelisting default factions

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68895d7072a883279ce06691b845cc69