### PR TITLE
Fix admin privilege category scroll sizing

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -756,6 +756,10 @@ else
             cat:SetContents(pnl)
             cat:SetExpanded(true)
         end
+        categoryList:InvalidateLayout(true)
+        local canvas = categoryList:GetCanvas()
+        canvas:SizeToChildren(false, true)
+        categoryList:SetTall(canvas:GetTall())
         return categoryList, current
     end
 


### PR DESCRIPTION
## Summary
- ensure usergroup privilege categories resize to their canvas so the scroll panel fills available space

## Testing
- `~/.luarocks/bin/luacheck gamemode/core/libraries/admin.lua`

------
https://chatgpt.com/codex/tasks/task_e_688eae00c6e4832780505c14d2a13ae5