### PR TITLE
Add compatibility condition functions

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -75,7 +75,7 @@
   Privileges with inheritance and file logs.
 
 * **Modular Extensions**
-  Hot-loading modules with third-party addon compatibility.
+  Hot-loading modules with third-party addon compatibility using global or custom conditions.
 
 * **Workshop & Config**
   Manage client downloads and tweak hundreds of in-game settings.


### PR DESCRIPTION
## Summary
- document optional condition functions for addon compatibility
- support `condition` field when loading compatibility code

## Testing
- `luacheck gamemode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c2b74db088327aa76b3956644660f