### PR TITLE
Use liaSheet in configuration pages

### DIFF
--- a/gamemode/core/libraries/config.lua
+++ b/gamemode/core/libraries/config.lua
@@ -810,15 +810,11 @@ hook.Add("PopulateConfigurationButtons", "liaConfigPopulate", function(pages)
 
     local function buildConfiguration(parent)
         parent:Clear()
-        local search = vgui.Create("DTextEntry", parent)
-        search:Dock(TOP)
-        search:SetTall(30)
-        search:DockMargin(5, 5, 5, 5)
-        search:SetPlaceholderText(L("searchConfigs"))
-        local scroll = vgui.Create("DScrollPanel", parent)
-        scroll:Dock(FILL)
+        local sheet = parent:Add("liaSheet")
+        sheet:Dock(FILL)
+        sheet:SetPlaceholderText(L("searchConfigs"))
         local function populate(filter)
-            scroll:Clear()
+            sheet:Clear()
             local categories = {}
             local keys = {}
             for k in pairs(lia.config.stored) do
@@ -851,7 +847,7 @@ hook.Add("PopulateConfigurationButtons", "liaConfigPopulate", function(pages)
             table.sort(categoryNames)
             for _, categoryName in ipairs(categoryNames) do
                 local items = categories[categoryName]
-                local cat = vgui.Create("DCollapsibleCategory", scroll)
+                local cat = vgui.Create("DCollapsibleCategory", sheet.canvas)
                 cat:Dock(TOP)
                 cat:SetLabel(categoryName)
                 cat:SetExpanded(true)
@@ -886,7 +882,7 @@ hook.Add("PopulateConfigurationButtons", "liaConfigPopulate", function(pages)
             end
         end
 
-        search.OnTextChanged = function() populate(search:GetValue():lower()) end
+        sheet.search.OnTextChanged = function() populate(sheet.search:GetValue():lower()) end
         populate("")
     end
 

--- a/gamemode/core/libraries/option.lua
+++ b/gamemode/core/libraries/option.lua
@@ -435,19 +435,17 @@ hook.Add("PopulateConfigurationButtons", "liaOptionsPopulate", function(pages)
         name = L("options"),
         drawFunc = function(parent)
             parent:Clear()
-            local searchEntry = vgui.Create("DTextEntry", parent)
-            searchEntry:Dock(TOP)
-            searchEntry:SetTall(30)
-            searchEntry:DockMargin(5, 5, 5, 5)
-            searchEntry:SetPlaceholderText(L("searchOptions"))
-            local scroll = vgui.Create("DScrollPanel", parent)
-            scroll:Dock(FILL)
+            local sheet = parent:Add("liaSheet")
+            sheet:Dock(FILL)
+            sheet:SetPlaceholderText(L("searchOptions"))
+
             local function refresh()
-                scroll:Clear()
-                buildOptions(scroll, searchEntry:GetValue():lower())
+                sheet:Clear()
+                buildOptions(sheet.canvas, sheet.search:GetValue():lower())
+                sheet:Refresh()
             end
 
-            searchEntry.OnTextChanged = function() refresh() end
+            sheet.search.OnTextChanged = refresh
             refresh()
         end
     }


### PR DESCRIPTION
## Summary
- swap manual search panels for `liaSheet` in keybinds
- use `liaSheet` for options and config pages

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68896f736c5c83278c4a19c141ba68f2