### PR TITLE
Localize warnings panel title

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -712,6 +712,7 @@ LANGUAGE = {
     viewWarnsDesc = "Displays all warnings issued to the specified player.",
     warnPlayer = "Warn Player",
     viewPlayerWarnings = "View Player Warnings",
+    playerWarningsTitle = "%s's Warnings",
     warnings = "Warnings",
     warning = "Warning",
     warnUsage = "Usage: warn [player] [reason]",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -712,6 +712,7 @@ LANGUAGE = {
     viewWarnsDesc = "Affiche les avertissements d’un joueur.",
     warnPlayer = "Avertir",
     viewPlayerWarnings = "Voir les avertissements",
+    playerWarningsTitle = "Avertissements de %s",
     warnings = "Avertissements",
     warning = "Avertissement",
     warnUsage = "Usage : warn [joueur] [raison]",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -712,6 +712,7 @@ LANGUAGE = {
     viewWarnsDesc = "Mostra tutti i warning emessi al giocatore specificato.",
     warnPlayer = "Avvisa Giocatore",
     viewPlayerWarnings = "Vedi Warning Giocatore",
+    playerWarningsTitle = "Warning di %s",
     warnings = "Warning",
     warning = "Warning",
     warnUsage = "Uso: warn [giocatore] [motivo]",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -712,6 +712,7 @@ LANGUAGE = {
     viewWarnsDesc = "Mostra advertências de jogador.",
     warnPlayer = "Advertir Jogador",
     viewPlayerWarnings = "Ver Advertências",
+    playerWarningsTitle = "Advertências de %s",
     warnings = "Advertências",
     warning = "Advertência",
     warnUsage = "Uso: warn [jogador] [razão]",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -712,6 +712,7 @@ LANGUAGE = {
     viewWarnsDesc = "Показать предупреждения игрока.",
     warnPlayer = "Предупредить",
     viewPlayerWarnings = "Предупреждения игрока",
+    playerWarningsTitle = "Предупреждения %s",
     warnings = "Предупреждения",
     warning = "Предупреждение",
     warnUsage = "Использование: warn [игрок] [причина]",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -712,6 +712,7 @@ LANGUAGE = {
     viewWarnsDesc = "Ver advertencias.",
     warnPlayer = "Advertir",
     viewPlayerWarnings = "Ver advertencias",
+    playerWarningsTitle = "Advertencias de %s",
     warnings = "Advertencias",
     warning = "Advertencia",
     warnUsage = "Uso: warn [jugador] [razón]",

--- a/gamemode/modules/administration/submodules/warns/commands.lua
+++ b/gamemode/modules/administration/submodules/warns/commands.lua
@@ -65,7 +65,7 @@ lia.command.add("viewwarns", {
                 })
             end
 
-            lia.util.CreateTableUI(client, target:Nick() .. "'s " .. L("warnings"), {
+            lia.util.CreateTableUI(client, L("playerWarningsTitle", target:Nick()), {
                 {
                     name = L("id"),
                     field = "index"


### PR DESCRIPTION
## Summary
- localize the warnings list UI title
- add translation entries for all languages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d18f80cd88327957398573bb5f97d