### PR TITLE
Fix roster search filtering hiding player entries

### DIFF
--- a/gamemode/modules/teams/netcalls/client.lua
+++ b/gamemode/modules/teams/netcalls/client.lua
@@ -21,6 +21,7 @@ net.Receive("CharacterInfo", function()
 
     if IsValid(lia.gui.rosterSheet) then
         local sheet = lia.gui.rosterSheet
+        sheet.search:SetValue("")
         sheet:Clear()
         local rows = {}
         local originals = {}


### PR DESCRIPTION
## Summary
- Clear roster search box before repopulating to ensure players aren't hidden

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688da3f326948327929e284e56dc349c