### PR TITLE
Show addon size instead of description

### DIFF
--- a/gamemode/core/libraries/workshop.lua
+++ b/gamemode/core/libraries/workshop.lua
@@ -289,24 +289,24 @@ else
                 for id in pairs(ids) do
                     steamworks.FileInfo(id, function(fi)
                         if not fi then return end
-                        local title = fi.title or "ID:" .. id
-                        local desc = fi.description or ""
-                        local url = fi.previewurl or ""
-                        if sheet.AddPreviewRow then
-                            sheet:AddPreviewRow({
+                    local title = fi.title or "ID:" .. id
+                    local desc = fi.size and L("addonSize", formatSize(fi.size)) or ""
+                    local url = fi.previewurl or ""
+                    if sheet.AddPreviewRow then
+                        sheet:AddPreviewRow({
+                            title = title,
+                            desc = desc,
+                            url = url,
+                            size = 128
+                        })
+                    else
+                        if sheet.AddTextRow then
+                            sheet:AddTextRow({
                                 title = title,
-                                desc = desc,
-                                url = url,
-                                size = 128
+                                desc = desc
                             })
-                        else
-                            if sheet.AddTextRow then
-                                sheet:AddTextRow({
-                                    title = title,
-                                    desc = desc
-                                })
-                            end
                         end
+                    end
 
                         if IsValid(sheet) and sheet.Refresh then sheet:Refresh() end
                     end)

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -205,6 +205,7 @@ LANGUAGE = {
     plygetplaytimeDesc = "Shows the total playtime of the specified character.",
     workshopAddons = "Addons",
     totalAutoAddons = "Total Auto Downloaded Addons: %s",
+    addonSize = "This addon is %s",
     itemOnGround = "Your item has been placed on the ground.",
     fixpac_success = "PAC has been restarted and caches cleared.",
     pacenable_success = "PAC has been enabled.",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -205,6 +205,7 @@ LANGUAGE = {
     plygetplaytimeDesc = "Montre le temps de jeu du personnage cible.",
     workshopAddons = "Addons",
     totalAutoAddons = "Addons auto‑téléchargés : %s",
+    addonSize = "Cet addon fait %s",
     itemOnGround = "Objet posé au sol.",
     fixpac_success = "PAC redémarré et caches nettoyés.",
     pacenable_success = "PAC activé.",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -205,6 +205,7 @@ LANGUAGE = {
     plygetplaytimeDesc = "Mostra il tempo totale di gioco del personaggio specificato.",
     workshopAddons = "Addons",
     totalAutoAddons = "Totale Addons Auto Scaricati: %s",
+    addonSize = "Questo addon è di %s",
     itemOnGround = "Il tuo oggetto è stato posato a terra.",
     fixpac_success = "PAC è stato riavviato e le cache sono state pulite.",
     pacenable_success = "PAC è stato abilitato.",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -205,6 +205,7 @@ LANGUAGE = {
     plygetplaytimeDesc = "Mostra o tempo total de jogo do personagem especificado.",
     workshopAddons = "Addons",
     totalAutoAddons = "Addons auto-download: %s",
+    addonSize = "Este addon tem %s",
     itemOnGround = "O teu item foi colocado no chão.",
     fixpac_success = "PAC reiniciado e cache limpo.",
     pacenable_success = "PAC activado.",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -205,6 +205,7 @@ LANGUAGE = {
     plygetplaytimeDesc = "Показывает общее время игры указанного персонажа.",
     workshopAddons = "Аддоны",
     totalAutoAddons = "Автоматически загруженных аддонов: %s",
+    addonSize = "Этот аддон весит %s",
     itemOnGround = "Предмет размещён на земле.",
     fixpac_success = "PAC перезапущен, кэш очищен.",
     pacenable_success = "PAC включён.",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -205,6 +205,7 @@ LANGUAGE = {
     plygetplaytimeDesc = "Muestra el tiempo total de un personaje.",
     workshopAddons = "Addons",
     totalAutoAddons = "Addons auto‑descargados: %s",
+    addonSize = "Este addon pesa %s",
     itemOnGround = "Tu ítem se colocó en el suelo.",
     fixpac_success = "PAC reiniciado y cachés limpiados.",
     pacenable_success = "PAC habilitado.",


### PR DESCRIPTION
## Summary
- show addon size in information tab using `fi.size`
- add `addonSize` translation for all languages

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688992a602748327a0e40fb6ed71bc7d