### PR TITLE
Fix privilege editing UI reload

### DIFF
--- a/gamemode/init.lua
+++ b/gamemode/init.lua
@@ -9,3 +9,4 @@ for _, netString in ipairs(networkStrings) do
     util.AddNetworkString(netString)
 end
 util.AddNetworkString("liaGroupsSetPerm")
+util.AddNetworkString("liaGroupPermChanged")


### PR DESCRIPTION
## Summary
- keep admin menu from rebuilding when toggling permissions
- update privilege lists dynamically

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688d4834a8fc8327857095d199d930d6