### PR TITLE
Refactor group rename

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -95,6 +95,10 @@ function lia.administrator.removeGroup(groupName)
 end
 
 function lia.administrator.renameGroup(oldName, newName)
+    oldName = string.Trim(oldName or "")
+    newName = string.Trim(newName or "")
+    if oldName == "" or newName == "" or oldName == newName then return end
+
     if lia.administrator.DefaultGroups[oldName] then
         lia.error("[Lilia Administration] The base usergroups cannot be renamed!\n")
         return
@@ -105,7 +109,7 @@ function lia.administrator.renameGroup(oldName, newName)
         return
     end
 
-    if lia.administrator.groups[newName] then
+    if lia.administrator.groups[newName] or lia.administrator.DefaultGroups[newName] then
         lia.error("[Lilia Administration] This usergroup already exists!\n")
         return
     end

--- a/gamemode/modules/administration/submodules/usergroups/module.lua
+++ b/gamemode/modules/administration/submodules/usergroups/module.lua
@@ -99,17 +99,9 @@ if SERVER then
     end)
 
     net.Receive("liaGroupsRename", function(_, p)
-        local old = string.Trim(net.ReadString() or "")
-        local new = string.Trim(net.ReadString() or "")
-        if old == "" or new == "" then return end
-        if old == new then return end
-        if not lia.administrator.groups or not lia.administrator.groups[old] then return end
-        if lia.administrator.groups[new] or lia.administrator.DefaultGroups and lia.administrator.DefaultGroups[new] then return end
-        if lia.administrator.DefaultGroups and lia.administrator.DefaultGroups[old] then return end
-        local perms = lia.administrator.groups[old]
-        lia.administrator.groups[new] = perms
-        lia.administrator.groups[old] = nil
-        lia.administrator.save()
+        local old = net.ReadString()
+        local new = net.ReadString()
+        lia.administrator.renameGroup(old, new)
         broadcastGroups()
         p:notify(p, "Group '" .. old .. "' renamed to '" .. new .. "'.")
     end)


### PR DESCRIPTION
## Summary
- streamline `renameGroup` logic
- delegate usergroup renaming from the usergroups module to the central library

## Testing
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688bda74c5fc8327981a9893663a0414