### PR TITLE
Ensure superadmins have universal permissions

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -41,6 +41,7 @@ function lia.administrator.hasAccess(ply, privilege, target)
         end
     end
 
+    if tostring(grp):lower() == "superadmin" then return true end
     local g = lia.administrator.groups and lia.administrator.groups[grp] or nil
     if g and g[privilege] == true then return true end
     local min = lia.administrator.privileges and lia.administrator.privileges[privilege] or "user"


### PR DESCRIPTION
## Summary
- Guarantee that players in the `superadmin` group always pass privilege checks

## Testing
- `luacheck gamemode/core/libraries/admin.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 - forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688da48db1288327b057925f0a2096aa