### PR TITLE
Add markedForDeath character variable

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -59,7 +59,7 @@ end
 
 function GM:PlayerShouldPermaKill(client)
     local character = client:getChar()
-    return character:getData("markedForDeath", false)
+    return character:getMarkedForDeath()
 end
 
 function GM:CharLoaded(id)

--- a/gamemode/core/libraries/character.lua
+++ b/gamemode/core/libraries/character.lua
@@ -396,6 +396,14 @@ lia.char.registerVar("classwhitelists", {
     noDisplay = true
 })
 
+lia.char.registerVar("markedForDeath", {
+    field = "markedfordeath",
+    fieldType = "boolean",
+    default = false,
+    noDisplay = true,
+    noNetworking = true
+})
+
 function lia.char.getCharData(charID, key)
     local charIDsafe = tonumber(charID)
     if not charIDsafe then return end

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -923,9 +923,9 @@ lia.command.add("pktoggle", {
             return
         end
 
-        local currentState = character:getData("markedForDeath", false)
+        local currentState = character:getMarkedForDeath()
         local newState = not currentState
-        character:setData("markedForDeath", newState)
+        character:setMarkedForDeath(newState)
         if newState then
             client:notifyLocalized("pktoggle_true")
         else


### PR DESCRIPTION
## Summary
- track markedForDeath as a proper character variable
- update PK check and admin command to use the new variable

## Testing
- `luacheck gamemode/core/hooks/server.lua gamemode/modules/administration/commands.lua gamemode/core/libraries/character.lua` *(fails: `expected '=' near 'end'`)*

------
https://chatgpt.com/codex/tasks/task_e_688e94b519d48327a6d9e0d7ed0c3c7b