### PR TITLE
Fix empty roster tab in information menu

### DIFF
--- a/gamemode/modules/teams/netcalls/client.lua
+++ b/gamemode/modules/teams/netcalls/client.lua
@@ -26,10 +26,8 @@ net.Receive("CharacterInfo", function()
         local rows = {}
         local originals = {}
         for _, data in ipairs(characterData) do
-            if data.faction == factionID then
-                rows[#rows + 1] = {data.name, data.class or L("none"), data.lastOnline, data.hoursPlayed}
-                originals[#originals + 1] = data
-            end
+            rows[#rows + 1] = {data.name, data.class or L("none"), data.lastOnline, data.hoursPlayed}
+            originals[#originals + 1] = data
         end
 
         local row = sheet:AddListViewRow({
@@ -91,7 +89,7 @@ net.Receive("CharacterInfo", function()
     if IsValid(characterPanel) then characterPanel:Remove() end
     local rows = {}
     for _, data in ipairs(characterData) do
-        if data.faction == factionID then table.insert(rows, data) end
+        table.insert(rows, data)
     end
 
     local columns = {


### PR DESCRIPTION
## Summary
- Remove unnecessary faction filtering when populating roster data so all members show in the F1 information tab

## Testing
- `luac -p gamemode/modules/teams/netcalls/client.lua` *(command not found)*
- `apt-get update` *(403 errors: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688d680f0e6483279826f7663308c2ae