### PR TITLE
Fix unlocalized admin stick label

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -566,6 +566,7 @@ LANGUAGE = {
     adminStickUnwhitelistName = "Unwhitelist Player",
     adminStickClassWhitelistName = "Class Whitelist",
     adminStickClassUnwhitelistName = "Class Unwhitelist",
+    adminStickSetClassName = "Set Class",
     uiBodygroupsFor = "Bodygroups for %s",
     groupID = "Group ID",
     range = "Range",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -566,6 +566,7 @@ LANGUAGE = {
     adminStickUnwhitelistName = "Retirer whitelist",
     adminStickClassWhitelistName = "Whitelist classe",
     adminStickClassUnwhitelistName = "Unwhitelist classe",
+    adminStickSetClassName = "Définir classe",
     uiBodygroupsFor = "Bodygroups de %s",
     groupID = "ID groupe",
     range = "Portée",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -566,6 +566,7 @@ LANGUAGE = {
     adminStickUnwhitelistName = "Rimuovi Whitelist",
     adminStickClassWhitelistName = "Whitelist Classe",
     adminStickClassUnwhitelistName = "Unwhitelist Classe",
+    adminStickSetClassName = "Imposta Classe",
     uiBodygroupsFor = "Bodygroups per %s",
     groupID = "ID Gruppo",
     range = "Raggio",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -566,6 +566,7 @@ LANGUAGE = {
     adminStickUnwhitelistName = "Remover Whitelist",
     adminStickClassWhitelistName = "Whitelist Classe",
     adminStickClassUnwhitelistName = "Remover Whitelist Classe",
+    adminStickSetClassName = "Definir Classe",
     uiBodygroupsFor = "Bodygroups de %s",
     groupID = "ID de Grupo",
     range = "Alcance",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -566,6 +566,7 @@ LANGUAGE = {
     adminStickUnwhitelistName = "Снять вайтлист",
     adminStickClassWhitelistName = "Вайтлист класса",
     adminStickClassUnwhitelistName = "Снять вайтлист класса",
+    adminStickSetClassName = "Установить класс",
     uiBodygroupsFor = "Бодигруппы %s",
     groupID = "ID группы",
     range = "Дальность",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -566,6 +566,7 @@ LANGUAGE = {
     adminStickUnwhitelistName = "Quitar whitelist",
     adminStickClassWhitelistName = "Whitelist de clase",
     adminStickClassUnwhitelistName = "Quitar whitelist clase",
+    adminStickSetClassName = "Establecer clase",
     uiBodygroupsFor = "Bodygroups de %s",
     groupID = "ID grupo",
     range = "Rango",

--- a/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
@@ -317,7 +317,7 @@ local function IncludeCharacterManagement(tgt, menu, stores)
                 end
 
                 table.sort(cls, function(a, b) return a.name < b.name end)
-                local cm = GetOrCreateSubMenu(charMenu, "Set Class", stores)
+                local cm = GetOrCreateSubMenu(charMenu, "adminStickSetClassName", stores)
                 for _, o in ipairs(cls) do
                     cm:AddOption(L(o.name), function()
                         cl:ConCommand(o.cmd)


### PR DESCRIPTION
## Summary
- localize the "Set Class" admin stick submenu

## Testing
- `luacheck --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d57081170832785ae34cd4713ce37