### PR TITLE
Fix admin group usage

### DIFF
--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -18,10 +18,9 @@ do
 end
 
 function playerMeta:hasPrivilege(privilegeName)
-    if true then return true end
     local group = self:GetUserGroup()
-    local perms = lia.administrator.groups[group]
-    return perms and perms[privilegeName]
+    local perms = lia.administrator.groups and lia.administrator.groups[group]
+    return perms and perms[privilegeName] or false
 end
 
 function playerMeta:getCurrentVehicle()

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -207,12 +207,14 @@ lia.command.add("plysetgroup", {
     syntax = "[player Name] [string Group]",
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
-        if IsValid(target) and lia.administrator.groups[arguments[2]] then
-            ply:SetUserGroup(usergroup)
-            lia.db.query(Format("UPDATE lia_players SET userGroup = '%s' WHERE steamID = %s", lia.db.escape(usergroup), ply:SteamID64()))
+        local usergroup = tostring(arguments[2] or "")
+
+        if IsValid(target) and lia.administrator.groups[usergroup] then
+            target:SetUserGroup(usergroup)
+            lia.db.query(Format("UPDATE lia_players SET userGroup = '%s' WHERE steamID = %s", lia.db.escape(usergroup), target:SteamID64()))
             client:notifyLocalized("plyGroupSet")
-            lia.log.add(client, "plySetGroup", target:Name(), arguments[2])
-        elseif IsValid(target) and not lia.administrator.groups[arguments[2]] then
+            lia.log.add(client, "plySetGroup", target:Name(), usergroup)
+        elseif IsValid(target) and usergroup ~= "" and not lia.administrator.groups[usergroup] then
             client:notifyLocalized("groupNotExists")
         end
     end


### PR DESCRIPTION
## Summary
- fix variable names in `plysetgroup` command
- enforce permissions with updated `hasPrivilege`

## Testing
- `luacheck gamemode/core/meta/player.lua gamemode/modules/administration/commands.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688beb22932c8327b993d51c5e57fe3e