### PR TITLE
Fix door save table name

### DIFF
--- a/gamemode/modules/doors/libraries/server.lua
+++ b/gamemode/modules/doors/libraries/server.lua
@@ -78,8 +78,8 @@ function MODULE:SaveData()
         end
     end
 
-    lia.db.delete("doors", condition):next(function()
-        if #rows > 0 then return lia.db.bulkInsert("doors", rows) end
+    lia.db.delete("lia_doors", condition):next(function()
+        if #rows > 0 then return lia.db.bulkInsert("lia_doors", rows) end
     end)
 end
 


### PR DESCRIPTION
## Summary
- ensure the door module saves data to `lia_doors`

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889a129c7008327a632f1abb8ed30ad