### PR TITLE
Override admin checks to respect usergroup inheritance

### DIFF
--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -202,6 +202,17 @@ local function groupHasType(groupName, t)
     return false
 end
 
+local oldIsAdmin = playerMeta.IsAdmin
+local oldIsSuperAdmin = playerMeta.IsSuperAdmin
+
+function playerMeta:IsAdmin()
+    return (oldIsAdmin and oldIsAdmin(self)) or groupDerivesFrom(self:GetUserGroup(), "admin")
+end
+
+function playerMeta:IsSuperAdmin()
+    return (oldIsSuperAdmin and oldIsSuperAdmin(self)) or groupDerivesFrom(self:GetUserGroup(), "superadmin")
+end
+
 function playerMeta:isUser()
     return groupDerivesFrom(self:GetUserGroup(), "user")
 end


### PR DESCRIPTION
## Summary
- override `IsAdmin` and `IsSuperAdmin` to check for usergroup inheritance
- preserve original admin checks by calling the base implementations first

## Testing
- `luacheck gamemode/core/meta/player.lua` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: Unable to locate package luacheck)*

------
https://chatgpt.com/codex/tasks/task_e_688d6e0fac708327aa591e2769900640