### PR TITLE
feat: add CAMI compatibility

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -65,8 +65,8 @@
 * **Interaction Menu**
   Contextual radial options for money, voice and recognition.
 
-* **Administration Tools**
-  Built-in admin menu handles logging, tickets, warns, teleport and spectate. Optional compatibility is available for ULX, ServerGuard, and SAM.
+  * **Administration Tools**
+    Built-in admin menu handles logging, tickets, warns, teleport and spectate. Optional compatibility is available for CAMI, ULX, ServerGuard, and SAM.
 
 * **Performance & Protection**
   Tick monitoring, network profiling and anti-exploit checks.

--- a/gamemode/core/libraries/loader.lua
+++ b/gamemode/core/libraries/loader.lua
@@ -234,10 +234,16 @@ local ConditionalFiles = {
         realm = "server"
     },
     {
+        path = "lilia/gamemode/core/libraries/compatibility/cami.lua",
+        global = "CAMI",
+        name = "CAMI",
+        realm = "shared",
+    },
+    {
         path = "lilia/gamemode/core/libraries/compatibility/ulx.lua",
         global = "ulx",
         name = "ULX",
-        realm = "shared"
+        realm = "shared",
     },
     {
         path = "lilia/gamemode/core/libraries/compatibility/serverguard.lua",


### PR DESCRIPTION
## Summary
- load CAMI compatibility module when CAMI is present
- implement helper functions and server-side hooks for CAMI privileges
- document CAMI as optional admin integration

## Testing
- `luacheck gamemode/core/libraries/compatibility/cami.lua gamemode/core/libraries/loader.lua | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688ea954e1e88327a8f0966678e23484