### PR TITLE
Ensure roster tab populates when opened

### DIFF
--- a/gamemode/modules/teams/libraries/client.lua
+++ b/gamemode/modules/teams/libraries/client.lua
@@ -39,9 +39,12 @@ function MODULE:CreateInformationButtons(pages)
             local sheet = vgui.Create("liaSheet", parent)
             sheet:SetPlaceholderText(L("search"))
             lia.gui.rosterSheet = sheet
-
-            net.Start("RequestRoster")
-            net.SendToServer()
+        end,
+        onSelect = function()
+            if IsValid(lia.gui.rosterSheet) then
+                net.Start("RequestRoster")
+                net.SendToServer()
+            end
         end
     })
 end


### PR DESCRIPTION
## Summary
- Refresh faction roster when its information tab is selected

## Testing
- `luacheck gamemode/modules/teams/libraries/client.lua` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688d6f55144483279c7ecdad9374efb2