### PR TITLE
localize keybind labels

### DIFF
--- a/gamemode/core/derma/f1menu/cl_menu.lua
+++ b/gamemode/core/derma/f1menu/cl_menu.lua
@@ -9,7 +9,7 @@ function PANEL:Init()
     self:SetPopupStayAtBack(true)
     self.noAnchor = CurTime() + 0.4
     self.anchorMode = true
-    self.invKey = lia.keybind.get("Open Inventory", KEY_I)
+    self.invKey = lia.keybind.get(L("Open Inventory"), KEY_I)
     local baseBtnW, btnH, spacing = 150, 40, 20
     self.baseBtnW = baseBtnW
     local topBar = self:Add("DPanel")

--- a/gamemode/core/libraries/keybind.lua
+++ b/gamemode/core/libraries/keybind.lua
@@ -325,9 +325,9 @@ hook.Add("PopulateConfigurationButtons", "PopulateKeybinds", function(pages)
     }
 end)
 
-lia.keybind.add(KEY_NONE, "Open Inventory", function()
+lia.keybind.add(KEY_NONE, L("Open Inventory"), function()
     local f1Menu = vgui.Create("liaMenu")
     f1Menu:setActiveTab(L("inv"))
 end)
 
-lia.keybind.add(KEY_NONE, "Admin Mode", function() lia.command.send("adminmode") end)
+lia.keybind.add(KEY_NONE, L("Admin Mode"), function() lia.command.send("adminmode") end)

--- a/gamemode/modules/interactionmenu/libraries/client.lua
+++ b/gamemode/modules/interactionmenu/libraries/client.lua
@@ -126,7 +126,7 @@ local function openMenu(options, isInteraction, titleText, closeKey, netMsg)
     MODULE.Menu = frame
 end
 
-lia.keybind.add(KEY_TAB, "Interaction Menu", function()
+lia.keybind.add(KEY_TAB, L("Interaction Menu"), function()
     local client = LocalPlayer()
     if not client:getChar() or not MODULE:checkInteractionPossibilities() then return end
     if IsValid(MODULE.Menu) then
@@ -134,14 +134,14 @@ lia.keybind.add(KEY_TAB, "Interaction Menu", function()
         MODULE.Menu = nil
     end
 
-    openMenu(MODULE.Interactions, true, L("playerInteractions"), lia.keybind.get("Interaction Menu", KEY_TAB), "RunOption")
+    openMenu(MODULE.Interactions, true, L("playerInteractions"), lia.keybind.get(L("Interaction Menu"), KEY_TAB), "RunOption")
 end)
 
-lia.keybind.add(KEY_G, "Personal Actions", function()
+lia.keybind.add(KEY_G, L("Personal Actions"), function()
     if IsValid(MODULE.Menu) then
         MODULE.Menu:Close()
         MODULE.Menu = nil
     end
 
-    openMenu(MODULE.Actions, false, L("actionsMenu"), lia.keybind.get("Personal Actions", KEY_G), "RunLocalOption")
+    openMenu(MODULE.Actions, false, L("actionsMenu"), lia.keybind.get(L("Personal Actions"), KEY_G), "RunLocalOption")
 end)


### PR DESCRIPTION
## Summary
- localize interaction and actions menu keybind labels
- localize default inventory and admin mode keybinds
- ensure f1 menu uses localized inventory keybind name

## Testing
- `luacheck gamemode/modules/interactionmenu/libraries/client.lua gamemode/core/libraries/keybind.lua gamemode/core/derma/f1menu/cl_menu.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688dd77e2c1083278d737bd6930a6790