### PR TITLE
Use liaCheckBox for boolean arg inputs

### DIFF
--- a/gamemode/core/libraries/util.lua
+++ b/gamemode/core/libraries/util.lua
@@ -473,8 +473,9 @@ else
             label:SizeToContents()
             local textW = select(1, surface.GetTextSize(name))
             local ctrl
-            if fieldType == "boolean" then
-                ctrl = vgui.Create("DCheckBox", panel)
+            local isBool = fieldType == "boolean"
+            if isBool then
+                ctrl = vgui.Create("liaCheckBox", panel)
             elseif fieldType == "table" then
                 ctrl = vgui.Create("DComboBox", panel)
                 if istable(dataTbl) then
@@ -496,7 +497,12 @@ else
             end
 
             panel.PerformLayout = function(_, w, h)
-                local ctrlH, ctrlW = 30, w * 0.7
+                local ctrlH, ctrlW
+                if isBool then
+                    ctrlH, ctrlW = 22, 22
+                else
+                    ctrlH, ctrlW = 30, w * 0.7
+                end
                 local totalW = textW + 10 + ctrlW
                 local xOff = (w - totalW) / 2
                 label:SetPos(xOff, (h - label:GetTall()) / 2)


### PR DESCRIPTION
## Summary
- use `liaCheckBox` instead of `DCheckBox` in `lia.util.requestArguments`
- size boolean input controls the same as in admin menu

## Testing
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688d67075b988327bc7f3a46030f6c40