### PR TITLE
feat: categorize command logs

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -248,10 +248,12 @@ function GM:PlayerSay(client, message)
 
     local logType = logTypeMap[chatType] or "chat"
     lia.chat.send(client, chatType, message, anonymous)
-    if logType == "chat" then
-        lia.log.add(client, logType, chatType and chatType:upper() or "??", message)
-    else
-        lia.log.add(client, logType, message)
+    if lia.chat.classes[chatType] then
+        if logType == "chat" then
+            lia.log.add(client, logType, chatType and chatType:upper() or "??", message)
+        else
+            lia.log.add(client, logType, message)
+        end
     end
 
     hook.Run("PostPlayerSay", client, message, chatType, anonymous)

--- a/gamemode/core/libraries/logger.lua
+++ b/gamemode/core/libraries/logger.lua
@@ -93,7 +93,7 @@ lia.log.types = {
     },
     ["command"] = {
         func = function(client, text) return string.format("Player '%s' ran command: %s.", client:Name(), text) end,
-        category = "Chat"
+        category = "Commands"
     },
     ["money"] = {
         func = function(client, amount) return string.format("Player '%s' changed money by: %s.", client:Name(), amount) end,


### PR DESCRIPTION
## Summary
- separate command log entries into their own category
- restrict chat logging to registered chat classes only

## Testing
- `luacheck gamemode/core/libraries/logger.lua gamemode/core/hooks/server.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688d6fd230988327bf90d62ea12edb75