### PR TITLE
Add EspEnabled Option

### DIFF
--- a/gamemode/modules/administration/submodules/permissions/config.lua
+++ b/gamemode/modules/administration/submodules/permissions/config.lua
@@ -4,6 +4,16 @@
     type = "Boolean"
 })
 
+lia.option.add("espEnabled", "ESP Enabled", "Toggle ESP features", false, nil, {
+    category = "ESP",
+    isQuick = true,
+    visible = function()
+        local ply = LocalPlayer()
+        if not IsValid(ply) then return false end
+        return ply:isStaffOnDuty() or ply:hasPrivilege("No Clip Outside Staff Character")
+    end
+})
+
 lia.option.add("espPlayers", "ESP Players", "Enable ESP for players", false, nil, {
     category = "ESP",
     isQuick = true,

--- a/gamemode/modules/administration/submodules/permissions/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/client.lua
@@ -13,6 +13,7 @@ function MODULE:HUDPaint()
     if not client:getChar() or not client:IsValid() or not client:IsPlayer() then return end
     if not client:isNoClipping() then return end
     if not (client:hasPrivilege("No Clip ESP Outside Staff Character") or client:isStaffOnDuty()) then return end
+    if not lia.option.get("espEnabled", false) then return end
     local marginx, marginy = ScrW() * 0.1, ScrH() * 0.1
     local maxDistanceSq = 4096
     for _, ent in ents.Iterator() do


### PR DESCRIPTION
## Summary
- add a toggle option `espEnabled` to quickly enable/disable ESP features
- check this new option before drawing ESP overlays

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68896651243083279a73e85c65d11b2a