### PR TITLE
Use writeBigTable for usergroup sync

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -145,12 +145,15 @@ if SERVER then
     end
 
     function lia.administrator.sync(client)
-        net.Start("updateAdminGroups")
-        net.WriteTable(lia.administrator.groups)
         if client and IsValid(client) then
-            net.Send(client)
+            lia.net.writeBigTable(client, "updateAdminGroups", lia.administrator.groups)
         else
-            net.Broadcast()
+            local players = player.GetHumans()
+            if #players > 0 then
+                for _, ply in ipairs(players) do
+                    lia.net.writeBigTable(ply, "updateAdminGroups", lia.administrator.groups)
+                end
+            end
         end
     end
 

--- a/gamemode/modules/administration/netcalls/client.lua
+++ b/gamemode/modules/administration/netcalls/client.lua
@@ -6,7 +6,6 @@
 
     hook.Run("InitializedConfig")
 end)
-
 local function deserializeFallback(raw)
     if lia.data and lia.data.deserialize then return lia.data.deserialize(raw) end
     if istable(raw) then return raw end
@@ -240,4 +239,8 @@ net.Receive("managesitrooms", function()
         makeButton("reposition", 3)
         makeButton("rename", 2)
     end
+end)
+
+lia.net.readBigTable("updateAdminGroups", function(data)
+    lia.administrator.groups = data or {}
 end)


### PR DESCRIPTION
## Summary
- switch usergroup sync to use `lia.net.writeBigTable`
- listen for `updateAdminGroups` with `lia.net.readBigTable` on the client

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889d68d044083279add62586ce0f7df