### PR TITLE
Tie permakill module to banned char var

### DIFF
--- a/gamemode/modules/administration/submodules/permakill/module.lua
+++ b/gamemode/modules/administration/submodules/permakill/module.lua
@@ -56,6 +56,15 @@ if SERVER then
             end
         end
     end)
+
+    function MODULE:CanPlayerUseChar(client, character)
+        if character:getData("banned") then
+            net.Start("PK_Notice")
+            net.WriteString(character:getName())
+            net.Send(client)
+            return false, L("bannedCharacter")
+        end
+    end
 else
     net.Receive("OpenPKViewer", function()
         local cases = net.ReadTable()


### PR DESCRIPTION
## Summary
- prevent banned characters from being loaded by checking the `banned` flag in permakill module
- send a notification when a banned character is selected

## Testing
- `luacheck gamemode/modules/administration/submodules/permakill/module.lua` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: unable to locate package luacheck)*

------
https://chatgpt.com/codex/tasks/task_e_688ed464b34c832790a1da71a2319df3