### PR TITLE
Store VoiceBan in player data

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -959,8 +959,7 @@ function GM:PlayerCanHearPlayersVoice(listener, speaker)
     if not IsValid(listener) or not IsValid(speaker) or listener == speaker then return false, false end
     if speaker:getNetVar("IsDeadRestricted", false) then return false, false end
     if speaker:getNetVar("liaGagged", false) then return false, false end
-    local char = speaker:getChar()
-    if not char or char:getData("VoiceBan", false) then return false, false end
+    if not speaker:getChar() or speaker:getLiliaData("VoiceBan", false) then return false, false end
     if not lia.config.get("IsVoiceEnabled", true) then return false, false end
     local voiceType = speaker:getNetVar("VoiceType", "Talking")
     local baseRange = TalkRanges[voiceType] or TalkRanges.Talking

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -572,7 +572,8 @@ lia.command.add("plymute", {
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) and target:getChar() then
-            target:getChar():setData("VoiceBan", true)
+            target:setLiliaData("VoiceBan", true)
+            target:saveLiliaData()
             lia.log.add(client, "plyMute", target:Name())
             lia.db.insertTable({
                 player = target:Name(),
@@ -597,7 +598,8 @@ lia.command.add("plyunmute", {
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) and target:getChar() then
-            target:getChar():setData("VoiceBan", false)
+            target:setLiliaData("VoiceBan", false)
+            target:saveLiliaData()
             lia.log.add(client, "plyUnmute", target:Name())
             lia.db.insertTable({
                 player = target:Name(),
@@ -1508,10 +1510,10 @@ lia.command.add("charvoicetoggle", {
             return false
         end
 
-        local char = target:getChar()
-        if char then
-            local isBanned = char:getData("VoiceBan", false)
-            char:setData("VoiceBan", not isBanned)
+        if target:getChar() then
+            local isBanned = target:getLiliaData("VoiceBan", false)
+            target:setLiliaData("VoiceBan", not isBanned)
+            target:saveLiliaData()
             if isBanned then
                 client:notifyLocalized("voiceUnmuted", target:Name())
                 target:notifyLocalized("voiceUnmutedByAdmin")


### PR DESCRIPTION
## Summary
- Persist voice bans in player Lilia data for mute/unmute commands
- Check player data for VoiceBan when determining voice chat access

## Testing
- `luacheck gamemode/modules/administration/commands.lua gamemode/core/hooks/server.lua` *(fails: expected '=' near 'end')*

------
https://chatgpt.com/codex/tasks/task_e_688ec9c256e08327addc2a068e16ba3c