### PR TITLE
feat: associate spawn menu items with creator

### DIFF
--- a/gamemode/modules/administration/submodules/itemspawner/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/itemspawner/libraries/server.lua
@@ -40,6 +40,12 @@ net.Receive("SpawnMenuSpawnItem", function(_, client)
         local ent = item:getEntity()
         if not IsValid(ent) then return end
         tryFixPropPosition(client, ent)
+        if IsValid(client) then
+            ent.SteamID64 = client:SteamID64()
+            local char = client:getChar()
+            if char then ent.liaCharID = char:getID() end
+            ent:SetCreator(client)
+        end
         undo.Create("item")
         undo.SetPlayer(client)
         undo.AddEntity(ent)


### PR DESCRIPTION
## Summary
- ensure spawn menu spawned items record who created them by storing SteamID64, char ID, and creator reference

## Testing
- `luacheck gamemode/modules/administration/submodules/itemspawner/libraries/server.lua` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688d6ed222fc8327ae4b42b99da05dc1