### PR TITLE
feat: add punch playtime protection

### DIFF
--- a/gamemode/modules/attributes/config.lua
+++ b/gamemode/modules/attributes/config.lua
@@ -83,3 +83,12 @@ lia.config.add("AllowPush", "Allow Push", true, nil, {
     category = "General",
     type = "Boolean"
 })
+
+lia.config.add("PunchPlaytime", "Punch Playtime Protection", 7200, nil, {
+    desc = "Minimum playtime in seconds required to punch.",
+    category = "General",
+    isGlobal = true,
+    type = "Int",
+    min = 0,
+    max = 86400
+})

--- a/gamemode/modules/attributes/libraries/shared.lua
+++ b/gamemode/modules/attributes/libraries/shared.lua
@@ -49,3 +49,10 @@ end
 function MODULE:GetMaxStartingAttributePoints()
     return lia.config.get("StartingAttributePoints")
 end
+
+function MODULE:CanPlayerThrowPunch(client)
+    local required = lia.config.get("PunchPlaytime", 7200)
+    if required <= 0 then return end
+    if not IsValid(client) or client:GetUserGroup() ~= "user" then return end
+    if client:getPlayTime() < required then return false end
+end


### PR DESCRIPTION
## Summary
- add PunchPlaytime config to restrict punching until players reach configured playtime (default 7200 seconds)
- prevent base users from punching until playtime requirement met

## Testing
- `luacheck gamemode/modules/attributes/config.lua gamemode/modules/attributes/libraries/shared.lua`


------
https://chatgpt.com/codex/tasks/task_e_688e4b82f5f08327919a5e862393e089