### PR TITLE
feat: highlight unconfigured doors via ESP

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -1095,6 +1095,7 @@ LANGUAGE = {
     propModelESPLabel = "Prop Model: %s",
     entityClassESPLabel = "Entity Class: %s",
     entityCreatorESPLabel = "Creator: %s",
+    unconfiguredDoorESPLabel = "Unconfigured Door",
     nicknameLabel = "Nickname: %s",
     steamNameLabel = "Steam Name: %s",
     steamIDLabel = "Steam ID: %s",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -1095,6 +1095,7 @@ LANGUAGE = {
     propModelESPLabel = "Modèle prop : %s",
     entityClassESPLabel = "Classe entité : %s",
     entityCreatorESPLabel = "Créateur : %s",
+    unconfiguredDoorESPLabel = "Porte non configurée",
     nicknameLabel = "Pseudo : %s",
     steamNameLabel = "Nom Steam : %s",
     steamIDLabel = "SteamID : %s",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -1095,6 +1095,7 @@ LANGUAGE = {
     propModelESPLabel = "Modello Prop: %s",
     entityClassESPLabel = "Classe Entità: %s",
     entityCreatorESPLabel = "Creatore: %s",
+    unconfiguredDoorESPLabel = "Porta non configurata",
     nicknameLabel = "Nickname: %s",
     steamNameLabel = "Nome Steam: %s",
     steamIDLabel = "Steam ID: %s",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -1095,6 +1095,7 @@ LANGUAGE = {
     propModelESPLabel = "Modelo: %s",
     entityClassESPLabel = "Classe: %s",
     entityCreatorESPLabel = "Criador: %s",
+    unconfiguredDoorESPLabel = "Porta não configurada",
     nicknameLabel = "Alcunha: %s",
     steamNameLabel = "Nome Steam: %s",
     steamIDLabel = "Steam ID: %s",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -1095,6 +1095,7 @@ LANGUAGE = {
     propModelESPLabel = "Модель пропа: %s",
     entityClassESPLabel = "Класс: %s",
     entityCreatorESPLabel = "Создатель: %s",
+    unconfiguredDoorESPLabel = "Не настроенная дверь",
     nicknameLabel = "Ник: %s",
     steamNameLabel = "Steam‑имя: %s",
     steamIDLabel = "SteamID: %s",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -1095,6 +1095,7 @@ LANGUAGE = {
     propModelESPLabel = "Modelo: %s",
     entityClassESPLabel = "Clase: %s",
     entityCreatorESPLabel = "Creador: %s",
+    unconfiguredDoorESPLabel = "Puerta no configurada",
     nicknameLabel = "Nick: %s",
     steamNameLabel = "Steam: %s",
     steamIDLabel = "Steam ID: %s",

--- a/gamemode/modules/administration/submodules/permissions/config.lua
+++ b/gamemode/modules/administration/submodules/permissions/config.lua
@@ -54,6 +54,16 @@ lia.option.add("espEntities", "ESP Entities", "Enable ESP for entities", false, 
     end
 })
 
+lia.option.add("espUnconfiguredDoors", "ESP Unconfigured Doors", "Enable ESP for doors without configuration", false, nil, {
+    category = "ESP",
+    isQuick = true,
+    visible = function()
+        local ply = LocalPlayer()
+        if not IsValid(ply) then return false end
+        return ply:isStaffOnDuty() or ply:hasPrivilege("No Clip Outside Staff Character")
+    end
+})
+
 lia.option.add("espItemsColor", "ESP Items Color", "Sets the ESP color for items", {
     r = 0,
     g = 255,
@@ -86,6 +96,20 @@ lia.option.add("espPropsColor", "ESP Props Color", "Sets the ESP color for props
     r = 255,
     g = 0,
     b = 0,
+    a = 255
+}, nil, {
+    category = "ESP",
+    visible = function()
+        local ply = LocalPlayer()
+        if not IsValid(ply) then return false end
+        return ply:isStaffOnDuty() or ply:hasPrivilege("No Clip Outside Staff Character")
+    end
+})
+
+lia.option.add("espUnconfiguredDoorsColor", "ESP Unconfigured Doors Color", "Sets the ESP color for unconfigured doors", {
+    r = 255,
+    g = 0,
+    b = 255,
     a = 255
 }, nil, {
     category = "ESP",

--- a/gamemode/modules/administration/submodules/permissions/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/client.lua
@@ -34,6 +34,12 @@ function MODULE:HUDPaint()
         elseif ent.isProp and ent:isProp() and lia.option.get("espProps") then
             entityType = "Props"
             label = L("propModelESPLabel", ent:GetModel() or L("unknown"))
+        elseif ent:isDoor() and lia.option.get("espUnconfiguredDoors") then
+            local hasVar = ent:getNetVar("name") ~= nil or ent:getNetVar("title") ~= nil or ent:getNetVar("price") ~= nil or ent:getNetVar("noSell") ~= nil or ent:getNetVar("factions") ~= nil or ent:getNetVar("classes") ~= nil or ent:getNetVar("disabled") ~= nil or ent:getNetVar("hidden") ~= nil or ent:getNetVar("locked") ~= nil
+            if not hasVar then
+                entityType = "UnconfiguredDoors"
+                label = L("unconfiguredDoorESPLabel")
+            end
         elseif ESP_DrawnEntities[ent:GetClass()] and lia.option.get("espEntities") then
             entityType = "Entities"
             label = L("entityClassESPLabel", ent:GetClass() or L("unknown"))


### PR DESCRIPTION
## Summary
- show ESP markers on doors missing door system variables
- add config options and language entries for the unconfigured door ESP

## Testing
- `luacheck gamemode/languages/english.lua gamemode/languages/french.lua gamemode/languages/italian.lua gamemode/languages/portuguese.lua gamemode/languages/russian.lua gamemode/languages/spanish.lua gamemode/modules/administration/submodules/permissions/config.lua gamemode/modules/administration/submodules/permissions/libraries/client.lua` *(fails: expected '=' near 'end')*


------
https://chatgpt.com/codex/tasks/task_e_688e4160e2888327943fbca79ba5bd91