### PR TITLE
feat: add hook to extend admin stick HUD

### DIFF
--- a/gamemode/modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua
+++ b/gamemode/modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua
@@ -64,6 +64,8 @@ function SWEP:DrawHUD()
         end
     end
 
+    hook.Run("AddToAdminStickHUD", client, target, information)
+
     local length, thickness = 20, 1
     surface.SetDrawColor(crossColor)
     surface.DrawRect(x - length / 2, y - thickness / 2, length, thickness)


### PR DESCRIPTION
## Summary
- allow other modules to extend admin stick HUD with `AddToAdminStickHUD` hook

## Testing
- `luac -p gamemode/modules/administration/submodules/adminstick/entities/weapons/adminstick/cl_init.lua` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688d85c63e0c8327a2488f184d901321