### PR TITLE
Fix logs tab listing

### DIFF
--- a/gamemode/modules/administration/submodules/logging/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/logging/libraries/server.lua
@@ -57,7 +57,9 @@ net.Receive("send_logs_request", function(_, client)
         if idx > #catList then return MODULE:SendLogsInChunks(client, logsByCategory) end
         local cat = catList[idx]
         MODULE:ReadLogEntries(cat):next(function(entries)
-            logsByCategory[cat] = entries
+            if #entries > 0 then
+                logsByCategory[cat] = entries
+            end
             fetch(idx + 1)
         end)
     end


### PR DESCRIPTION
## Summary
- avoid sending log categories that have no entries

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68899c2f3f84832782752d58ad3f3a5e