### PR TITLE
feat: add banned character variable

### DIFF
--- a/gamemode/core/derma/mainmenu/character.lua
+++ b/gamemode/core/derma/mainmenu/character.lua
@@ -497,7 +497,7 @@ function PANEL:createSelectedCharacterInfoPanel(character)
     local selectText = L("selectCharacter")
     if clientChar and character:getID() == clientChar:getID() then
         selectText = L("alreadyUsingCharacter")
-    elseif character:getData("banned") then
+    elseif character:isBanned() then
         selectText = L("bannedCharacter")
     end
 
@@ -505,7 +505,7 @@ function PANEL:createSelectedCharacterInfoPanel(character)
     self.selectBtn:SetSize(bw, bh)
     self.selectBtn:SetPos(cx, fy + fh + pad)
     self.selectBtn:SetText(selectText)
-    if clientChar and character:getID() == clientChar:getID() or character:getData("banned") then
+    if clientChar and character:getID() == clientChar:getID() or character:isBanned() then
         self.selectBtn:SetEnabled(false)
         self.selectBtn:SetTextColor(Color(255, 255, 255))
     end

--- a/gamemode/core/libraries/character.lua
+++ b/gamemode/core/libraries/character.lua
@@ -404,6 +404,13 @@ lia.char.registerVar("markedForDeath", {
     noNetworking = true
 })
 
+lia.char.registerVar("banned", {
+    field = "banned",
+    fieldType = "integer",
+    default = 0,
+    noDisplay = true
+})
+
 function lia.char.getCharData(charID, key)
     local charIDsafe = tonumber(charID)
     if not charIDsafe then return end
@@ -738,6 +745,35 @@ if SERVER then
                 client:SetupHands()
             end
         end
+        return true
+    end
+
+    function lia.char.getCharBanned(charID)
+        local charIDsafe = tonumber(charID)
+        if not charIDsafe then return end
+        local result = sql.Query("SELECT banned FROM lia_characters WHERE id = " .. charIDsafe .. " LIMIT 1")
+        if istable(result) and result[1] then
+            return tonumber(result[1].banned) or 0
+        end
+    end
+
+    function lia.char.setCharBanned(charID, value)
+        local charIDsafe = tonumber(charID)
+        if not charIDsafe then return end
+        value = tonumber(value) or 0
+        local promise = lia.db.updateTable({
+            banned = value
+        }, nil, "characters", "id = " .. charIDsafe)
+        if deferred.isPromise(promise) then
+            promise:catch(function(err) lia.information(L("charSetDataSQLError", "UPDATE lia_characters SET banned", err)) end)
+        elseif promise == false then
+            return false
+        end
+
+        if lia.char.loaded[charIDsafe] then
+            lia.char.loaded[charIDsafe]:setBanned(value)
+        end
+
         return true
     end
 end

--- a/gamemode/core/meta/character.lua
+++ b/gamemode/core/meta/character.lua
@@ -459,10 +459,21 @@ if SERVER then
         hook.Run("OnCharKick", self, client)
     end
 
+    function characterMeta:isBanned()
+        local banned = self:getBanned()
+        return banned ~= 0 and (banned == -1 or banned > os.time())
+    end
+
     function characterMeta:ban(time)
         time = tonumber(time)
-        if time then time = os.time() + math.max(math.ceil(time), 60) end
-        self:setData("banned", time or true)
+        local value
+        if time then
+            value = os.time() + math.max(math.ceil(time), 60)
+        else
+            value = -1
+        end
+
+        self:setBanned(value)
         self:save()
         self:kick()
         hook.Run("OnCharPermakilled", self, time or nil)

--- a/gamemode/modules/administration/submodules/permakill/module.lua
+++ b/gamemode/modules/administration/submodules/permakill/module.lua
@@ -46,7 +46,8 @@ if SERVER then
         for _, ply in player.Iterator() do
             if ply:SteamID() == data.steamID and ply:getChar() then
                 if isCharBan then
-                    ply:getChar():setData("banned", true)
+                    ply:getChar():setBanned(-1)
+                    ply:getChar():save()
                     ply:getChar():kick()
                 else
                     ply:getChar():ban()
@@ -58,7 +59,7 @@ if SERVER then
     end)
 
     function MODULE:CanPlayerUseChar(client, character)
-        if character:getData("banned") then
+        if character:isBanned() then
             net.Start("PK_Notice")
             net.WriteString(character:getName())
             net.Send(client)

--- a/gamemode/modules/mainmenu/libraries/server.lua
+++ b/gamemode/modules/mainmenu/libraries/server.lua
@@ -17,15 +17,13 @@
 end
 
 function MODULE:CanPlayerUseChar(_, character)
-    local banned = character:getData("banned")
-    if banned and isnumber(banned) and banned > os.time() then return false, L("bannedCharacter") end
+    if character:isBanned() then return false, L("bannedCharacter") end
     return true
 end
 
 function MODULE:CanPlayerSwitchChar(client, character, newCharacter)
-    local banned = character:getData("banned")
     if character:getID() == newCharacter:getID() then return false, L("alreadyUsingCharacter") end
-    if banned and isnumber(banned) and banned > os.time() then return false, L("bannedCharacter") end
+    if character:isBanned() then return false, L("bannedCharacter") end
     if not client:Alive() then return false, L("youAreDead") end
     if client:hasRagdoll() then return false, L("youAreRagdolled") end
     if client:hasValidVehicle() then return false, L("cannotSwitchInVehicle") end


### PR DESCRIPTION
## Summary
- add `banned` char var with helper functions
- use `isBanned` in main menu and admin flows
- update permakill to respect character bans

## Testing
- `luac -p gamemode/core/libraries/character.lua` (fails: unexpected symbol near '')
- `luac -p gamemode/modules/administration/submodules/permakill/module.lua`
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_688ed60526ec8327bebde98a2f840a3b