### PR TITLE
Localize missing strings

### DIFF
--- a/gamemode/core/libraries/core.lua
+++ b/gamemode/core/libraries/core.lua
@@ -553,7 +553,7 @@ for _, file in ipairs(ConditionalFiles) do
         if ok then
             shouldLoad = result
         else
-            lia.error("Compatibility condition error: " .. tostring(result))
+            lia.error(L("compatibilityConditionError", tostring(result)))
         end
     elseif file.global then
         shouldLoad = _G[file.global] ~= nil

--- a/gamemode/core/libraries/item.lua
+++ b/gamemode/core/libraries/item.lua
@@ -184,7 +184,7 @@ end
 function lia.item.getItemByID(itemID)
     assert(isnumber(itemID), "itemID must be a number")
     local item = lia.item.instances[itemID]
-    if not item then return nil, "Item not found" end
+    if not item then return nil, L("itemNotFound") end
     local location = "unknown"
     if item.invID then
         local inventory = lia.item.getInv(item.invID)
@@ -201,14 +201,14 @@ end
 function lia.item.getInstancedItemByID(itemID)
     assert(isnumber(itemID), "itemID must be a number")
     local item = lia.item.instances[itemID]
-    if not item then return nil, "Item not found" end
+    if not item then return nil, L("itemNotFound") end
     return item
 end
 
 function lia.item.getItemDataByID(itemID)
     assert(isnumber(itemID), "itemID must be a number")
     local item = lia.item.instances[itemID]
-    if not item then return nil, "Item not found" end
+    if not item then return nil, L("itemNotFound") end
     return item.data
 end
 
@@ -509,7 +509,7 @@ if SERVER then
         assert(isnumber(itemID), "itemID must be a number")
         assert(isstring(key), "key must be a string")
         local item = lia.item.instances[itemID]
-        if not item then return false, "Item not found" end
+        if not item then return false, L("itemNotFound") end
         item:setData(key, value, receivers, noSave, noCheckEntity)
         return true
     end

--- a/gamemode/core/libraries/logger.lua
+++ b/gamemode/core/libraries/logger.lua
@@ -766,7 +766,7 @@ end
 
 function lia.log.add(client, logType, ...)
     local logString, category = lia.log.getString(client, logType, ...)
-    if not isstring(category) then category = "Uncategorized" end
+    if not isstring(category) then category = L("uncategorized") end
     if not isstring(logString) then return end
     hook.Run("OnServerLog", client, logType, logString, category)
     lia.printLog(category, logString)

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -1198,5 +1198,8 @@ Reload: Drop]],
     agoFormat = "%s (%s) ago",
     gmaFileBlocked = "Blocked %s",
     gmaFileNotWhitelisted = "Warning: File %s not whitelisted. Skipping..",
+    itemNotFound = "Item not found",
+    compatibilityConditionError = "Compatibility condition error: %s",
+    uncategorized = "Uncategorized",
     defaultGameDescription = "A Lilia Gamemode",
 }

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -1192,5 +1192,8 @@ LANGUAGE = {
     agoFormat = "%s (%s) ago",
     gmaFileBlocked = "Blocked %s",
     gmaFileNotWhitelisted = "Warning: File %s not whitelisted. Skipping..",
+    itemNotFound = "Objet introuvable",
+    compatibilityConditionError = "Erreur de condition de compatibilité : %s",
+    uncategorized = "Non classé",
     defaultGameDescription = "A Lilia Gamemode",
 }

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -1195,5 +1195,8 @@ Ricarica: Droppa]],
     agoFormat = "%s (%s) ago",
     gmaFileBlocked = "Blocked %s",
     gmaFileNotWhitelisted = "Warning: File %s not whitelisted. Skipping..",
+    itemNotFound = "Oggetto non trovato",
+    compatibilityConditionError = "Errore di condizione di compatibilità: %s",
+    uncategorized = "Senza categoria",
     defaultGameDescription = "A Lilia Gamemode",
 }

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -1195,5 +1195,8 @@ Reload: Largar]],
     agoFormat = "%s (%s) ago",
     gmaFileBlocked = "Blocked %s",
     gmaFileNotWhitelisted = "Warning: File %s not whitelisted. Skipping..",
+    itemNotFound = "Item não encontrado",
+    compatibilityConditionError = "Erro de condição de compatibilidade: %s",
+    uncategorized = "Sem categoria",
     defaultGameDescription = "A Lilia Gamemode",
 }

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -1195,5 +1195,8 @@ R: Бросить]],
     agoFormat = "%s (%s) ago",
     gmaFileBlocked = "Blocked %s",
     gmaFileNotWhitelisted = "Warning: File %s not whitelisted. Skipping..",
+    itemNotFound = "Предмет не найден",
+    compatibilityConditionError = "Ошибка проверки совместимости: %s",
+    uncategorized = "Без категории",
     defaultGameDescription = "A Lilia Gamemode",
 }

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -1195,5 +1195,8 @@ Recargar: Soltar]],
     agoFormat = "%s (%s) ago",
     gmaFileBlocked = "Blocked %s",
     gmaFileNotWhitelisted = "Warning: File %s not whitelisted. Skipping..",
+    itemNotFound = "Objeto no encontrado",
+    compatibilityConditionError = "Error de condición de compatibilidad: %s",
+    uncategorized = "Sin categoría",
     defaultGameDescription = "A Lilia Gamemode",
 }

--- a/gamemode/modules/administration/submodules/logging/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/logging/libraries/server.lua
@@ -34,7 +34,7 @@ net.Receive("send_logs_request", function(_, client)
     if not CanPlayerSeeLog(client) then return end
     local categories = {}
     for _, v in pairs(lia.log.types) do
-        categories[v.category or "Uncategorized"] = true
+        categories[v.category or L("uncategorized")] = true
     end
 
     local catList = {}


### PR DESCRIPTION
## Summary
- add localization keys for item not found, compatibility condition errors, and uncategorized log categories
- use the new localized strings in core libraries and logging system

## Testing
- `lua -v` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688d0adb33208327bd39d089a99a07ad