### PR TITLE
Use char variables for appearance and session data

### DIFF
--- a/gamemode/core/derma/mainmenu/character.lua
+++ b/gamemode/core/derma/mainmenu/character.lua
@@ -535,8 +535,8 @@ function PANEL:updateModelEntity(character)
     local model = character.getModel and character:getModel() or LocalPlayer():GetModel()
     self.modelEntity = ClientsideModel(model, RENDERGROUP_OPAQUE)
     if not IsValid(self.modelEntity) then return end
-    self.modelEntity:SetSkin(character:getData("skin", 0))
-    local groups = character:getData("groups", {})
+    self.modelEntity:SetSkin(character:getSkin())
+    local groups = character:getBodygroups()
     for i = 0, self.modelEntity:GetNumBodyGroups() - 1 do
         local value = groups[i]
         if value == nil then value = groups[tostring(i)] end

--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -26,7 +26,7 @@ function GM:PlayerLoadedChar(client, character)
     }, nil, "characters", "id = " .. character:getID())
 
     client:removeRagdoll()
-    character:setData("loginTime", os.time())
+    character:setLoginTime(os.time())
     hook.Run("PlayerLoadout", client)
     local ammoTable = character:getAmmo()
     if table.IsEmpty(ammoTable) then return end
@@ -330,13 +330,13 @@ function GM:PostPlayerLoadout(client)
     if not character then return end
     client:Give("lia_hands")
     client:SetupHands()
-    for k, v in pairs(character:getData("groups", {})) do
+    for k, v in pairs(character:getBodygroups()) do
         local index = tonumber(k)
         local value = tonumber(v) or 0
         if index then client:SetBodygroup(index, value) end
     end
 
-    client:SetSkin(character:getData("skin", 0))
+    client:SetSkin(character:getSkin())
     client:setNetVar("VoiceType", "Talking")
 end
 

--- a/gamemode/core/libraries/character.lua
+++ b/gamemode/core/libraries/character.lua
@@ -201,8 +201,7 @@ lia.char.registerVar("model", {
                 newData.model = model
             elseif istable(model) then
                 newData.model = model[1]
-                newData.data = newData.data or {}
-                newData.data.skin = model[2] or 0
+                newData.skin = model[2] or 0
                 local groups = {}
                 if isstring(model[3]) then
                     local i = 0
@@ -216,10 +215,55 @@ lia.char.registerVar("model", {
                     end
                 end
 
-                newData.data.groups = groups
+                newData.bodygroups = groups
             end
         end
     end
+})
+
+lia.char.registerVar("skin", {
+    field = "skin",
+    fieldType = "integer",
+    default = 0,
+    onSet = function(character, value)
+        local oldVar = character:getSkin()
+        character.vars.skin = value
+        local client = character:getPlayer()
+        if IsValid(client) and client:getChar() == character then client:SetSkin(value) end
+        net.Start("charSet")
+        net.WriteString("skin")
+        net.WriteType(character.vars.skin)
+        net.WriteType(character:getID())
+        net.Broadcast()
+        hook.Run("OnCharVarChanged", character, "skin", oldVar, value)
+    end,
+    onGet = function(character, default) return character.vars.skin or default or 0 end,
+    noDisplay = true
+})
+
+lia.char.registerVar("bodygroups", {
+    field = "bodygroups",
+    fieldType = "text",
+    default = {},
+    onSet = function(character, value)
+        local oldVar = character:getBodygroups()
+        character.vars.bodygroups = value
+        local client = character:getPlayer()
+        if IsValid(client) and client:getChar() == character then
+            for k, v in pairs(value or {}) do
+                local index = tonumber(k)
+                if index then client:SetBodygroup(index, v or 0) end
+            end
+        end
+        net.Start("charSet")
+        net.WriteString("bodygroups")
+        net.WriteType(character.vars.bodygroups)
+        net.WriteType(character:getID())
+        net.Broadcast()
+        hook.Run("OnCharVarChanged", character, "bodygroups", oldVar, value)
+    end,
+    onGet = function(character, default) return character.vars.bodygroups or default or {} end,
+    noDisplay = true
 })
 
 lia.char.registerVar("class", {
@@ -262,6 +306,14 @@ lia.char.registerVar("faction", {
 
 lia.char.registerVar("money", {
     field = "money",
+    fieldType = "integer",
+    default = 0,
+    isLocal = true,
+    noDisplay = true
+})
+
+lia.char.registerVar("loginTime", {
+    field = "logintime",
     fieldType = "integer",
     default = 0,
     isLocal = true,

--- a/gamemode/core/meta/character.lua
+++ b/gamemode/core/meta/character.lua
@@ -418,14 +418,14 @@ if SERVER then
 
             client:SetTeam(self:getFaction())
             client:setNetVar("char", self:getID())
-            PrintTable(self:getData("groups", {}), 1)
-            for k, v in pairs(self:getData("groups", {})) do
+            PrintTable(self:getBodygroups(), 1)
+            for k, v in pairs(self:getBodygroups()) do
                 local index = tonumber(k)
                 local value = tonumber(v) or 0
                 if index then client:SetBodygroup(index, value) end
             end
 
-            client:SetSkin(self:getData("skin", 0))
+            client:SetSkin(self:getSkin())
             hook.Run("SetupPlayerModel", client, self)
             if not noNetworking then
                 for _, v in ipairs(self:getInv(true)) do

--- a/gamemode/items/base/outfit.lua
+++ b/gamemode/items/base/outfit.lua
@@ -28,7 +28,7 @@ function ITEM:removeOutfit(client)
     if hook.Run("CanOutfitChangeModel", self) ~= false then
         character:setModel(self:getData("oldMdl", character:getModel()))
         self:setData("oldMdl", nil)
-        client:SetSkin(self:getData("oldSkin", character:getData("skin", 0)))
+        client:SetSkin(self:getData("oldSkin", character:getSkin()))
         self:setData("oldSkin", nil)
         local oldGroups = character:getData("oldGroups", {})
         for k in pairs(self.bodyGroups or {}) do
@@ -36,10 +36,10 @@ function ITEM:removeOutfit(client)
             if index > -1 then
                 client:SetBodygroup(index, oldGroups[index] or 0)
                 oldGroups[index] = nil
-                local groups = character:getData("groups", {})
+                local groups = character:getBodygroups()
                 if groups[index] then
                     groups[index] = nil
-                    character:setData("groups", groups)
+                    character:setBodygroups(groups)
                 end
             end
         end
@@ -115,7 +115,7 @@ ITEM.functions.Equip = {
 
             if isnumber(item.newSkin) then
                 item:setData("oldSkin", item.player:GetSkin())
-                character:setData("skin", item.newSkin)
+                character:setSkin(item.newSkin)
                 item.player:SetSkin(item.newSkin)
             end
 
@@ -132,13 +132,13 @@ ITEM.functions.Equip = {
 
                 character:setData("oldGroups", oldGroups)
                 item:setData("oldGroups", oldGroups)
-                local newGroups = character:getData("groups", {})
+                local newGroups = character:getBodygroups()
                 for index, value in pairs(groups) do
                     newGroups[index] = value
                     item.player:SetBodygroup(index, value)
                 end
 
-                if table.Count(newGroups) > 0 then character:setData("groups", newGroups) end
+                if table.Count(newGroups) > 0 then character:setBodygroups(newGroups) end
             end
         end
 

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -2049,9 +2049,9 @@ lia.command.add("charsetbodygroup", {
         local index = target:FindBodygroupByName(bodyGroup)
         if index > -1 then
             if value and value < 1 then value = nil end
-            local groups = target:getChar():getData("groups", {})
+            local groups = target:getChar():getBodygroups()
             groups[index] = value
-            target:getChar():setData("groups", groups)
+            target:getChar():setBodygroups(groups)
             target:SetBodygroup(index, value or 0)
             client:notifyLocalized("changeBodygroups", client:Name(), target:Name(), bodyGroup, value or 0)
         else
@@ -2080,7 +2080,7 @@ lia.command.add("charsetskin", {
             return
         end
 
-        target:getChar():setData("skin", skin)
+        target:getChar():setSkin(skin)
         target:SetSkin(skin or 0)
         client:notifyLocalized("changeSkin", client:Name(), target:Name(), skin or 0)
     end

--- a/gamemode/modules/protection/libraries/server.lua
+++ b/gamemode/modules/protection/libraries/server.lua
@@ -22,7 +22,7 @@ function MODULE:CanPlayerSwitchChar(client, character)
             return false, L("tookDamageSwitchCooldown")
         end
 
-        local loginTime = character:getData("loginTime", 0)
+        local loginTime = character:getLoginTime()
         if switchCooldown > 0 and loginTime + switchCooldown > os.time() then
             lia.log.add(client, "permissionDenied", L("logSwitchCharCooldown"))
             return false, L("switchCooldown")

--- a/gamemode/modules/teams/libraries/server.lua
+++ b/gamemode/modules/teams/libraries/server.lua
@@ -54,8 +54,7 @@ function MODULE:PlayerLoadedChar(client, character)
         character:setData("factionKickWarn", nil)
     end
 
-    local data = character:getData("pclass")
-    local class = data and lia.class.list[data]
+    local class = lia.class.list[character:getClass()]
     if character then
         if class and client:Team() == class.faction then
             local oldClass = character:getClass()


### PR DESCRIPTION
## Summary
- Add `skin`, `bodygroups`, and `loginTime` character variables and adjust model setup to populate them
- Update commands, items, UI, and hooks to use new character variable APIs instead of `setData`
- Restore class selection via existing `class` variable rather than `pclass` data key

## Testing
- `luacheck gamemode/core/libraries/character.lua gamemode/core/hooks/server.lua gamemode/modules/administration/commands.lua gamemode/items/base/outfit.lua gamemode/modules/teams/libraries/server.lua gamemode/core/meta/character.lua gamemode/core/derma/mainmenu/character.lua gamemode/modules/protection/libraries/server.lua` *(fails: accessing undefined variable net, timer, IsValid, lia, hook, L, player; line is too long; unused argument self)*

------
https://chatgpt.com/codex/tasks/task_e_688ed93dce7c8327b7d5d89cc113b4f6