### PR TITLE
Localize default game description

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -320,7 +320,7 @@ function GM:InitializedSchema()
 end
 
 function GM:GetGameDescription()
-    return istable(SCHEMA) and tostring(SCHEMA.name) or "A Lilia Gamemode"
+    return istable(SCHEMA) and tostring(SCHEMA.name) or L("defaultGameDescription")
 end
 
 function GM:PostPlayerLoadout(client)

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -1198,4 +1198,5 @@ Reload: Drop]],
     agoFormat = "%s (%s) ago",
     gmaFileBlocked = "Blocked %s",
     gmaFileNotWhitelisted = "Warning: File %s not whitelisted. Skipping..",
+    defaultGameDescription = "A Lilia Gamemode",
 }

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -1192,4 +1192,5 @@ LANGUAGE = {
     agoFormat = "%s (%s) ago",
     gmaFileBlocked = "Blocked %s",
     gmaFileNotWhitelisted = "Warning: File %s not whitelisted. Skipping..",
+    defaultGameDescription = "A Lilia Gamemode",
 }

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -1195,4 +1195,5 @@ Ricarica: Droppa]],
     agoFormat = "%s (%s) ago",
     gmaFileBlocked = "Blocked %s",
     gmaFileNotWhitelisted = "Warning: File %s not whitelisted. Skipping..",
+    defaultGameDescription = "A Lilia Gamemode",
 }

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -1195,4 +1195,5 @@ Reload: Largar]],
     agoFormat = "%s (%s) ago",
     gmaFileBlocked = "Blocked %s",
     gmaFileNotWhitelisted = "Warning: File %s not whitelisted. Skipping..",
+    defaultGameDescription = "A Lilia Gamemode",
 }

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -1195,4 +1195,5 @@ R: Бросить]],
     agoFormat = "%s (%s) ago",
     gmaFileBlocked = "Blocked %s",
     gmaFileNotWhitelisted = "Warning: File %s not whitelisted. Skipping..",
+    defaultGameDescription = "A Lilia Gamemode",
 }

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -1195,4 +1195,5 @@ Recargar: Soltar]],
     agoFormat = "%s (%s) ago",
     gmaFileBlocked = "Blocked %s",
     gmaFileNotWhitelisted = "Warning: File %s not whitelisted. Skipping..",
+    defaultGameDescription = "A Lilia Gamemode",
 }


### PR DESCRIPTION
## Summary
- add `defaultGameDescription` to language files
- use localized default description in `GetGameDescription`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c3ce040f083278fe160964b3fbcf7