### PR TITLE
Add admin menu tab with usergroups

### DIFF
--- a/gamemode/modules/administration/submodules/usergroups/module.lua
+++ b/gamemode/modules/administration/submodules/usergroups/module.lua
@@ -422,9 +422,11 @@ else
         if IsValid(LocalPlayer()) and LocalPlayer().notify then LocalPlayer():notify(msg) end
     end)
 
-    function MODULE:CreateMenuButtons(tabs)
-        if IsValid(LocalPlayer()) then
-            tabs[L("userGroups")] = function(parent)
+    function MODULE:PopulateAdminTabs(pages)
+        if not IsValid(LocalPlayer()) then return end
+        table.insert(pages, {
+            name = L("userGroups"),
+            drawFunc = function(parent)
                 lia.gui.usergroups = parent
                 parent:Clear()
                 parent:DockPadding(10, 10, 10, 10)
@@ -432,6 +434,6 @@ else
                 net.Start("liaGroupsRequest")
                 net.SendToServer()
             end
-        end
+        })
     end
 end

--- a/gamemode/modules/f1menu/libraries/client.lua
+++ b/gamemode/modules/f1menu/libraries/client.lua
@@ -131,6 +131,28 @@ function MODULE:CreateMenuButtons(tabs)
             sheet:AddSheet(page.name, panel)
         end
     end
+
+    tabs[L("admin")] = function(adminPanel)
+        local sheet = adminPanel:Add("DPropertySheet")
+        sheet:Dock(FILL)
+        sheet:DockMargin(10, 10, 10, 10)
+        local pages = {}
+        hook.Run("PopulateAdminTabs", pages)
+        if not pages then return end
+        table.sort(pages, function(a, b)
+            local an = tostring(a.name):lower()
+            local bn = tostring(b.name):lower()
+            return an < bn
+        end)
+
+        for _, page in ipairs(pages) do
+            local panel = sheet:Add("DPanel")
+            panel:Dock(FILL)
+            panel.Paint = function() end
+            if page.drawFunc then page.drawFunc(panel) end
+            sheet:AddSheet(page.name, panel)
+        end
+    end
 end
 
 function MODULE:CanDisplayCharInfo(name)


### PR DESCRIPTION
## Summary
- add a new Admin tab inside the F1 menu
- populate Admin tab via `PopulateAdminTabs` hook
- move User Groups UI into the Admin tab

## Testing
- `luajit -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68898bfeb3a88327afa96d5d70f8a2de