### PR TITLE
Fix ticket requester/admin lookup

### DIFF
--- a/gamemode/modules/administration/submodules/logging/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/logging/libraries/server.lua
@@ -167,11 +167,11 @@ function MODULE:OnPlayerObserve(client, state)
 end
 
 function MODULE:TicketSystemClaim(admin, requester)
-    lia.db.count("ticketclaims", "admin = " .. lia.db.convertDataType(admin:SteamID64())):next(function(count) lia.log.add(admin, "ticketClaimed", requester:Name(), count) end)
+    lia.db.count("ticketclaims", "admin = " .. lia.db.convertDataType(admin:SteamID())):next(function(count) lia.log.add(admin, "ticketClaimed", requester:Name(), count) end)
 end
 
 function MODULE:TicketSystemClose(admin, requester)
-    lia.db.count("ticketclaims", "admin = " .. lia.db.convertDataType(admin:SteamID64())):next(function(count) lia.log.add(admin, "ticketClosed", requester:Name(), count) end)
+    lia.db.count("ticketclaims", "admin = " .. lia.db.convertDataType(admin:SteamID())):next(function(count) lia.log.add(admin, "ticketClosed", requester:Name(), count) end)
 end
 
 function MODULE:WarningIssued(admin, target, reason, index)

--- a/gamemode/modules/administration/submodules/tickets/commands.lua
+++ b/gamemode/modules/administration/submodules/tickets/commands.lua
@@ -23,7 +23,7 @@ lia.command.add("plyviewclaims", {
             return
         end
 
-        local steamID = target:SteamID64()
+        local steamID = target:SteamID()
         MODULE:GetAllCaseClaims():next(function(caseclaims)
             local claim = caseclaims[steamID]
             if not claim then

--- a/gamemode/modules/administration/submodules/tickets/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/tickets/libraries/client.lua
@@ -11,8 +11,8 @@ function MODULE:TicketFrame(requester, message, claimed)
             local txt = v:GetChildren()[5]
             txt:AppendText("\n" .. message)
             txt:GotoTextEnd()
-            timer.Remove("ticketsystem-" .. requester:SteamID64())
-            timer.Create("ticketsystem-" .. requester:SteamID64(), 60, 1, function() if IsValid(v) then v:Remove() end end)
+            timer.Remove("ticketsystem-" .. requester:SteamID())
+            timer.Create("ticketsystem-" .. requester:SteamID(), 60, 1, function() if IsValid(v) then v:Remove() end end)
             surface.PlaySound("ui/hint.wav")
             return
         end
@@ -132,9 +132,9 @@ function MODULE:TicketFrame(requester, message, claimed)
             end
         end
 
-        if IsValid(requester) and timer.Exists("ticketsystem-" .. requester:SteamID64()) then timer.Remove("ticketsystem-" .. requester:SteamID64()) end
+        if IsValid(requester) and timer.Exists("ticketsystem-" .. requester:SteamID()) then timer.Remove("ticketsystem-" .. requester:SteamID()) end
     end
 
     table.insert(TicketFrames, frm)
-    timer.Create("ticketsystem-" .. requester:SteamID64(), 60, 1, function() if IsValid(frm) then frm:Remove() end end)
+    timer.Create("ticketsystem-" .. requester:SteamID(), 60, 1, function() if IsValid(frm) then frm:Remove() end end)
 end

--- a/gamemode/modules/administration/submodules/tickets/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/tickets/libraries/server.lua
@@ -14,12 +14,12 @@ local function buildClaimTable(rows)
         local info = caseclaims[adminID]
         info.claims = info.claims + 1
         if row.timestamp > info.lastclaim then info.lastclaim = row.timestamp end
-        local reqPly = player.GetBySteamID64(row.request)
+        local reqPly = player.GetBySteamID(row.request)
         info.claimedFor[row.request] = IsValid(reqPly) and reqPly:Nick() or row.request
     end
 
     for adminID, info in pairs(caseclaims) do
-        local ply = player.GetBySteamID64(adminID)
+        local ply = player.GetBySteamID(adminID)
         if IsValid(ply) then info.name = ply:Nick() end
     end
     return caseclaims
@@ -31,8 +31,8 @@ end
 
 function MODULE:TicketSystemClaim(admin, requester)
     lia.db.insertTable({
-        request = requester:SteamID64(),
-        admin = admin:SteamID64(),
+        request = requester:SteamID(),
+        admin = admin:SteamID(),
         timestamp = os.time()
     }, nil, "ticketclaims")
 end
@@ -55,7 +55,7 @@ function MODULE:PlayerDisconnected(client)
         end
     end
 
-    MODULE.ActiveTickets[client:SteamID64()] = nil
+    MODULE.ActiveTickets[client:SteamID()] = nil
 end
 
 function MODULE:SendPopup(noob, message)
@@ -70,17 +70,17 @@ function MODULE:SendPopup(noob, message)
     end
 
     if IsValid(noob) and noob:IsPlayer() then
-        MODULE.ActiveTickets[noob:SteamID64()] = {
+        MODULE.ActiveTickets[noob:SteamID()] = {
             timestamp = os.time(),
             requester = noob:SteamID(),
             admin = noob.CaseClaimed and IsValid(noob.CaseClaimed) and noob.CaseClaimed:SteamID() or nil,
             message = message
         }
 
-        timer.Remove("ticketsystem-" .. noob:SteamID64())
-        timer.Create("ticketsystem-" .. noob:SteamID64(), 60, 1, function()
+        timer.Remove("ticketsystem-" .. noob:SteamID())
+        timer.Create("ticketsystem-" .. noob:SteamID(), 60, 1, function()
             if IsValid(noob) and noob:IsPlayer() then noob.CaseClaimed = nil end
-            MODULE.ActiveTickets[noob:SteamID64()] = nil
+            MODULE.ActiveTickets[noob:SteamID()] = nil
         end)
     end
 end

--- a/gamemode/modules/administration/submodules/tickets/module.lua
+++ b/gamemode/modules/administration/submodules/tickets/module.lua
@@ -45,7 +45,7 @@ if CLIENT then
 
             local requester = t.requester or ""
             if requester ~= "" then
-                local requesterPly = player.GetBySteamID(requester)
+                  local requesterPly = player.GetBySteamID(requester)
                 if IsValid(requesterPly) then requester = requesterPly:Nick() end
             end
 

--- a/gamemode/modules/administration/submodules/tickets/netcalls/client.lua
+++ b/gamemode/modules/administration/submodules/tickets/netcalls/client.lua
@@ -61,6 +61,6 @@ net.Receive("TicketSystemClose", function()
         if v.idiot == requester then v:Remove() end
     end
 
-    if timer.Exists("ticketsystem-" .. requester:SteamID64()) then timer.Remove("ticketsystem-" .. requester:SteamID64()) end
+    if timer.Exists("ticketsystem-" .. requester:SteamID()) then timer.Remove("ticketsystem-" .. requester:SteamID()) end
 end)
 

--- a/gamemode/modules/administration/submodules/tickets/netcalls/server.lua
+++ b/gamemode/modules/administration/submodules/tickets/netcalls/server.lua
@@ -28,7 +28,7 @@ net.Receive("TicketSystemClaim", function(_, client)
 
         hook.Run("TicketSystemClaim", client, requester)
         requester.CaseClaimed = client
-        local t = MODULE.ActiveTickets[requester:SteamID64()]
+        local t = MODULE.ActiveTickets[requester:SteamID()]
         if t then t.admin = client:SteamID() end
     end
 end)
@@ -41,7 +41,7 @@ net.Receive("TicketSystemClose", function(_, client)
     end
 
     if not requester or not IsValid(requester) or requester.CaseClaimed ~= client then return end
-    if timer.Exists("ticketsystem-" .. requester:SteamID64()) then timer.Remove("ticketsystem-" .. requester:SteamID64()) end
+    if timer.Exists("ticketsystem-" .. requester:SteamID()) then timer.Remove("ticketsystem-" .. requester:SteamID()) end
     for _, v in player.Iterator() do
         if v:hasPrivilege("Always See Tickets") or v:isStaffOnDuty() then
             net.Start("TicketSystemClose")
@@ -52,7 +52,7 @@ net.Receive("TicketSystemClose", function(_, client)
 
     hook.Run("TicketSystemClose", client, requester)
     requester.CaseClaimed = nil
-    MODULE.ActiveTickets[requester:SteamID64()] = nil
+    MODULE.ActiveTickets[requester:SteamID()] = nil
 end)
 
 net.Receive("liaRequestActiveTickets", function(_, client)


### PR DESCRIPTION
## Summary
- Store ticket requester and admin using SteamID and resolve names with `player.GetBySteamID`
- Update network handlers, commands, and logs to operate on SteamID identifiers
- Key active ticket timers by SteamID for consistent cleanup

## Testing
- `luacheck --version` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688d7421e00c8327b6126c9f85c6d52c