### PR TITLE
Improve group UI with rename feature

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -69,6 +69,27 @@ function lia.admin.removeGroup(groupName)
     if SERVER then lia.admin.save() end
 end
 
+function lia.admin.renameGroup(oldName, newName)
+    if lia.admin.DefaultGroups[oldName] then
+        lia.error("[Lilia Administration] The base usergroups cannot be renamed!\n")
+        return
+    end
+
+    if not lia.admin.groups[oldName] then
+        lia.error("[Lilia Administration] This usergroup doesn't exist!\n")
+        return
+    end
+
+    if lia.admin.groups[newName] then
+        lia.error("[Lilia Administration] This usergroup already exists!\n")
+        return
+    end
+
+    lia.admin.groups[newName] = lia.admin.groups[oldName]
+    lia.admin.groups[oldName] = nil
+    if SERVER then lia.admin.save() end
+end
+
 if SERVER then
     function lia.admin.addPermission(groupName, permission)
         if not lia.admin.groups[groupName] then


### PR DESCRIPTION
## Summary
- add `lia.admin.renameGroup` to allow renaming user groups
- support `liaGroupsRename` network message and button layout updates
- show create/rename/delete buttons at bottom of group panels

## Testing
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6889a7a73b1483278bda086eca066bd8