### PR TITLE
Fix privilege checks localization

### DIFF
--- a/gamemode/modules/f1menu/libraries/server.lua
+++ b/gamemode/modules/f1menu/libraries/server.lua
@@ -6,7 +6,7 @@ end
 net.Receive("liaTeleportToEntity", function(_, ply)
     local ent = net.ReadEntity()
     if not IsValid(ent) then return end
-    if not ply:hasPrivilege("Staff Permission — Teleport to Entity (Entity Tab)") then return end
+    if not ply:hasPrivilege(L("teleportToEntityTab")) then return end
     local pos = ent:GetPos() + Vector(0, 0, 50)
     ply:SetPos(pos)
     ply:notifyLocalized("teleportedToEntity", ent:GetClass())

--- a/gamemode/modules/protection/libraries/client.lua
+++ b/gamemode/modules/protection/libraries/client.lua
@@ -1736,7 +1736,7 @@ function MODULE:PopulateAdminTabs(pages)
                             btn.DoClick = func
                         end
 
-                        if client:hasPrivilege("Staff Permission — View Entity (Entity Tab)") then
+                        if client:hasPrivilege(L("viewEntityTab")) then
                             makeBtn("view", function()
                                 if IsValid(lia.gui.menu) then lia.gui.menu:remove() end
                                 local prevTP = lia.option.get("thirdPersonEnabled", false)
@@ -1745,7 +1745,7 @@ function MODULE:PopulateAdminTabs(pages)
                             end)
                         end
 
-                        if client:hasPrivilege("Staff Permission — Teleport to Entity (Entity Tab)") then
+                        if client:hasPrivilege(L("teleportToEntityTab")) then
                             makeBtn("teleport", function()
                                 net.Start("liaTeleportToEntity")
                                 net.WriteEntity(ent)


### PR DESCRIPTION
## Summary
- localize privilege checks so that they use translation keys

## Testing
- `luacheck --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d370c30108327869c6eabdc1ac1a6