### PR TITLE
Enable privilege toggling for custom groups

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -392,6 +392,22 @@ if SERVER then
         broadcastGroups()
         p:notify(p, "Group '" .. old .. "' renamed to '" .. new .. "'.")
     end)
+
+    net.Receive("liaGroupsSetPerm", function(_, p)
+        local group = net.ReadString()
+        local privilege = net.ReadString()
+        local value = net.ReadBool()
+        if group == "" or privilege == "" then return end
+        if lia.administrator.DefaultGroups and lia.administrator.DefaultGroups[group] then return end
+        if not lia.administrator.groups or not lia.administrator.groups[group] then return end
+        if value then
+            lia.administrator.addPermission(group, privilege)
+        else
+            lia.administrator.removePermission(group, privilege)
+        end
+        lia.administrator.save()
+        broadcastGroups()
+    end)
 else
     local PRIV_LIST = {}
     local LAST_GROUP
@@ -476,6 +492,13 @@ else
                     current[name] = true
                 else
                     current[name] = nil
+                end
+                if editable then
+                    net.Start("liaGroupsSetPerm")
+                    net.WriteString(g)
+                    net.WriteString(name)
+                    net.WriteBool(v)
+                    net.SendToServer()
                 end
             end
 

--- a/gamemode/init.lua
+++ b/gamemode/init.lua
@@ -8,3 +8,4 @@ DeriveGamemode("sandbox")
 for _, netString in ipairs(networkStrings) do
     util.AddNetworkString(netString)
 end
+util.AddNetworkString("liaGroupsSetPerm")


### PR DESCRIPTION
## Summary
- allow admins to toggle privileges on non-default user groups
- sync permission changes from the client to the server

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688c129c1bc0832787a98cf841586f5f