### PR TITLE
Localize vendor default name and character name conflict

### DIFF
--- a/gamemode/core/libraries/character.lua
+++ b/gamemode/core/libraries/character.lua
@@ -118,7 +118,7 @@ lia.char.registerVar("name", {
 
         if not lia.config.get("AllowExistNames", true) then
             for _, v in pairs(lia.char.names) do
-                if v == value then return false, "A character with this name already exists." end
+                if v == value then return false, "nameAlreadyExists" end
             end
         end
         return true

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -587,6 +587,7 @@ LANGUAGE = {
     sitroomRepositioned = "SitRoom repositioned successfully.",
     enterSitroomPrompt = "Enter the name of the SitRoom:",
     invalidName = "Invalid name!",
+    nameAlreadyExists = "A character with this name already exists.",
     sitroomSet = "SitRoom has been set!",
     sendToSitRoomDesc = "Send a player to a SitRoom",
     sitroomNotSet = "No SitRoom has been set!",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -587,6 +587,7 @@ LANGUAGE = {
     sitroomRepositioned = "Sitroom repositionnée.",
     enterSitroomPrompt = "Nom de la Sitroom :",
     invalidName = "Nom invalide !",
+    nameAlreadyExists = "Un personnage porte déjà ce nom.",
     sitroomSet = "Sitroom définie !",
     sendToSitRoomDesc = "Envoyer un joueur en Sitroom",
     sitroomNotSet = "Aucune Sitroom définie !",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -587,6 +587,7 @@ LANGUAGE = {
     sitroomRepositioned = "SitRoom riposizionata con successo.",
     enterSitroomPrompt = "Inserisci il nome della SitRoom:",
     invalidName = "Nome non valido!",
+    nameAlreadyExists = "Esiste già un personaggio con questo nome.",
     sitroomSet = "SitRoom impostata!",
     sendToSitRoomDesc = "Invia un giocatore a una SitRoom",
     sitroomNotSet = "Nessuna SitRoom impostata!",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -587,6 +587,7 @@ LANGUAGE = {
     sitroomRepositioned = "SitRoom reposicionada com sucesso.",
     enterSitroomPrompt = "Introduz nome da SitRoom:",
     invalidName = "Nome inválido!",
+    nameAlreadyExists = "Já existe um personagem com esse nome.",
     sitroomSet = "SitRoom definida!",
     sendToSitRoomDesc = "Enviar jogador para SitRoom",
     sitroomNotSet = "Nenhuma SitRoom definida!",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -587,6 +587,7 @@ LANGUAGE = {
     sitroomRepositioned = "Атмосфера перемещена.",
     enterSitroomPrompt = "Введите имя атмосферы:",
     invalidName = "Неверное имя!",
+    nameAlreadyExists = "Персонаж с таким именем уже существует.",
     sitroomSet = "Атмосфера установлена!",
     sendToSitRoomDesc = "Отправить игрока в атмосферу",
     sitroomNotSet = "Атмосфера не настроена!",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -587,6 +587,7 @@ LANGUAGE = {
     sitroomRepositioned = "Sala reubicada.",
     enterSitroomPrompt = "Nombre de la sala:",
     invalidName = "Nombre inválido",
+    nameAlreadyExists = "Ya existe un personaje con ese nombre.",
     sitroomSet = "Sala establecida.",
     sendToSitRoomDesc = "Enviar jugador a sala",
     sitroomNotSet = "No hay sala establecida.",

--- a/gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/cl_init.lua
+++ b/gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/cl_init.lua
@@ -21,5 +21,5 @@ end
 function ENT:onDrawEntityInfo(alpha)
     local pos = self:LocalToWorld(self:OBBCenter()) + TEXT_OFFSET
     local screenPos = toScreen(pos)
-    drawText(self:getNetVar("name", "Jane Doe"), screenPos.x, screenPos.y, ColorAlpha(configGet("Color"), alpha), 1, 1, nil, alpha * 0.65)
+    drawText(self:getNetVar("name", L("vendorDefaultName")), screenPos.x, screenPos.y, ColorAlpha(configGet("Color"), alpha), 1, 1, nil, alpha * 0.65)
 end

--- a/gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/shared.lua
+++ b/gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/shared.lua
@@ -11,7 +11,7 @@ ENT.DrawEntityInfo = true
 ENT.IsPersistent = true
 function ENT:setupVars()
     if SERVER then
-        self:setNetVar("name", "Jane Doe")
+        self:setNetVar("name", L("vendorDefaultName"))
         self:setNetVar("preset", "none")
         self.receivers = {}
     end


### PR DESCRIPTION
## Summary
- localize vendor default name in vendor entity code
- show new `nameAlreadyExists` language phrase
- localize duplicate character name error

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688d174063608327bcfc03460d12e94a