### PR TITLE
Refactor lia_admin table to per-usergroup rows

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -435,9 +435,9 @@ CREATE TABLE IF NOT EXISTS lia_saveditems (
     _angles text
 );
 CREATE TABLE IF NOT EXISTS lia_admin (
-    usergroups text,
+    usergroup text PRIMARY KEY,
     privileges text,
-    inheritances text,
+    inheritance text,
     types text
 );
 CREATE TABLE IF NOT EXISTS lia_data (
@@ -585,10 +585,11 @@ CREATE TABLE IF NOT EXISTS `lia_saveditems` (
     primary key (`id`)
 );
 CREATE TABLE IF NOT EXISTS `lia_admin` (
-    `usergroups` text default null,
+    `usergroup` text not null,
     `privileges` text default null,
-    `inheritances` text default null,
-    `types` text default null
+    `inheritance` text default null,
+    `types` text default null,
+    PRIMARY KEY (`usergroup`)
 );
 ]])
         local index = 1


### PR DESCRIPTION
## Summary
- redefine `lia_admin` table with explicit `usergroup`, `privileges`, `inheritance`, and `types` columns
- load and save admin data per usergroup and rebuild privilege mappings
- add helper to derive privilege minima from group assignments

## Testing
- `luacheck gamemode/core/libraries/admin.lua gamemode/core/libraries/database.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688daeddb56c8327b0846e9906f4a82e