### PR TITLE
Override admin checks to respect usergroup inheritance

### DIFF
--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -202,6 +202,14 @@ local function groupHasType(groupName, t)
     return false
 end
 
+function playerMeta:IsAdmin()
+    return groupDerivesFrom(self:GetUserGroup(), "admin")
+end
+
+function playerMeta:IsSuperAdmin()
+    return groupDerivesFrom(self:GetUserGroup(), "superadmin")
+end
+
 function playerMeta:isUser()
     return groupDerivesFrom(self:GetUserGroup(), "user")
 end


### PR DESCRIPTION
## Summary
- override `IsAdmin` and `IsSuperAdmin` to check for usergroup inheritance

## Testing
- `luacheck gamemode/core/meta/player.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d6e0fac708327aa591e2769900640