### PR TITLE
Fix roster last online localization

### DIFF
--- a/gamemode/modules/teams/netcalls/server.lua
+++ b/gamemode/modules/teams/netcalls/server.lua
@@ -36,7 +36,7 @@ net.Receive("RequestRoster", function(_, client)
                     local lastDiff = os.time() - last
                     local timeSince = lia.time.TimeSince(last)
                     local timeStripped = timeSince:match("^(.-)%sago$") or timeSince
-                    lastOnlineText = string.format("%s (%s) ago", timeStripped, formatDHM(lastDiff))
+                    lastOnlineText = string.format(L("agoFormat"), timeStripped, formatDHM(lastDiff))
                 end
 
                 local classID = tonumber(v._class) or 0


### PR DESCRIPTION
## Summary
- use localized string when showing last online timestamps in faction roster

## Testing
- `luacheck gamemode/modules/teams/netcalls/server.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d741818bc8327930c4e9bdcbf71c2