### PR TITLE
Fix unlocalized emote text

### DIFF
--- a/gamemode/modules/chatbox/libraries/shared.lua
+++ b/gamemode/modules/chatbox/libraries/shared.lua
@@ -297,7 +297,7 @@ lia.chat.register("me's", {
             nameCol = Color(tempCol.r + 40, tempCol.b + 60, tempCol.g + 40)
         end
 
-        chat.AddText(nameCol, "**" .. speako .. "'s", texCol, " " .. text)
+        chat.AddText(nameCol, L("mePossessiveFormat", speako, ""), texCol, text)
     end,
     prefix = {"/me's", "/action's"},
     font = "liaChatFontItalics",
@@ -321,7 +321,7 @@ lia.chat.register("mefarfar", {
             nameCol = Color(tempCol.r + 40, tempCol.b + 60, tempCol.g + 40)
         end
 
-        chat.AddText(nameCol, "**" .. speako, texCol, " " .. text)
+        chat.AddText(nameCol, L("emoteFormat", speako, ""), texCol, text)
     end,
     onCanHear = lia.config.get("ChatRange", 280) * 4,
     prefix = {"/mefarfar", "/actionyy", "/meyy"},


### PR DESCRIPTION
## Summary
- localize emote chat messages in the chatbox library

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688d5a31e2148327a264d0a7d8d24605