### PR TITLE
Fix privilege mapping for usergroups

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -35,8 +35,19 @@ local function rebuildPrivileges()
         for priv, allowed in pairs(perms) do
             if priv ~= "_info" and allowed == true then
                 local current = lia.administrator.privileges[priv]
-                if not current or getGroupLevel(groupName) < getGroupLevel(current) then
-                    lia.administrator.privileges[priv] = groupName
+                local groupLevel = getGroupLevel(groupName)
+                local currentLevel = current and getGroupLevel(current) or math.huge
+
+                -- Determine the base default group name for this group's level.
+                if not current or groupLevel < currentLevel then
+                    local base
+                    for name, lvl in pairs(lia.administrator.DefaultGroups or {}) do
+                        if lvl == groupLevel then
+                            base = name
+                            break
+                        end
+                    end
+                    lia.administrator.privileges[priv] = base or "user"
                 end
             end
         end


### PR DESCRIPTION
## Summary
- correct privilege rebuild logic to map privileges to base default groups

## Testing
- `luacheck gamemode/core/libraries/admin.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688dbf87bc888327ae4d1c76d15c7ffe