### PR TITLE
Fix reset keybind button placement

### DIFF
--- a/gamemode/core/libraries/keybind.lua
+++ b/gamemode/core/libraries/keybind.lua
@@ -300,8 +300,7 @@ hook.Add("PopulateConfigurationButtons", "PopulateKeybinds", function(pages)
         end
 
         if allowEdit then
-            local resetAllBtn = parent:Add("liaMediumButton")
-            resetAllBtn:Dock(BOTTOM)
+            local resetAllBtn = vgui.Create("liaMediumButton")
             resetAllBtn:SetTall(40)
             resetAllBtn:SetText(L("resetAllKeybinds"))
             resetAllBtn.DoClick = function()
@@ -316,6 +315,7 @@ hook.Add("PopulateConfigurationButtons", "PopulateKeybinds", function(pages)
                 lia.keybind.save()
                 buildKeybinds(parent)
             end
+            sheet:AddPanelRow(resetAllBtn, {height = 40})
         end
     end
 


### PR DESCRIPTION
## Summary
- make the `Reset All Keybinds` button part of the keybinds list

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c0a2a550483278a423f7fe96f6e20