### PR TITLE
Move logs tab under admin menu

### DIFF
--- a/gamemode/modules/administration/submodules/logging/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/logging/libraries/client.lua
@@ -80,12 +80,15 @@ net.Receive("send_logs", function()
     if IsValid(receivedPanel) then OpenLogsUI(receivedPanel, categorizedLogs) end
 end)
 
-function MODULE:CreateMenuButtons(tabs)
+function MODULE:PopulateAdminTabs(pages)
     if IsValid(LocalPlayer()) and LocalPlayer():hasPrivilege("Can See Logs") then
-        tabs[L("logs")] = function(panel)
-            receivedPanel = panel
-            net.Start("send_logs_request")
-            net.SendToServer()
-        end
+        table.insert(pages, {
+            name = L("logs"),
+            drawFunc = function(panel)
+                receivedPanel = panel
+                net.Start("send_logs_request")
+                net.SendToServer()
+            end
+        })
     end
 end


### PR DESCRIPTION
## Summary
- shift the Logs page from general menu to the admin tabs

## Testing
- `luajit` not available; no tests run

------
https://chatgpt.com/codex/tasks/task_e_688995d9a25c8327b62ad22756b06deb