### PR TITLE
Fix usergroup sheet display

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -638,6 +638,9 @@ hook.Add("PopulateAdminTabs", "liaAdmin", function(pages)
             parent:Clear()
             parent:DockPadding(10, 10, 10, 10)
             parent.Paint = function(p, w, h) derma.SkinHook("Paint", "Frame", p, w, h) end
+            if lia.administrator.groups then
+                buildGroupsUI(parent, lia.administrator.groups, lia.administrator.groups)
+            end
             net.Start("liaGroupsRequest")
             net.SendToServer()
         end


### PR DESCRIPTION
## Summary
- ensure existing usergroups populate immediately when opening the Usergroups tab

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c107a59088327a562b858762fa57e