### PR TITLE
Fix entity tab item display

### DIFF
--- a/gamemode/modules/protection/libraries/client.lua
+++ b/gamemode/modules/protection/libraries/client.lua
@@ -1699,6 +1699,12 @@ function MODULE:PopulateAdminTabs(pages)
                     searchSheet:SetPlaceholderText(L("searchEntities"))
                     for _, ent in ipairs(list) do
                         local className = ent:GetClass()
+                        if className == "lia_item" and ent.getItemTable then
+                            local item = ent:getItemTable()
+                            if item and item.name then
+                                className = item.name
+                            end
+                        end
                         local itemPanel = vgui.Create("DPanel")
                         itemPanel:SetTall(100)
                         itemPanel.Paint = function(pnl, w, h)


### PR DESCRIPTION
## Summary
- improve admin entity panel display so lia_item uses item name instead of class name

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68899b4151f08327a165d6cdc5c397fb