### PR TITLE
feat: add admin logging function

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -142,7 +142,7 @@ function lia.administrator.load()
 
     local function continueLoad(groups)
         lia.administrator.groups = groups or {}
-        lia.bootstrap(L("administration"), L("adminSystemLoaded"))
+        lia.admin(L("adminSystemLoaded"))
         hook.Run("OnAdminSystemLoaded", lia.administrator.groups or {}, lia.administrator.privileges or {})
     end
 

--- a/gamemode/core/libraries/compatibility/ulx.lua
+++ b/gamemode/core/libraries/compatibility/ulx.lua
@@ -1,4 +1,4 @@
 
 timer.Create("LiliaULXWarning", 10, 0, function()
-    MsgC(Color(255, 0, 0), "[ULX WARNING] " .. L("ulxBreakWarning") .. "\n")
+    lia.admin(L("ulxBreakWarning"))
 end)

--- a/gamemode/core/libraries/loader.lua
+++ b/gamemode/core/libraries/loader.lua
@@ -370,6 +370,11 @@ function lia.information(msg)
     MsgC(Color(83, 143, 239), tostring(msg), "\n")
 end
 
+function lia.admin(msg)
+    MsgC(Color(83, 143, 239), "[Lilia] ", "[Admin] ")
+    MsgC(Color(255, 153, 0), tostring(msg), "\n")
+end
+
 function lia.bootstrap(section, msg)
     MsgC(Color(83, 143, 239), "[Lilia] ", "[Bootstrap] ")
     MsgC(Color(0, 255, 0), "[" .. section .. "] ")

--- a/gamemode/modules/administration/libraries/shared.lua
+++ b/gamemode/modules/administration/libraries/shared.lua
@@ -67,7 +67,7 @@ properties.Add("copytoclipboard", {
         self:MsgStart()
         local s = ent:GetModel()
         SetClipboardText(s)
-        print(s)
+        lia.admin(s)
         self:MsgEnd()
     end,
     Receive = function() end

--- a/gamemode/modules/administration/submodules/permissions/commands.lua
+++ b/gamemode/modules/administration/submodules/permissions/commands.lua
@@ -1545,13 +1545,13 @@ lia.command.add("getallinfos", {
             return
         end
 
-        print(L("allInfoFor", char:getName()))
+        lia.admin(L("allInfoFor", char:getName()))
         for column, value in pairs(data) do
             if istable(value) then
-                print(column .. ":")
+                lia.admin(column .. ":")
                 PrintTable(value)
             else
-                print(column .. " = " .. tostring(value))
+                lia.admin(column .. " = " .. tostring(value))
             end
         end
 

--- a/gamemode/modules/administration/submodules/tickets/netcalls/client.lua
+++ b/gamemode/modules/administration/submodules/tickets/netcalls/client.lua
@@ -4,10 +4,10 @@ net.Receive("ViewClaims", function()
     local steamid = net.ReadString()
     if steamid and steamid ~= "" and steamid ~= " " then
         local v = tbl[steamid]
-        print(L("claimRecordLast", v.name, v.claims, string.NiceTime(os.time() - v.lastclaim)))
+        lia.admin(L("claimRecordLast", v.name, v.claims, string.NiceTime(os.time() - v.lastclaim)))
     else
         for _, v in pairs(tbl) do
-            print(L("claimRecord", v.name, v.claims))
+            lia.admin(L("claimRecord", v.name, v.claims))
         end
     end
 end)

--- a/gamemode/modules/protection/netcalls/server.lua
+++ b/gamemode/modules/protection/netcalls/server.lua
@@ -538,15 +538,15 @@ function MODULE:InitializedModules()
 
     for netName in pairs(MaliciousNet) do
         if util.NetworkStringToID(netName) ~= 0 then
-            print(L("backdoorDetectedConsole", netName))
+            lia.admin(L("backdoorDetectedConsole", netName))
             if isfunction(net.Receivers[netName]) then
                 local backdoorInfos = debug.getinfo(net.Receivers[netName], "S")
-                print(L("backdoorDeclaredIn", netName, backdoorInfos.short_src, backdoorInfos.linedefined))
+                lia.admin(L("backdoorDeclaredIn", netName, backdoorInfos.short_src, backdoorInfos.linedefined))
                 lia.log.add(nil, "backdoorDetected", netName, backdoorInfos.short_src, backdoorInfos.linedefined)
             else
                 lia.log.add(nil, "backdoorDetected", netName)
             end
-
+            
             net.Receive(netName, function(_, client)
                 lia.log.add(client, "exploitAttempt", client:Name(), client:SteamID64(), tostring(netName))
                 for _, p in player.Iterator() do


### PR DESCRIPTION
## Summary
- add `lia.admin` helper for admin-related console messages
- replace ad-hoc admin logs with `lia.admin`
- convert remaining admin console prints to `lia.admin` across ticket claims, permission audits, clipboard actions, and protection warnings

## Testing
- `luacheck gamemode/modules/administration/libraries/shared.lua gamemode/modules/administration/submodules/permissions/commands.lua gamemode/modules/administration/submodules/tickets/netcalls/client.lua gamemode/modules/protection/netcalls/server.lua gamemode/core/libraries/admin.lua gamemode/core/libraries/compatibility/ulx.lua gamemode/core/libraries/loader.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y luacheck` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688da83af5d08327a63e7e8a7e86eda2