### PR TITLE
Log staff administration commands

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -428,6 +428,16 @@ CREATE TABLE IF NOT EXISTS lia_bans (
     timestamp integer,
     evidence varchar(255)
 );
+CREATE TABLE IF NOT EXISTS lia_staffactions (
+    id integer primary key autoincrement,
+    player varchar(255) NOT NULL,
+    playerSteamID varchar(255),
+    steamID varchar(255),
+    action varchar(255),
+    staffName varchar(255),
+    staffSteamID varchar(255),
+    timestamp integer
+);
 CREATE TABLE IF NOT EXISTS lia_doors (
     gamemode text,
     map text,
@@ -587,6 +597,17 @@ CREATE TABLE IF NOT EXISTS `lia_bans` (
     `bannerSteamID` varchar(255) default null collate 'utf8mb4_general_ci',
     `timestamp` int default null,
     `evidence` varchar(255) default null collate 'utf8mb4_general_ci',
+    primary key (`id`)
+);
+CREATE TABLE IF NOT EXISTS `lia_staffactions` (
+    `id` int not null auto_increment,
+    `player` varchar(255) not null collate 'utf8mb4_general_ci',
+    `playerSteamID` varchar(255) default null collate 'utf8mb4_general_ci',
+    `steamID` varchar(255) default null collate 'utf8mb4_general_ci',
+    `action` varchar(255) default null collate 'utf8mb4_general_ci',
+    `staffName` varchar(255) default null collate 'utf8mb4_general_ci',
+    `staffSteamID` varchar(255) default null collate 'utf8mb4_general_ci',
+    `timestamp` int default null,
     primary key (`id`)
 );
 CREATE TABLE IF NOT EXISTS `lia_doors` (

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -181,6 +181,15 @@ lia.command.add("plykick", {
             target:Kick(L("kickMessage", target, arguments[2] or L("genericReason")))
             client:notifyLocalized("plyKicked")
             lia.log.add(client, "plyKick", target:Name())
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plykick",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
         end
     end
 })
@@ -196,6 +205,15 @@ lia.command.add("plykill", {
             target:Kill()
             client:notifyLocalized("plyKilled")
             lia.log.add(client, "plyKill", target:Name())
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plykill",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
         end
     end
 })
@@ -212,6 +230,15 @@ lia.command.add("plyunban", {
 
             client:notifyLocalized("playerUnbanned")
             lia.log.add(client, "plyUnban", steamid)
+            lia.db.insertTable({
+                player = "",
+                playerSteamID = steamid,
+                steamID = steamid,
+                action = "plyunban",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
         end
     end
 })
@@ -228,6 +255,15 @@ lia.command.add("plyfreeze", {
             local dur = tonumber(arguments[2]) or 0
             if dur > 0 then timer.Simple(dur, function() if IsValid(target) then target:Freeze(false) end end) end
             lia.log.add(client, "plyFreeze", target:Name(), dur)
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plyfreeze",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
         end
     end
 })
@@ -242,6 +278,15 @@ lia.command.add("plyunfreeze", {
         if IsValid(target) then
             target:Freeze(false)
             lia.log.add(client, "plyUnfreeze", target:Name())
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plyunfreeze",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
         end
     end
 })
@@ -256,6 +301,15 @@ lia.command.add("plyslay", {
         if IsValid(target) then
             target:Kill()
             lia.log.add(client, "plySlay", target:Name())
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plyslay",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
         end
     end
 })
@@ -270,6 +324,15 @@ lia.command.add("plyrespawn", {
         if IsValid(target) then
             target:Spawn()
             lia.log.add(client, "plyRespawn", target:Name())
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plyrespawn",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
         end
     end
 })
@@ -297,6 +360,15 @@ lia.command.add("plyblind", {
             end
 
             lia.log.add(client, "plyBlind", target:Name(), dur or 0)
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plyblind",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
         end
     end
 })
@@ -313,6 +385,15 @@ lia.command.add("plyunblind", {
             net.WriteBool(false)
             net.Send(target)
             lia.log.add(client, "plyUnblind", target:Name())
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plyunblind",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
         end
     end
 })
@@ -338,6 +419,15 @@ lia.command.add("plyblindfade", {
             net.WriteFloat(fadeOut)
             net.Send(target)
             lia.log.add(client, "plyBlindFade", target:Name(), duration, colorName)
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plyblindfade",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
         end
     end
 })
@@ -347,7 +437,7 @@ lia.command.add("blindfadeall", {
     privilege = "Blind Fade All",
     desc = "blindFadeAllDesc",
     syntax = "[number Time optional] [string Color optional] [number FadeIn optional] [number FadeOut optional]",
-    onRun = function(_, arguments)
+    onRun = function(client, arguments)
         local duration = tonumber(arguments[1]) or 0
         local colorName = (arguments[2] or "black"):lower()
         local fadeIn = tonumber(arguments[3]) or duration * 0.05
@@ -363,6 +453,15 @@ lia.command.add("blindfadeall", {
                 net.Send(ply)
             end
         end
+        lia.db.insertTable({
+            player = "all",
+            playerSteamID = "",
+            steamID = "",
+            action = "blindfadeall",
+            staffName = client:Name(),
+            staffSteamID = client:SteamID64(),
+            timestamp = os.time()
+        }, nil, "staffactions")
     end
 })
 
@@ -376,6 +475,15 @@ lia.command.add("plygag", {
         if IsValid(target) then
             target:setNetVar("liaGagged", true)
             lia.log.add(client, "plyGag", target:Name())
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plygag",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
             hook.Run("PlayerGagged", target, client)
         end
     end
@@ -391,6 +499,15 @@ lia.command.add("plyungag", {
         if IsValid(target) then
             target:setNetVar("liaGagged", false)
             lia.log.add(client, "plyUngag", target:Name())
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plyungag",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
             hook.Run("PlayerUngagged", target, client)
         end
     end
@@ -406,6 +523,15 @@ lia.command.add("plymute", {
         if IsValid(target) and target:getChar() then
             target:getChar():setData("VoiceBan", true)
             lia.log.add(client, "plyMute", target:Name())
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plymute",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
             hook.Run("PlayerMuted", target, client)
         end
     end
@@ -421,6 +547,15 @@ lia.command.add("plyunmute", {
         if IsValid(target) and target:getChar() then
             target:getChar():setData("VoiceBan", false)
             lia.log.add(client, "plyUnmute", target:Name())
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plyunmute",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
             hook.Run("PlayerUnmuted", target, client)
         end
     end
@@ -438,6 +573,15 @@ lia.command.add("plybring", {
             returnPositions[target] = target:GetPos()
             target:SetPos(client:GetPos() + client:GetForward() * 50)
             lia.log.add(client, "plyBring", target:Name())
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plybring",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
         end
     end
 })
@@ -453,6 +597,15 @@ lia.command.add("plygoto", {
             returnPositions[client] = client:GetPos()
             client:SetPos(target:GetPos() + target:GetForward() * 50)
             lia.log.add(client, "plyGoto", target:Name())
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plygoto",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
         end
     end
 })
@@ -470,6 +623,15 @@ lia.command.add("plyreturn", {
             target:SetPos(pos)
             returnPositions[target] = nil
             lia.log.add(client, "plyReturn", target:Name())
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plyreturn",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
         end
     end
 })
@@ -485,6 +647,15 @@ lia.command.add("plyjail", {
             target:Lock()
             target:Freeze(true)
             lia.log.add(client, "plyJail", target:Name())
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plyjail",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
         end
     end
 })
@@ -500,6 +671,15 @@ lia.command.add("plyunjail", {
             target:UnLock()
             target:Freeze(false)
             lia.log.add(client, "plyUnjail", target:Name())
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plyunjail",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
         end
     end
 })
@@ -514,6 +694,15 @@ lia.command.add("plycloak", {
         if IsValid(target) then
             target:SetNoDraw(true)
             lia.log.add(client, "plyCloak", target:Name())
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plycloak",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
         end
     end
 })
@@ -528,6 +717,15 @@ lia.command.add("plyuncloak", {
         if IsValid(target) then
             target:SetNoDraw(false)
             lia.log.add(client, "plyUncloak", target:Name())
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plyuncloak",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
         end
     end
 })
@@ -542,6 +740,15 @@ lia.command.add("plygod", {
         if IsValid(target) then
             target:GodEnable()
             lia.log.add(client, "plyGod", target:Name())
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plygod",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
         end
     end
 })
@@ -556,6 +763,15 @@ lia.command.add("plyungod", {
         if IsValid(target) then
             target:GodDisable()
             lia.log.add(client, "plyUngod", target:Name())
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plyungod",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
         end
     end
 })
@@ -571,6 +787,15 @@ lia.command.add("plyignite", {
             local dur = tonumber(arguments[2]) or 5
             target:Ignite(dur)
             lia.log.add(client, "plyIgnite", target:Name(), dur)
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plyignite",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
         end
     end
 })
@@ -585,6 +810,15 @@ lia.command.add("plyextinguish", {
         if IsValid(target) then
             target:Extinguish()
             lia.log.add(client, "plyExtinguish", target:Name())
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plyextinguish",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
         end
     end
 })
@@ -599,6 +833,15 @@ lia.command.add("plystrip", {
         if IsValid(target) then
             target:StripWeapons()
             lia.log.add(client, "plyStrip", target:Name())
+            lia.db.insertTable({
+                player = target:Name(),
+                playerSteamID = target:SteamID64(),
+                steamID = target:SteamID64(),
+                action = "plystrip",
+                staffName = client:Name(),
+                staffSteamID = client:SteamID64(),
+                timestamp = os.time()
+            }, nil, "staffactions")
         end
     end
 })


### PR DESCRIPTION
## Summary
- create `lia_staffactions` table for recording staff-issued player commands
- record each administrative player command in `lia_staffactions`

## Testing
- `luacheck gamemode/modules/administration/commands.lua` *(215 warnings, 0 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688e63238e908327870b00eba0c59063