### PR TITLE
Fix truncated descriptions in addon info

### DIFF
--- a/gamemode/core/derma/panels/sheet.lua
+++ b/gamemode/core/derma/panels/sheet.lua
@@ -95,8 +95,7 @@ function PANEL:AddTextRow(data)
             if d then
                 d:SetPos(pad, pad + t:GetTall() + 5)
                 d:SetWide(p:GetWide() - pad * 2 - (r and r:GetWide() + 10 or 0))
-                local _, h = d:GetContentSize()
-                d:SetTall(h)
+                d:SizeToContentsY()
             end
 
             if r then
@@ -150,8 +149,7 @@ function PANEL:AddPreviewRow(data)
             if d then
                 d:SetPos(pad + size + pad, pad + t:GetTall() + 5)
                 d:SetWide(p:GetWide() - (pad + size + pad) - pad - (r and r:GetWide() + 10 or 0))
-                local _, h = d:GetContentSize()
-                d:SetTall(h)
+                d:SizeToContentsY()
             end
 
             if r then


### PR DESCRIPTION
## Summary
- fix Addons tab description not displaying all text

## Testing
- `luacheck gamemode --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889675852888327aa2828f98482fb09