### PR TITLE
Localize more text

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -996,6 +996,7 @@ LANGUAGE = {
     charIDCopyFormat = "CharID: %s (copy)",
     steamIDCopyFormat = "SteamID: %s (copy)",
     steamID64CopyFormat = "SteamID64: %s (copy)",
+    charlistTitle = "Charlist for SteamID64: %s",
     giveFlagFormat = "Give Flag %s",
     takeFlagFormat = "Take Flag %s",
     setFactionTitle = "Set Faction (%s)",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -993,6 +993,7 @@ LANGUAGE = {
     charIDCopyFormat = "CharID : %s (copié)",
     steamIDCopyFormat = "SteamID : %s (copié)",
     steamID64CopyFormat = "SteamID64 : %s (copié)",
+    charlistTitle = "Charlist for SteamID64: %s",
     giveFlagFormat = "Donner drapeau %s",
     takeFlagFormat = "Retirer drapeau %s",
     setFactionTitle = "Définir faction (%s)",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -993,6 +993,7 @@ LANGUAGE = {
     charIDCopyFormat = "CharID: %s (copia)",
     steamIDCopyFormat = "SteamID: %s (copia)",
     steamID64CopyFormat = "SteamID64: %s (copia)",
+    charlistTitle = "Charlist for SteamID64: %s",
     giveFlagFormat = "Dai Flag %s",
     takeFlagFormat = "Togli Flag %s",
     setFactionTitle = "Imposta Fazione (%s)",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -993,6 +993,7 @@ LANGUAGE = {
     charIDCopyFormat = "CharID: %s (copiado)",
     steamIDCopyFormat = "SteamID: %s (copiado)",
     steamID64CopyFormat = "SteamID64: %s (copiado)",
+    charlistTitle = "Charlist for SteamID64: %s",
     giveFlagFormat = "Dar Flag %s",
     takeFlagFormat = "Tirar Flag %s",
     setFactionTitle = "Definir Facção (%s)",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -993,6 +993,7 @@ LANGUAGE = {
     charIDCopyFormat = "CharID: %s (скопировано)",
     steamIDCopyFormat = "SteamID: %s (скопировано)",
     steamID64CopyFormat = "SteamID64: %s (скопировано)",
+    charlistTitle = "Charlist for SteamID64: %s",
     giveFlagFormat = "Выдать флаг %s",
     takeFlagFormat = "Забрать флаг %s",
     setFactionTitle = "Установить фракцию (%s)",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -993,6 +993,7 @@ LANGUAGE = {
     charIDCopyFormat = "CharID: %s (copiado)",
     steamIDCopyFormat = "SteamID: %s (copiado)",
     steamID64CopyFormat = "SteamID64: %s (copiado)",
+    charlistTitle = "Charlist for SteamID64: %s",
     giveFlagFormat = "Dar flag %s",
     takeFlagFormat = "Quitar flag %s",
     setFactionTitle = "Establecer facción (%s)",

--- a/gamemode/modules/administration/submodules/permissions/commands.lua
+++ b/gamemode/modules/administration/submodules/permissions/commands.lua
@@ -160,7 +160,7 @@ lia.command.add("charlist", {
                     Name = row.name,
                     Desc = row.desc,
                     Faction = row.faction,
-                    Banned = info.banned and "Yes" or "No",
+                    Banned = info.banned and L("yes") or L("no"),
                     BanningAdminName = info.charBanInfo and info.charBanInfo.name or "",
                     BanningAdminSteamID = info.charBanInfo and info.charBanInfo.steamID or "",
                     BanningAdminRank = info.charBanInfo and info.charBanInfo.rank or "",

--- a/gamemode/modules/administration/submodules/permissions/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/client.lua
@@ -130,12 +130,12 @@ net.Receive("DisplayCharList", function()
         })
     end
 
-    local _, listView = lia.util.CreateTableUI("Charlist for SteamID64: " .. targetSteamIDsafe, columns, sendData)
+    local _, listView = lia.util.CreateTableUI(L("charlistTitle", targetSteamIDsafe), columns, sendData)
     if IsValid(listView) then
         for _, line in ipairs(listView:GetLines()) do
             local dataIndex = line:GetID()
             local rowData = sendData[dataIndex]
-            if rowData and rowData.Banned == "Yes" then
+            if rowData and rowData.Banned == L("yes") then
                 line.DoPaint = line.Paint
                 line.Paint = function(pnl, w, h)
                     surface.SetDrawColor(200, 100, 100)

--- a/gamemode/modules/teams/commands.lua
+++ b/gamemode/modules/teams/commands.lua
@@ -103,7 +103,7 @@ lia.command.add("roster", {
                         name = v.name,
                         faction = v.faction,
                         steamID = v.steamID,
-                        class = classData and classData.name or "None",
+                        class = classData and classData.name or L("none"),
                         lastOnline = lastOnlineText,
                         hoursPlayed = formatDHM(tonumber(v.totalOnlineTime) or 0)
                     })

--- a/gamemode/modules/teams/netcalls/client.lua
+++ b/gamemode/modules/teams/netcalls/client.lua
@@ -27,7 +27,7 @@ net.Receive("CharacterInfo", function()
         local originals = {}
         for _, data in ipairs(characterData) do
             if data.faction == factionID then
-                rows[#rows + 1] = {data.name, data.class or "None", data.lastOnline, data.hoursPlayed}
+                rows[#rows + 1] = {data.name, data.class or L("none"), data.lastOnline, data.hoursPlayed}
                 originals[#originals + 1] = data
             end
         end

--- a/gamemode/modules/teams/netcalls/server.lua
+++ b/gamemode/modules/teams/netcalls/server.lua
@@ -46,7 +46,7 @@ net.Receive("RequestRoster", function(_, client)
                     name = v.name,
                     faction = v.faction,
                     steamID = v.steamID,
-                    class = classData and classData.name or "None",
+                    class = classData and classData.name or L("none"),
                     lastOnline = lastOnlineText,
                     hoursPlayed = formatDHM(tonumber(v.totalOnlineTime) or 0)
                 })


### PR DESCRIPTION
## Summary
- localize `None` string in team roster code
- translate "Yes"/"No" banned text in admin permissions list
- localize charlist UI title and update languages

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c35f682448327857c24db9841ecd6