### PR TITLE
Expose admin privilege checks for CAMI

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -8,7 +8,8 @@ lia.administrator.DefaultGroups = {
 }
 
 lia.administrator._camiSource = "lia"
-local function getGroupLevel(group)
+
+function lia.administrator.getGroupLevel(group)
     local levels = lia.administrator.DefaultGroups or {}
     if levels[group] then return levels[group] end
     local visited, current = {}, group
@@ -23,11 +24,15 @@ local function getGroupLevel(group)
     return levels.user or 1
 end
 
-local function shouldGrant(group, min)
+local getGroupLevel = lia.administrator.getGroupLevel
+
+function lia.administrator.shouldGrant(group, min)
     local levels = lia.administrator.DefaultGroups or {}
     local m = tostring(min or "user"):lower()
     return getGroupLevel(group) >= (levels[m] or 1)
 end
+
+local shouldGrant = lia.administrator.shouldGrant
 
 local function rebuildPrivileges()
     lia.administrator.privileges = {}

--- a/gamemode/core/libraries/compatibility/cami.lua
+++ b/gamemode/core/libraries/compatibility/cami.lua
@@ -41,7 +41,9 @@ local function liaAdminBootstrapFromCAMI()
                 local min = tostring(pr.MinAccess or "user"):lower()
                 lia.administrator.privileges[pr.Name] = min
                 for groupName in pairs(lia.administrator.groups or {}) do
-                    if shouldGrant(groupName, min) then lia.administrator.groups[groupName][pr.Name] = true end
+                    if lia.administrator.shouldGrant and lia.administrator.shouldGrant(groupName, min) then
+                        lia.administrator.groups[groupName][pr.Name] = true
+                    end
                 end
             end
         end
@@ -69,7 +71,9 @@ hook.Add("CAMI.OnPrivilegeRegistered", "liaAdminOnPrivilegeRegistered", function
     for groupName, perms in pairs(lia.administrator.groups or {}) do
         perms = perms or {}
         lia.administrator.groups[groupName] = perms
-        if shouldGrant(groupName, min) then perms[name] = true end
+        if lia.administrator.shouldGrant and lia.administrator.shouldGrant(groupName, min) then
+            perms[name] = true
+        end
     end
 
     if SERVER then


### PR DESCRIPTION
## Summary
- expose `getGroupLevel` and `shouldGrant` as admin library functions
- ensure CAMI compatibility uses the shared `shouldGrant` check when syncing privileges

## Testing
- `luac -p gamemode/core/libraries/admin.lua gamemode/core/libraries/compatibility/cami.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_688dcd84906883279d42a3d35bd83df9