### PR TITLE
refactor: move bans to dedicated table

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -271,6 +271,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS `lia_persistence`;
     DROP TABLE IF EXISTS `lia_warnings`;
     DROP TABLE IF EXISTS `lia_playerkills`;
+    DROP TABLE IF EXISTS `lia_bans`;
     DROP TABLE IF EXISTS `lia_chardata`;
     DROP TABLE IF EXISTS `lia_data`;
 ]])
@@ -305,6 +306,7 @@ function lia.db.wipeTables(callback)
     DROP TABLE IF EXISTS lia_persistence;
     DROP TABLE IF EXISTS lia_warnings;
     DROP TABLE IF EXISTS lia_playerkills;
+    DROP TABLE IF EXISTS lia_bans;
     DROP TABLE IF EXISTS lia_chardata;
     DROP TABLE IF EXISTS lia_data;
 ]], realCallback)
@@ -329,10 +331,7 @@ CREATE TABLE IF NOT EXISTS lia_players (
     data varchar,
     lastIP varchar,
     lastOnline integer,
-    totalOnlineTime float,
-    banStart integer,
-    banDuration integer,
-    banReason text
+    totalOnlineTime float
 );
 CREATE TABLE IF NOT EXISTS lia_chardata (
     charID integer not null,
@@ -419,6 +418,16 @@ CREATE TABLE IF NOT EXISTS lia_playerkills (
     timestamp integer,
     evidence varchar(255)
 );
+CREATE TABLE IF NOT EXISTS lia_bans (
+    id integer primary key autoincrement,
+    player varchar(255) NOT NULL,
+    playerSteamID varchar(255),
+    reason varchar(255),
+    bannerName varchar(255),
+    bannerSteamID varchar(255),
+    timestamp integer,
+    evidence varchar(255)
+);
 CREATE TABLE IF NOT EXISTS lia_doors (
     gamemode text,
     map text,
@@ -476,9 +485,6 @@ CREATE TABLE IF NOT EXISTS `lia_players` (
     `lastIP` varchar(64) default null collate 'utf8mb4_general_ci',
     `lastOnline` int(32) default 0,
     `totalOnlineTime` float default 0,
-    `banStart` int(32) default null,
-    `banDuration` int(32) default 0,
-    `banReason` text collate 'utf8mb4_general_ci',
     primary key (`steamID`)
 );
 CREATE TABLE IF NOT EXISTS `lia_chardata` (
@@ -568,6 +574,17 @@ CREATE TABLE IF NOT EXISTS `lia_playerkills` (
     `steamID` varchar(255) default null collate 'utf8mb4_general_ci',
     `submitterName` varchar(255) default null collate 'utf8mb4_general_ci',
     `submitterSteamID` varchar(255) default null collate 'utf8mb4_general_ci',
+    `timestamp` int default null,
+    `evidence` varchar(255) default null collate 'utf8mb4_general_ci',
+    primary key (`id`)
+);
+CREATE TABLE IF NOT EXISTS `lia_bans` (
+    `id` int not null auto_increment,
+    `player` varchar(255) not null collate 'utf8mb4_general_ci',
+    `playerSteamID` varchar(255) default null collate 'utf8mb4_general_ci',
+    `reason` varchar(255) default null collate 'utf8mb4_general_ci',
+    `bannerName` varchar(255) default null collate 'utf8mb4_general_ci',
+    `bannerSteamID` varchar(255) default null collate 'utf8mb4_general_ci',
     `timestamp` int default null,
     `evidence` varchar(255) default null collate 'utf8mb4_general_ci',
     primary key (`id`)

--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -574,14 +574,17 @@ if SERVER then
         net.Broadcast()
     end
 
-    function playerMeta:banPlayer(reason, duration)
+    function playerMeta:banPlayer(reason, duration, banner)
         local steam64 = self:SteamID64()
-        local banStart = os.time()
-        lia.db.updateTable({
-            banStart = banStart,
-            banDuration = (duration or 0) * 60,
-            banReason = reason or L("genericReason")
-        }, nil, "players", "steamID = " .. steam64)
+        lia.db.insertTable({
+            player = self:Name(),
+            playerSteamID = steam64,
+            reason = reason or L("genericReason"),
+            bannerName = IsValid(banner) and banner:Name() or "",
+            bannerSteamID = IsValid(banner) and banner:SteamID64() or "",
+            timestamp = os.time(),
+            evidence = ""
+        }, nil, "bans")
 
         self:Kick(L("banMessage", self, duration or 0, reason or L("genericReason", self)))
     end

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -163,7 +163,7 @@ lia.command.add("plyban", {
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
-            target:banPlayer(arguments[3], arguments[2])
+            target:banPlayer(arguments[3], arguments[2], client)
             client:notifyLocalized("plyBanned")
             lia.log.add(client, "plyBan", target:Name())
         end
@@ -208,11 +208,7 @@ lia.command.add("plyunban", {
     onRun = function(client, arguments)
         local steamid = arguments[1]
         if steamid and steamid ~= "" then
-            lia.db.updateTable({
-                banStart = nil,
-                banDuration = 0,
-                banReason = ""
-            }, nil, "players", "steamID = " .. steamid)
+            lia.db.query("DELETE FROM lia_bans WHERE playerSteamID = " .. steamid)
 
             client:notifyLocalized("playerUnbanned")
             lia.log.add(client, "plyUnban", steamid)


### PR DESCRIPTION
## Summary
- move ban storage from `lia_players` to new `lia_bans` table
- update ban/unban logic to use `lia_bans`
- adjust protection checks to consult new ban records

## Testing
- `luacheck gamemode/core/libraries/database.lua gamemode/core/hooks/server.lua gamemode/modules/administration/commands.lua gamemode/core/meta/player.lua gamemode/modules/protection/libraries/server.lua` (fails: 675 warnings / 2 errors)

------
https://chatgpt.com/codex/tasks/task_e_688e601830648327bf8212d828b15038