### PR TITLE
feat: show item size in admin stick

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -1059,6 +1059,7 @@ LANGUAGE = {
     serverEventCharLock = "Currently the server is in an event and you're unable to change characters.",
     allBotsKicked = "All bots kicked",
     itemESPLabel = "Item: %s",
+    itemSizeESPLabel = "Item Size: %sx%s",
     propModelESPLabel = "Prop Model: %s",
     entityClassESPLabel = "Entity Class: %s",
     entityCreatorESPLabel = "Creator: %s",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -1059,6 +1059,7 @@ LANGUAGE = {
     serverEventCharLock = "Événement serveur : changement de perso bloqué.",
     allBotsKicked = "Tous les bots kick",
     itemESPLabel = "Item : %s",
+    itemSizeESPLabel = "Taille de l'objet : %sx%s",
     propModelESPLabel = "Modèle prop : %s",
     entityClassESPLabel = "Classe entité : %s",
     entityCreatorESPLabel = "Créateur : %s",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -1059,6 +1059,7 @@ LANGUAGE = {
     serverEventCharLock = "Attualmente il server è in un evento e non puoi cambiare personaggio.",
     allBotsKicked = "Tutti i bot kickati",
     itemESPLabel = "Oggetto: %s",
+    itemSizeESPLabel = "Dimensione dell'oggetto: %sx%s",
     propModelESPLabel = "Modello Prop: %s",
     entityClassESPLabel = "Classe Entità: %s",
     entityCreatorESPLabel = "Creatore: %s",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -1059,6 +1059,7 @@ LANGUAGE = {
     serverEventCharLock = "Evento de servidor, não podes mudar de personagem.",
     allBotsKicked = "Todos os bots expulsos",
     itemESPLabel = "Item: %s",
+    itemSizeESPLabel = "Tamanho do item: %sx%s",
     propModelESPLabel = "Modelo: %s",
     entityClassESPLabel = "Classe: %s",
     entityCreatorESPLabel = "Criador: %s",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -1059,6 +1059,7 @@ LANGUAGE = {
     serverEventCharLock = "Серверное событие: смена персонажей заблокирована.",
     allBotsKicked = "Все боты кикнуты",
     itemESPLabel = "Предмет: %s",
+    itemSizeESPLabel = "Размер предмета: %sx%s",
     propModelESPLabel = "Модель пропа: %s",
     entityClassESPLabel = "Класс: %s",
     entityCreatorESPLabel = "Создатель: %s",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -1059,6 +1059,7 @@ LANGUAGE = {
     serverEventCharLock = "Servidor en evento, no puedes cambiar personaje.",
     allBotsKicked = "Todos los bots expulsados",
     itemESPLabel = "Ítem: %s",
+    itemSizeESPLabel = "Tamaño del ítem: %sx%s",
     propModelESPLabel = "Modelo: %s",
     entityClassESPLabel = "Clase: %s",
     entityCreatorESPLabel = "Creador: %s",

--- a/gamemode/modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua
+++ b/gamemode/modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua
@@ -35,7 +35,20 @@ function SWEP:DrawHUD()
     local information = {}
     if IsValid(target) then
         if not target:IsPlayer() then
-            if target.GetCreator and IsValid(target:GetCreator()) then table.Add(information, {L("entityClassESPLabel", target:GetClass()), L("entityCreatorESPLabel", tostring(target:GetCreator()))}) end
+            if target.GetCreator and IsValid(target:GetCreator()) then
+                table.insert(information, L("entityClassESPLabel", target:GetClass()))
+                table.insert(information, L("entityCreatorESPLabel", tostring(target:GetCreator())))
+            end
+
+            if target.isItem and target:isItem() then
+                local itemTable = target.getItemTable and target:getItemTable()
+                if itemTable then
+                    local itemName = L(itemTable.getName and itemTable:getName() or itemTable.name)
+                    table.insert(information, L("itemESPLabel", itemName))
+                    table.insert(information, L("itemSizeESPLabel", itemTable:getWidth(), itemTable:getHeight()))
+                end
+            end
+
             if target:IsVehicle() and IsValid(target:GetDriver()) then target = target:GetDriver() end
         end
 


### PR DESCRIPTION
## Summary
- show item information (name, width & height) when targeting items with the admin stick
- localize new item size label for all languages

## Testing
- `luacheck gamemode/modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua gamemode/languages/english.lua gamemode/languages/french.lua gamemode/languages/italian.lua gamemode/languages/portuguese.lua gamemode/languages/russian.lua gamemode/languages/spanish.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d6f05651c8327b00683f9d50978e4