### PR TITLE
feat: warn missing command arguments

### DIFF
--- a/gamemode/core/libraries/commands.lua
+++ b/gamemode/core/libraries/commands.lua
@@ -217,25 +217,27 @@ if SERVER then
             if command then
                 if not arguments then arguments = lia.command.extractArgs(text:sub(#match + 3)) end
                 local fields, valid = lia.command.parseSyntaxFields(command.syntax)
-                if IsValid(client) and client:IsPlayer() and valid and #fields > 0 then
+                if valid and #fields > 0 then
                     local tokens = combineBracketArgs(arguments)
                     local missing = {}
-                    local prefix = {}
                     for i, field in ipairs(fields) do
                         local arg = tokens[i]
                         if not arg or isPlaceholder(arg) then
-                            if not field.optional then missing[field.name] = field.type end
-                        else
-                            prefix[#prefix + 1] = arg
+                            if not field.optional then missing[#missing + 1] = field.name end
                         end
                     end
 
-                    if table.Count(missing) > 0 then
-                        net.Start("liaCmdArgPrompt")
-                        net.WriteString(match)
-                        net.WriteTable(missing)
-                        net.WriteTable(prefix)
-                        net.Send(client)
+                    if #missing > 0 then
+                        local msg = "Missing argument(s): " .. table.concat(missing, ", ")
+                        if command.syntax and command.syntax ~= "" then
+                            msg = msg .. " | Syntax: " .. command.syntax
+                        end
+
+                        if IsValid(client) then
+                            client:notify(msg)
+                        else
+                            print(msg)
+                        end
                         return true
                     end
                 end


### PR DESCRIPTION
## Summary
- notify players of missing command arguments using `client:notify`
- display expected syntax alongside missing argument warnings

## Testing
- `luacheck gamemode/core/libraries/commands.lua` *(fails: expected '=' near 'end')*

------
https://chatgpt.com/codex/tasks/task_e_688e5cc4c0a08327950c3f473d1f0a33