### PR TITLE
Handle boolean values in database conversion

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -711,6 +711,8 @@ function lia.db.convertDataType(value, noEscape)
         else
             return "'" .. lia.db.escape(util.TableToJSON(value)) .. "'"
         end
+    elseif isbool(value) then
+        return value and 1 or 0
     elseif value == NULL then
         return "NULL"
     end


### PR DESCRIPTION
## Summary
- Handle boolean values in `lia.db.convertDataType` to avoid runtime error during updates/inserts

## Testing
- `luacheck gamemode/core/libraries/database.lua` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: Unable to locate package luacheck)*

------
https://chatgpt.com/codex/tasks/task_e_688eafa2bed483279940b6510abeeb6b