### PR TITLE
Fix active ticket list in admin tab

### DIFF
--- a/gamemode/modules/administration/submodules/tickets/netcalls/server.lua
+++ b/gamemode/modules/administration/submodules/tickets/netcalls/server.lua
@@ -57,7 +57,11 @@ end)
 
 net.Receive("liaRequestActiveTickets", function(_, client)
     if not (client:hasPrivilege("Always See Tickets") or client:isStaffOnDuty()) then return end
+    local tickets = {}
+    for _, data in pairs(MODULE.ActiveTickets or {}) do
+        tickets[#tickets + 1] = data
+    end
     net.Start("liaActiveTickets")
-    net.WriteTable(MODULE.ActiveTickets or {})
+    net.WriteTable(tickets)
     net.Send(client)
 end)


### PR DESCRIPTION
## Summary
- Ensure active ticket data is sent as a sequential list so the admin panel can display open tickets

## Testing
- `luac -p gamemode/modules/administration/submodules/tickets/netcalls/server.lua` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d6f696e0c8327894c51ea27801432