### PR TITLE
feat: expand warning records

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -392,10 +392,12 @@ CREATE TABLE IF NOT EXISTS lia_ticketclaims (
 CREATE TABLE IF NOT EXISTS lia_warnings (
     id integer primary key autoincrement,
     charID integer,
-    steamID text,
+    warned text,
+    warnedSteamID text,
     timestamp datetime,
-    reason text,
-    admin text
+    message text,
+    warner text,
+    warnerSteamID text
 );
 CREATE TABLE IF NOT EXISTS lia_doors (
     gamemode text,
@@ -528,10 +530,12 @@ CREATE TABLE IF NOT EXISTS `lia_ticketclaims` (
 CREATE TABLE IF NOT EXISTS `lia_warnings` (
     `id` int not null auto_increment,
     `charID` int default null,
-    `steamID` varchar(64) default null collate 'utf8mb4_general_ci',
+    `warned` text collate 'utf8mb4_general_ci',
+    `warnedSteamID` varchar(64) default null collate 'utf8mb4_general_ci',
     `timestamp` datetime not null,
-    `reason` text collate 'utf8mb4_general_ci',
-    `admin` text collate 'utf8mb4_general_ci',
+    `message` text collate 'utf8mb4_general_ci',
+    `warner` text collate 'utf8mb4_general_ci',
+    `warnerSteamID` varchar(64) default null collate 'utf8mb4_general_ci',
     primary key (`id`)
 );
 CREATE TABLE IF NOT EXISTS `lia_doors` (

--- a/gamemode/modules/administration/submodules/warns/commands.lua
+++ b/gamemode/modules/administration/submodules/warns/commands.lua
@@ -21,10 +21,11 @@ lia.command.add("warn", {
         end
 
         local timestamp = os.date("%Y-%m-%d %H:%M:%S")
-        local adminStr = client:Nick() .. " (" .. client:SteamID() .. ")"
-        MODULE:AddWarning(target:getChar():getID(), target:SteamID64(), timestamp, reason, adminStr)
+        local warnerName = client:Nick()
+        local warnerSteamID = client:SteamID()
+        MODULE:AddWarning(target:getChar():getID(), target:Nick(), target:SteamID64(), timestamp, reason, warnerName, warnerSteamID)
         lia.db.count("warnings", "charID = " .. lia.db.convertDataType(target:getChar():getID())):next(function(count)
-            target:notifyLocalized("playerWarned", adminStr, reason)
+            target:notifyLocalized("playerWarned", warnerName .. " (" .. warnerSteamID .. ")", reason)
             client:notifyLocalized("warningIssued", target:Nick())
             hook.Run("WarningIssued", client, target, reason, count)
         end)
@@ -60,8 +61,9 @@ lia.command.add("viewwarns", {
                 table.insert(warningList, {
                     index = index,
                     timestamp = warn.timestamp or L("na"),
-                    reason = warn.reason or L("na"),
-                    admin = warn.admin or L("na")
+                    warner = warn.warner or L("na"),
+                    warnerSteamID = warn.warnerSteamID or L("na"),
+                    warningMessage = warn.message or L("na")
                 })
             end
 
@@ -75,12 +77,16 @@ lia.command.add("viewwarns", {
                     field = "timestamp"
                 },
                 {
-                    name = L("reason"),
-                    field = "reason"
+                    name = L("Warner", "Warner"),
+                    field = "warner"
                 },
                 {
-                    name = L("admin"),
-                    field = "admin"
+                    name = L("Warner Steam ID", "Warner Steam ID"),
+                    field = "warnerSteamID"
+                },
+                {
+                    name = L("Warning Message", "Warning Message"),
+                    field = "warningMessage"
                 }
             }, warningList, {
                 {

--- a/gamemode/modules/administration/submodules/warns/module.lua
+++ b/gamemode/modules/administration/submodules/warns/module.lua
@@ -29,10 +29,19 @@ if CLIENT then
 
         addSizedColumn(L("timestamp"))
         addSizedColumn(L("Warned", "Warned"))
+        addSizedColumn(L("Warned Steam ID", "Warned Steam ID"))
         addSizedColumn(L("Warner", "Warner"))
-        addSizedColumn(L("reason"))
+        addSizedColumn(L("Warner Steam ID", "Warner Steam ID"))
+        addSizedColumn(L("Warning Message", "Warning Message"))
         for _, warn in ipairs(warnings) do
-            list:AddLine(warn.timestamp or "", warn.steamID or "", warn.admin or "", warn.reason or "")
+            list:AddLine(
+                warn.timestamp or "",
+                warn.warned or "",
+                warn.warnedSteamID or "",
+                warn.warner or "",
+                warn.warnerSteamID or "",
+                warn.message or ""
+            )
         end
     end)
 

--- a/gamemode/modules/protection/commands.lua
+++ b/gamemode/modules/protection/commands.lua
@@ -21,12 +21,11 @@
             client:notifyLocalized("cheaterMarked", target:Name())
             target:notifyLocalized("cheaterMarkedByAdmin")
             local timestamp = os.date("%Y-%m-%d %H:%M:%S")
-            local adminStr = client:Nick() .. " (" .. client:SteamID() .. ")"
             local warnsModule = lia.module.list["warns"]
             if warnsModule and warnsModule.AddWarning then
-                warnsModule:AddWarning(target:getChar():getID(), target:SteamID64(), timestamp, L("cheaterWarningReason"), adminStr)
+                warnsModule:AddWarning(target:getChar():getID(), target:Nick(), target:SteamID64(), timestamp, L("cheaterWarningReason"), client:Nick(), client:SteamID())
                 lia.db.count("warnings", "charID = " .. lia.db.convertDataType(target:getChar():getID())):next(function(count)
-                    target:notifyLocalized("playerWarned", adminStr, L("cheaterWarningReason"))
+                    target:notifyLocalized("playerWarned", client:Nick() .. " (" .. client:SteamID() .. ")", L("cheaterWarningReason"))
                     client:notifyLocalized("warningIssued", target:Nick())
                     hook.Run("WarningIssued", client, target, L("cheaterWarningReason"), count)
                 end)


### PR DESCRIPTION
## Summary
- track warned players and admins with names, Steam IDs, and message in `lia_warnings`
- update warning logic and UI to use the new detailed fields
- ensure cheater toggling issues warnings with expanded info

## Testing
- `luacheck gamemode/core/libraries/database.lua gamemode/modules/administration/submodules/warns/libraries/server.lua gamemode/modules/administration/submodules/warns/commands.lua gamemode/modules/administration/submodules/warns/module.lua gamemode/modules/protection/commands.lua` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository InRelease not signed; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688dac3068b083278f4bc6b5b22b3c04