### PR TITLE
feat: add getPlayTime hook for SAM compatibility

### DIFF
--- a/gamemode/core/libraries/compatibility/sam.lua
+++ b/gamemode/core/libraries/compatibility/sam.lua
@@ -182,17 +182,16 @@ lia.command.add("playtime", {
     privilege = "View Own Playtime",
     desc = "playtimeDesc",
     onRun = function(client)
-        local steamID = client:SteamID64()
-        local result = sql.QueryRow("SELECT play_time FROM sam_players WHERE steamid = " .. SQLStr(steamID) .. ";")
-        if result then
-            local secs = tonumber(result.play_time) or 0
-            local h = math.floor(secs / 3600)
-            local m = math.floor((secs % 3600) / 60)
-            local s = secs % 60
-            client:ChatPrint(L("playtimeYour", h, m, s))
-        else
+        local secs = client:getPlayTime()
+        if not secs then
             client:ChatPrint(L("playtimeError"))
+            return
         end
+
+        local h = math.floor(secs / 3600)
+        local m = math.floor((secs % 3600) / 60)
+        local s = secs % 60
+        client:ChatPrint(L("playtimeYour", h, m, s))
     end
 })
 
@@ -219,13 +218,19 @@ lia.command.add("plygetplaytime", {
             return
         end
 
-        local secs = target:sam_get_play_time()
+        local secs = target:getPlayTime()
         local h = math.floor(secs / 3600)
         local m = math.floor((secs % 3600) / 60)
         local s = secs % 60
         client:ChatPrint(L("playtimeFor", target:Nick(), h, m, s))
     end
 })
+
+hook.Add("getPlayTime", "liaSAM", function(client)
+    if client.sam_get_play_time then
+        return client:sam_get_play_time()
+    end
+end)
 
 lia.administrator.registerPrivilege({
     Name = "Can See SAM Notifications Outside Staff Character",

--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -725,6 +725,8 @@ if SERVER then
     end
 
     function playerMeta:getPlayTime()
+        local hookResult = hook.Run("getPlayTime", self)
+        if hookResult ~= nil then return hookResult end
         local diff = os.time(lia.time.toNumber(self.lastJoin)) - os.time(lia.time.toNumber(self.firstJoin))
         return diff + RealTime() - (self.liaJoinTime or RealTime())
     end
@@ -926,6 +928,8 @@ else
     end
 
     function playerMeta:getPlayTime()
+        local hookResult = hook.Run("getPlayTime", self)
+        if hookResult ~= nil then return hookResult end
         local diff = os.time(lia.time.toNumber(lia.lastJoin)) - os.time(lia.time.toNumber(lia.firstJoin))
         return diff + RealTime() - (lia.joinTime or 0)
     end


### PR DESCRIPTION
## Summary
- expose `getPlayTime` hook so playtime can be sourced from SAM or Lilia
- update SAM commands to use `player:getPlayTime`

## Testing
- `luacheck gamemode/core/meta/player.lua gamemode/core/libraries/compatibility/sam.lua` *(fails: expected '=' near 'end')*


------
https://chatgpt.com/codex/tasks/task_e_688e43beffd083278e3411f678b67aea