### PR TITLE
feat: add playtime comparison helper

### DIFF
--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -1051,3 +1051,9 @@ else
         end
     end
 end
+
+function playerMeta:playTimeGreaterThan(time)
+    local playTime = self:getPlayTime()
+    if not playTime or not time then return false end
+    return playTime > time
+end

--- a/gamemode/modules/attributes/libraries/shared.lua
+++ b/gamemode/modules/attributes/libraries/shared.lua
@@ -54,5 +54,5 @@ function MODULE:CanPlayerThrowPunch(client)
     local required = lia.config.get("PunchPlaytime", 7200)
     if required <= 0 then return end
     if not IsValid(client) or client:GetUserGroup() ~= "user" then return end
-    if client:getPlayTime() < required then return false end
+    if not client:playTimeGreaterThan(required) then return false end
 end


### PR DESCRIPTION
## Summary
- add a utility meta method to compare a player's playtime against a threshold
- use the helper to enforce playtime requirement for punching

## Testing
- `luacheck gamemode/core/meta/player.lua gamemode/modules/attributes/libraries/shared.lua` *(fails: gamemode/core/meta/player.lua:74:58: expected '=' near 'end'; 38 warnings in shared.lua)*

------
https://chatgpt.com/codex/tasks/task_e_688e4eb77bb08327ad40fe2e7a3c1b68