### PR TITLE
localize notifications

### DIFF
--- a/gamemode/core/libraries/darkrp.lua
+++ b/gamemode/core/libraries/darkrp.lua
@@ -37,7 +37,7 @@ if SERVER then
     end
 
     function lia.darkrp.notify(client, _, _, message)
-        client:notify(message)
+        client:notifyLocalized(message)
     end
 else
     local function wrapCharacters(text, remainingWidth, maxWidth)

--- a/gamemode/modules/chatbox/commands.lua
+++ b/gamemode/modules/chatbox/commands.lua
@@ -55,7 +55,7 @@ lia.command.add("blockooc", {
     onRun = function(client)
         local blocked = GetGlobalBool("oocblocked", false)
         SetGlobalBool("oocblocked", not blocked)
-        client:notify(blocked and L("unlockedOOC") or L("blockedOOC"))
+        client:notifyLocalized(blocked and "unlockedOOC" or "blockedOOC")
         lia.log.add(client, "blockOOC", not blocked)
     end
 })

--- a/gamemode/modules/doors/commands.lua
+++ b/gamemode/modules/doors/commands.lua
@@ -152,7 +152,7 @@ lia.command.add("doortoggleownable", {
             door:setNetVar("noSell", newState and true or nil)
             lia.log.add(client, "doorToggleOwnable", door, newState)
             hook.Run("DoorOwnableToggled", client, door, newState)
-            client:notify(newState and L("doorMadeUnownable") or L("doorMadeOwnable"))
+            client:notifyLocalized(newState and "doorMadeUnownable" or "doorMadeOwnable")
             MODULE:SaveData()
         else
             client:notifyLocalized("doorNotValid")
@@ -204,7 +204,7 @@ lia.command.add("doortoggleenabled", {
             door:setNetVar("disabled", newState and true or nil)
             lia.log.add(client, newState and "doorDisable" or "doorEnable", door)
             hook.Run("DoorEnabledToggled", client, door, newState)
-            client:notify(newState and L("doorSetDisabled") or L("doorSetNotDisabled"))
+            client:notifyLocalized(newState and "doorSetDisabled" or "doorSetNotDisabled")
             MODULE:SaveData()
         else
             client:notifyLocalized("doorNotValid")
@@ -228,7 +228,7 @@ lia.command.add("doortogglehidden", {
             entity:setNetVar("hidden", newState)
             lia.log.add(client, "doorSetHidden", entity, newState)
             hook.Run("DoorHiddenToggled", client, entity, newState)
-            client:notify(newState and L("doorSetHidden") or L("doorSetNotHidden"))
+            client:notifyLocalized(newState and "doorSetHidden" or "doorSetNotHidden")
             MODULE:SaveData()
         else
             client:notifyLocalized("doorNotValid")

--- a/gamemode/modules/inventory/libraries/server.lua
+++ b/gamemode/modules/inventory/libraries/server.lua
@@ -73,7 +73,7 @@ function MODULE:HandleItemTransferRequest(client, itemID, x, y, invID)
     if not oldInventory or not oldInventory.items[itemID] then return end
     local transferAllowed, transferReason = hook.Run("CanItemBeTransfered", item, oldInventory, newInventory, client)
     if transferAllowed == false then
-        client:notify(transferReason or L("notNow"))
+        client:notifyLocalized(transferReason or "notNow")
         return
     end
 

--- a/gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/init.lua
+++ b/gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/init.lua
@@ -13,7 +13,7 @@ end
 function ENT:Use(activator)
     if not hook.Run("CanPlayerAccessVendor", activator, self) then
         if self.messages[VENDOR_NOTRADE] then
-            activator:notify(L("vendorMessageFormat", self:getNetVar("name"), L(self.messages[VENDOR_NOTRADE], activator)))
+            activator:notifyLocalized("vendorMessageFormat", self:getNetVar("name"), L(self.messages[VENDOR_NOTRADE], activator))
         end
         return
     end
@@ -22,7 +22,7 @@ function ENT:Use(activator)
     self.receivers[#self.receivers + 1] = activator
     activator.liaVendor = self
     if self:getNetVar("welcomeMessage") then
-        activator:notify(L("vendorMessageFormat", self:getNetVar("name"), self:getNetVar("welcomeMessage")))
+        activator:notifyLocalized("vendorMessageFormat", self:getNetVar("name"), self:getNetVar("welcomeMessage"))
     end
     hook.Run("PlayerAccessVendor", activator, self)
 end


### PR DESCRIPTION
## Summary
- use localization keys for door, chat, inventory, vendor, and DarkRP notifications

## Testing
- `luacheck gamemode/modules/doors/commands.lua gamemode/modules/chatbox/commands.lua gamemode/modules/inventory/libraries/server.lua gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/init.lua gamemode/core/libraries/darkrp.lua`

------
https://chatgpt.com/codex/tasks/task_e_688e411f2d208327b01c9372df3ec5f2