### PR TITLE
Localize NPC weapon property strings

### DIFF
--- a/gamemode/core/libraries/thirdparty/sh_extensions.lua
+++ b/gamemode/core/libraries/thirdparty/sh_extensions.lua
@@ -147,7 +147,7 @@ AddEntFunctionProperty("lia_npc_weapon_strip", "Strip Weapon", 651, function(ent
 end, function(ent) ent:GetActiveWeapon():Remove() end, "icon16/gun.png")
 
 properties.Add("lia_npc_weapon", {
-    MenuLabel = "Change Weapon (Popup)",
+    MenuLabel = L("changeWeaponPopup"),
     MenuIcon = "icon16/gun.png",
     Order = 650,
     Filter = function(_, ent, ply)
@@ -159,7 +159,7 @@ properties.Add("lia_npc_weapon", {
         if not IsValid(ent) then return false end
         local frame = vgui.Create("DFrame")
         frame:SetSize(ScrW() / 1.2, ScrH() / 1.1)
-        frame:SetTitle("Change weapon of " .. language.GetPhrase("#" .. ent:GetClass()))
+        frame:SetTitle(L("changeWeaponOf", language.GetPhrase("#" .. ent:GetClass())))
         frame:Center()
         frame:MakePopup()
         frame:SetDraggable(false)
@@ -226,14 +226,15 @@ properties.Add("lia_npc_weapon", {
             WarningText:SetContentAlignment(5)
             WarningText:SetTextColor(color_white)
             WarningText:SetFont("DermaLarge")
-            WarningText:SetText("WARNING! Not all NPCs can use weapons and not all weapons are usable by NPCs.")
+            WarningText:SetText(L("npcWeaponWarning1"))
+
             local WarningText2 = vgui.Create("DLabel", WarningThing)
             WarningText2:Dock(TOP)
             WarningText2:SetHeight(35)
             WarningText2:SetContentAlignment(5)
             WarningText2:SetTextColor(color_white)
             WarningText2:SetFont("DermaLarge")
-            WarningText2:SetText("This is entirely dependent on the addon the weapon and the NPC are from. This mod cannot change that.")
+            WarningText2:SetText(L("npcWeaponWarning2"))
         end
     end,
     Receive = function(_, _, ply)

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -1433,4 +1433,9 @@ Reload: Drop]],
     categoryManagement = "Management",
     categoryWarning = "Warning",
     categoryProtection = "Protection",
+
+    changeWeaponPopup = "Change Weapon (Popup)",
+    changeWeaponOf = "Change weapon of %s",
+    npcWeaponWarning1 = "WARNING! Not all NPCs can use weapons and not all weapons are usable by NPCs.",
+    npcWeaponWarning2 = "This is entirely dependent on the addon the weapon and the NPC are from. This mod cannot change that.",
 }

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -1325,4 +1325,9 @@ LANGUAGE = {
     accessPropertyPrivilege = "Accès à la propriété %s",
     accessToolPrivilege = "Accès à l'outil %s",
     defaultGameDescription = "A Lilia Gamemode",
+
+    changeWeaponPopup = "Changer d'arme (Popup)",
+    changeWeaponOf = "Changer l'arme de %s",
+    npcWeaponWarning1 = "AVERTISSEMENT ! Tous les PNJ ne peuvent pas utiliser des armes et toutes les armes ne sont pas utilisables par les PNJ.",
+    npcWeaponWarning2 = "Cela dépend entièrement de l'addon dont proviennent l'arme et le PNJ. Ce mod ne peut pas changer cela.",
 }

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -1328,4 +1328,9 @@ Ricarica: Droppa]],
     accessPropertyPrivilege = "Accesso alla proprietà %s",
     accessToolPrivilege = "Accesso allo strumento %s",
     defaultGameDescription = "A Lilia Gamemode",
+
+    changeWeaponPopup = "Cambia Arma (Popup)",
+    changeWeaponOf = "Cambia l'arma di %s",
+    npcWeaponWarning1 = "ATTENZIONE! Non tutti i PNG possono usare armi e non tutte le armi sono utilizzabili dai PNG.",
+    npcWeaponWarning2 = "Dipende interamente dall'addon da cui provengono l'arma e il PNG. Questa mod non può cambiarlo.",
 }

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -1328,4 +1328,9 @@ Reload: Largar]],
     accessPropertyPrivilege = "Acesso à propriedade %s",
     accessToolPrivilege = "Acesso à ferramenta %s",
     defaultGameDescription = "A Lilia Gamemode",
+
+    changeWeaponPopup = "Mudar Arma (Popup)",
+    changeWeaponOf = "Mudar a arma de %s",
+    npcWeaponWarning1 = "AVISO! Nem todos os NPCs podem usar armas e nem todas as armas são utilizáveis por NPCs.",
+    npcWeaponWarning2 = "Isso depende inteiramente do addon de onde vêm a arma e o NPC. Este mod não pode mudar isso.",
 }

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -1328,4 +1328,9 @@ R: Бросить]],
     accessPropertyPrivilege = "Доступ к свойству %s",
     accessToolPrivilege = "Доступ к инструменту %s",
     defaultGameDescription = "A Lilia Gamemode",
+
+    changeWeaponPopup = "Смена оружия (всплывающее)",
+    changeWeaponOf = "Сменить оружие у %s",
+    npcWeaponWarning1 = "ПРЕДУПРЕЖДЕНИЕ! Не все NPC могут использовать оружие, и не все оружия подходят для NPC.",
+    npcWeaponWarning2 = "Это полностью зависит от аддона, из которого оружие и NPC. Этот мод не может это изменить.",
 }

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -1328,4 +1328,9 @@ Recargar: Soltar]],
     accessPropertyPrivilege = "Acceso a la propiedad %s",
     accessToolPrivilege = "Acceso a la herramienta %s",
     defaultGameDescription = "A Lilia Gamemode",
+
+    changeWeaponPopup = "Cambiar arma (Popup)",
+    changeWeaponOf = "Cambiar el arma de %s",
+    npcWeaponWarning1 = "¡ADVERTENCIA! No todos los NPC pueden usar armas y no todas las armas son utilizables por NPCs.",
+    npcWeaponWarning2 = "Esto depende totalmente del addon del que provienen el arma y el NPC. Este mod no puede cambiar eso.",
 }


### PR DESCRIPTION
## Summary
- Localize NPC weapon change menu and warning messages
- Add translation keys for NPC weapon strings across all languages

## Testing
- `luacheck gamemode/core/libraries/thirdparty/sh_extensions.lua gamemode/languages/english.lua gamemode/languages/french.lua gamemode/languages/italian.lua gamemode/languages/portuguese.lua gamemode/languages/russian.lua gamemode/languages/spanish.lua` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688d8e123db483279af4730cdbc2b471