### PR TITLE
Add admin mod compatibility

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -66,7 +66,7 @@
   Contextual radial options for money, voice and recognition.
 
 * **Administration Tools**
-  Built-in admin menu handles logging, tickets, warns, teleport and spectate. ULX is not supported.
+  Built-in admin menu handles logging, tickets, warns, teleport and spectate. Optional compatibility is available for ULX, ServerGuard, and SAM.
 
 * **Performance & Protection**
   Tick monitoring, network profiling and anti-exploit checks.

--- a/gamemode/core/libraries/compatibility/serverguard.lua
+++ b/gamemode/core/libraries/compatibility/serverguard.lua
@@ -1,0 +1,80 @@
+local function run(cmd, ...)
+    RunConsoleCommand("serverguard", cmd, ...)
+    RunConsoleCommand("sg", cmd, ...)
+end
+
+hook.Add("RunAdminSystemCommand", "liaServerGuard", function(cmd, _, target, dur, reason)
+    local id = isstring(target) and target or IsValid(target) and target:SteamID()
+    if not id then return end
+
+    if cmd == "kick" then
+        run("kick", id, reason or "")
+        return true
+    elseif cmd == "ban" then
+        run("ban", id, tostring(dur or 0), reason or "")
+        return true
+    elseif cmd == "unban" then
+        run("unban", id)
+        return true
+    elseif cmd == "mute" then
+        run("mute", id, tostring(dur or 0))
+        return true
+    elseif cmd == "unmute" then
+        run("unmute", id)
+        return true
+    elseif cmd == "gag" then
+        run("gag", id, tostring(dur or 0))
+        return true
+    elseif cmd == "ungag" then
+        run("ungag", id)
+        return true
+    elseif cmd == "freeze" then
+        run("freeze", id, tostring(dur or 0))
+        return true
+    elseif cmd == "unfreeze" then
+        run("unfreeze", id)
+        return true
+    elseif cmd == "slay" then
+        run("slay", id)
+        return true
+    elseif cmd == "bring" then
+        run("bring", id)
+        return true
+    elseif cmd == "goto" then
+        run("goto", id)
+        return true
+    elseif cmd == "return" then
+        run("return", id)
+        return true
+    elseif cmd == "jail" then
+        run("jail", id, tostring(dur or 0))
+        return true
+    elseif cmd == "unjail" then
+        run("unjail", id)
+        return true
+    elseif cmd == "cloak" then
+        run("cloak", id)
+        return true
+    elseif cmd == "uncloak" then
+        run("uncloak", id)
+        return true
+    elseif cmd == "god" then
+        run("god", id)
+        return true
+    elseif cmd == "ungod" then
+        run("ungod", id)
+        return true
+    elseif cmd == "ignite" then
+        run("ignite", id, tostring(dur or 0))
+        return true
+    elseif cmd == "extinguish" or cmd == "unignite" then
+        run("extinguish", id)
+        return true
+    elseif cmd == "strip" then
+        run("strip", id)
+        return true
+    end
+end)
+
+hook.Add("ShouldLiliaAdminCommandsLoad", "liaServerGuard", function() return false end)
+

--- a/gamemode/core/libraries/compatibility/ulx.lua
+++ b/gamemode/core/libraries/compatibility/ulx.lua
@@ -1,0 +1,75 @@
+hook.Add("RunAdminSystemCommand", "liaULX", function(cmd, _, target, dur, reason)
+    local id = isstring(target) and target or IsValid(target) and target:SteamID()
+    if not id then return end
+
+    if cmd == "kick" then
+        RunConsoleCommand("ulx", "kick", id, reason or "")
+        return true
+    elseif cmd == "ban" then
+        RunConsoleCommand("ulx", "banid", id, tostring(dur or 0), reason or "")
+        return true
+    elseif cmd == "unban" then
+        RunConsoleCommand("ulx", "unban", id)
+        return true
+    elseif cmd == "mute" then
+        RunConsoleCommand("ulx", "mute", id)
+        return true
+    elseif cmd == "unmute" then
+        RunConsoleCommand("ulx", "unmute", id)
+        return true
+    elseif cmd == "gag" then
+        RunConsoleCommand("ulx", "gag", id)
+        return true
+    elseif cmd == "ungag" then
+        RunConsoleCommand("ulx", "ungag", id)
+        return true
+    elseif cmd == "freeze" then
+        RunConsoleCommand("ulx", "freeze", id)
+        return true
+    elseif cmd == "unfreeze" then
+        RunConsoleCommand("ulx", "unfreeze", id)
+        return true
+    elseif cmd == "slay" then
+        RunConsoleCommand("ulx", "slay", id)
+        return true
+    elseif cmd == "bring" then
+        RunConsoleCommand("ulx", "bring", id)
+        return true
+    elseif cmd == "goto" then
+        RunConsoleCommand("ulx", "goto", id)
+        return true
+    elseif cmd == "return" then
+        RunConsoleCommand("ulx", "return", id)
+        return true
+    elseif cmd == "jail" then
+        RunConsoleCommand("ulx", "jail", id, tostring(dur or 0))
+        return true
+    elseif cmd == "unjail" then
+        RunConsoleCommand("ulx", "unjail", id)
+        return true
+    elseif cmd == "cloak" then
+        RunConsoleCommand("ulx", "cloak", id)
+        return true
+    elseif cmd == "uncloak" then
+        RunConsoleCommand("ulx", "uncloak", id)
+        return true
+    elseif cmd == "god" then
+        RunConsoleCommand("ulx", "god", id)
+        return true
+    elseif cmd == "ungod" then
+        RunConsoleCommand("ulx", "ungod", id)
+        return true
+    elseif cmd == "ignite" then
+        RunConsoleCommand("ulx", "ignite", id)
+        return true
+    elseif cmd == "extinguish" or cmd == "unignite" then
+        RunConsoleCommand("ulx", "unignite", id)
+        return true
+    elseif cmd == "strip" then
+        RunConsoleCommand("ulx", "strip", id)
+        return true
+    end
+end)
+
+hook.Add("ShouldLiliaAdminCommandsLoad", "liaULX", function() return false end)
+

--- a/gamemode/core/libraries/loader.lua
+++ b/gamemode/core/libraries/loader.lua
@@ -234,6 +234,18 @@ local ConditionalFiles = {
         realm = "server"
     },
     {
+        path = "lilia/gamemode/core/libraries/compatibility/ulx.lua",
+        global = "ulx",
+        name = "ULX",
+        realm = "shared"
+    },
+    {
+        path = "lilia/gamemode/core/libraries/compatibility/serverguard.lua",
+        global = "serverguard",
+        name = "ServerGuard",
+        realm = "shared"
+    },
+    {
         path = "lilia/gamemode/core/libraries/compatibility/sam.lua",
         global = "sam",
         name = "SAM",


### PR DESCRIPTION
## Summary
- add ULX admin mod compatibility
- add ServerGuard admin mod compatibility
- mention admin mod support in docs

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e8fdca8888327a4122e0e8a5cd70a