### PR TITLE
Compact modules info rows

### DIFF
--- a/gamemode/core/derma/panels/sheet.lua
+++ b/gamemode/core/derma/panels/sheet.lua
@@ -67,15 +67,18 @@ function PANEL:AddTextRow(data)
     local title = data.title or ""
     local desc = data.desc or ""
     local right = data.right or ""
+    local compact = data.compact
     local row = self:AddRow(function(p, row)
+        local titleFont = compact and "liaSmallFont" or "liaMediumFont"
+        local descFont = compact and "liaMiniFont" or "liaSmallFont"
         local t = vgui.Create("DLabel", p)
-        t:SetFont("liaMediumFont")
+        t:SetFont(titleFont)
         t:SetText(title)
         t:SizeToContents()
         local d
         if desc ~= "" then
             d = vgui.Create("DLabel", p)
-            d:SetFont("liaSmallFont")
+            d:SetFont(descFont)
             d:SetWrap(true)
             d:SetAutoStretchVertical(true)
             d:SetText(desc)
@@ -84,26 +87,29 @@ function PANEL:AddTextRow(data)
         local r
         if right ~= "" then
             r = vgui.Create("DLabel", p)
-            r:SetFont("liaSmallFont")
+            r:SetFont(descFont)
             r:SetText(right)
             r:SizeToContents()
         end
 
         p.PerformLayout = function()
             local pad = self.padding
+            if compact then pad = math.ceil(pad * 0.5) end
+            local spacing = compact and 2 or 5
             t:SetPos(pad, pad)
             if d then
-                d:SetPos(pad, pad + t:GetTall() + 5)
+                d:SetPos(pad, pad + t:GetTall() + spacing)
                 d:SetWide(p:GetWide() - pad * 2 - (r and r:GetWide() + 10 or 0))
                 d:SizeToContentsY()
             end
 
             if r then
-                local y = d and pad + t:GetTall() + 5 + d:GetTall() - r:GetTall() or p:GetTall() * 0.5 - r:GetTall() * 0.5
+                local y = d and pad + t:GetTall() + spacing + d:GetTall() - r:GetTall() or p:GetTall() * 0.5 - r:GetTall() * 0.5
                 r:SetPos(p:GetWide() - r:GetWide() - pad, math.max(pad, y))
             end
 
-            local h = d and pad + t:GetTall() + 5 + d:GetTall() + pad or math.max(40, pad + t:GetTall() + pad)
+            local baseMin = compact and 30 or 40
+            local h = d and pad + t:GetTall() + spacing + d:GetTall() + pad or math.max(baseMin, pad + t:GetTall() + pad)
             p:SetTall(h)
         end
 

--- a/gamemode/core/libraries/modularity.lua
+++ b/gamemode/core/libraries/modularity.lua
@@ -221,6 +221,8 @@ hook.Add("CreateInformationButtons", "liaInformationModulesUnified", function(pa
         drawFunc = function(parent)
             local sheet = vgui.Create("liaSheet", parent)
             sheet:SetPlaceholderText(L("searchModules"))
+            sheet:SetPadding(5)
+            sheet:SetSpacing(4)
             for _, moduleData in SortedPairs(lia.module.list) do
                 local title = moduleData.name or ""
                 local desc = moduleData.desc or ""
@@ -228,7 +230,8 @@ hook.Add("CreateInformationButtons", "liaInformationModulesUnified", function(pa
                 local row = sheet:AddTextRow({
                     title = title,
                     desc = desc,
-                    right = right
+                    right = right,
+                    compact = true
                 })
 
                 row.filterText = (title .. " " .. desc .. " " .. right):lower()


### PR DESCRIPTION
## Summary
- add a `compact` option to `liaSheet:AddTextRow`
- make the module list use compact rows with smaller padding and spacing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889a044d10c8327b7f789982c6c8295