### PR TITLE
Remove charID from warnings system

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -400,7 +400,6 @@ CREATE TABLE IF NOT EXISTS lia_ticketclaims (
 );
 CREATE TABLE IF NOT EXISTS lia_warnings (
     id integer primary key autoincrement,
-    charID integer,
     warned text,
     warnedSteamID text,
     timestamp datetime,
@@ -568,7 +567,6 @@ CREATE TABLE IF NOT EXISTS `lia_ticketclaims` (
 );
 CREATE TABLE IF NOT EXISTS `lia_warnings` (
     `id` int not null auto_increment,
-    `charID` int default null,
     `warned` text collate 'utf8mb4_general_ci',
     `warnedSteamID` varchar(64) default null collate 'utf8mb4_general_ci',
     `timestamp` datetime not null,

--- a/gamemode/modules/administration/submodules/logging/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/logging/libraries/server.lua
@@ -175,11 +175,11 @@ function MODULE:TicketSystemClose(admin, requester)
 end
 
 function MODULE:WarningIssued(admin, target, reason, index)
-    lia.db.count("warnings", "charID = " .. lia.db.convertDataType(target:getChar():getID())):next(function(count) lia.log.add(admin, "warningIssued", target, reason, count, index) end)
+    lia.db.count("warnings", "warnedSteamID = " .. lia.db.convertDataType(target:SteamID64())):next(function(count) lia.log.add(admin, "warningIssued", target, reason, count, index) end)
 end
 
 function MODULE:WarningRemoved(admin, target, warning, index)
-    lia.db.count("warnings", "charID = " .. lia.db.convertDataType(target:getChar():getID())):next(function(count) lia.log.add(admin, "warningRemoved", target, warning, count, index) end)
+    lia.db.count("warnings", "warnedSteamID = " .. lia.db.convertDataType(target:SteamID64())):next(function(count) lia.log.add(admin, "warningRemoved", target, warning, count, index) end)
 end
 
 function MODULE:ItemTransfered(context)

--- a/gamemode/modules/administration/submodules/warns/commands.lua
+++ b/gamemode/modules/administration/submodules/warns/commands.lua
@@ -23,8 +23,8 @@ lia.command.add("warn", {
         local timestamp = os.date("%Y-%m-%d %H:%M:%S")
         local warnerName = client:Nick()
         local warnerSteamID = client:SteamID()
-        MODULE:AddWarning(target:getChar():getID(), target:Nick(), target:SteamID64(), timestamp, reason, warnerName, warnerSteamID)
-        lia.db.count("warnings", "charID = " .. lia.db.convertDataType(target:getChar():getID())):next(function(count)
+        MODULE:AddWarning(target:Nick(), target:SteamID64(), timestamp, reason, warnerName, warnerSteamID)
+        lia.db.count("warnings", "warnedSteamID = " .. lia.db.convertDataType(target:SteamID64())):next(function(count)
             target:notifyLocalized("playerWarned", warnerName .. " (" .. warnerSteamID .. ")", reason)
             client:notifyLocalized("warningIssued", target:Nick())
             hook.Run("WarningIssued", client, target, reason, count)
@@ -50,7 +50,7 @@ lia.command.add("viewwarns", {
             return
         end
 
-        MODULE:GetWarnings(target:getChar():getID()):next(function(warns)
+        MODULE:GetWarnings(target:SteamID64()):next(function(warns)
             if #warns == 0 then
                 client:notifyLocalized("noWarnings", target:Nick())
                 return
@@ -63,7 +63,8 @@ lia.command.add("viewwarns", {
                     timestamp = warn.timestamp or L("na"),
                     warner = warn.warner or L("na"),
                     warnerSteamID = warn.warnerSteamID or L("na"),
-                    warningMessage = warn.message or L("na")
+                    warningMessage = warn.message or L("na"),
+                    warnedSteamID = warn.warnedSteamID
                 })
             end
 
@@ -93,7 +94,7 @@ lia.command.add("viewwarns", {
                     name = L("removeWarning"),
                     net = "RequestRemoveWarning"
                 }
-            }, target:getChar():getID())
+            }, 0)
 
             lia.log.add(client, "viewWarns", target)
         end)

--- a/gamemode/modules/protection/commands.lua
+++ b/gamemode/modules/protection/commands.lua
@@ -22,8 +22,8 @@
             local timestamp = os.date("%Y-%m-%d %H:%M:%S")
             local warnsModule = lia.module.list["warns"]
             if warnsModule and warnsModule.AddWarning then
-                warnsModule:AddWarning(target:getChar():getID(), target:Nick(), target:SteamID64(), timestamp, L("cheaterWarningReason"), client:Nick(), client:SteamID())
-                lia.db.count("warnings", "charID = " .. lia.db.convertDataType(target:getChar():getID())):next(function(count)
+                warnsModule:AddWarning(target:Nick(), target:SteamID64(), timestamp, L("cheaterWarningReason"), client:Nick(), client:SteamID())
+                lia.db.count("warnings", "warnedSteamID = " .. lia.db.convertDataType(target:SteamID64())):next(function(count)
                     target:notifyLocalized("playerWarned", client:Nick() .. " (" .. client:SteamID() .. ")", L("cheaterWarningReason"))
                     client:notifyLocalized("warningIssued", target:Nick())
                     hook.Run("WarningIssued", client, target, L("cheaterWarningReason"), count)


### PR DESCRIPTION
## Summary
- Drop `charID` column from `lia_warnings` database schema and rely on SteamID for tracking warnings.
- Refactor warning library and commands to query and store warnings by `warnedSteamID`.
- Update protection, logging, and UI workflows to pass SteamIDs when issuing or removing warnings.

## Testing
- `luacheck .` *(fails: command not found)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688edcdceb30832785f434fc578b33fa