### PR TITLE
feat: prevent self warnings

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -649,6 +649,7 @@ LANGUAGE = {
     moderationTools = "Moderation Tools",
     changePlayerModel = "Change Playermodel",
     cannotMuteSelf = "You cannot toggle mute on yourself.",
+    cannotWarnSelf = "You cannot warn yourself.",
     voiceUnmuted = "You have unmuted %s.",
     voiceUnmutedByAdmin = "You have been unmuted by an admin.",
     voiceMuted = "You have muted %s.",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -649,6 +649,7 @@ LANGUAGE = {
     moderationTools = "Outils de modération",
     changePlayerModel = "Changer modèle joueur",
     cannotMuteSelf = "Vous ne pouvez pas vous muter.",
+    cannotWarnSelf = "Vous ne pouvez pas vous avertir.",
     voiceUnmuted = "%s a été démuté.",
     voiceUnmutedByAdmin = "Vous avez été démuté par un admin.",
     voiceMuted = "%s a été muté.",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -649,6 +649,7 @@ LANGUAGE = {
     moderationTools = "Strumenti Moderazione",
     changePlayerModel = "Cambia Playermodel",
     cannotMuteSelf = "Non puoi mutarti da solo.",
+    cannotWarnSelf = "Non puoi avvertire te stesso.",
     voiceUnmuted = "Hai smutato %s.",
     voiceUnmutedByAdmin = "Sei stato smutato da un admin.",
     voiceMuted = "Hai mutato %s.",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -649,6 +649,7 @@ LANGUAGE = {
     moderationTools = "Ferramentas de Moderação",
     changePlayerModel = "Mudar Modelo",
     cannotMuteSelf = "Não podes mutar-te.",
+    cannotWarnSelf = "Não podes advertir-te.",
     voiceUnmuted = "Desmutaste %s.",
     voiceUnmutedByAdmin = "Foste desmutado por um admin.",
     voiceMuted = "Mutaste %s.",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -649,6 +649,7 @@ LANGUAGE = {
     moderationTools = "Модерация",
     changePlayerModel = "Сменить модель",
     cannotMuteSelf = "Нельзя мутить себя.",
+    cannotWarnSelf = "Нельзя предупреждать себя.",
     voiceUnmuted = "Вы размутили %s.",
     voiceUnmutedByAdmin = "Админ снял вам мут.",
     voiceMuted = "Вы замутили %s.",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -649,6 +649,7 @@ LANGUAGE = {
     moderationTools = "Herramientas de moderación",
     changePlayerModel = "Cambiar modelo",
     cannotMuteSelf = "No puedes mutearte.",
+    cannotWarnSelf = "No puedes advertirte a ti mismo.",
     voiceUnmuted = "Has desmuteado a %s.",
     voiceUnmutedByAdmin = "Un admin te desmuteó.",
     voiceMuted = "Has muteado a %s.",

--- a/gamemode/modules/administration/submodules/warns/commands.lua
+++ b/gamemode/modules/administration/submodules/warns/commands.lua
@@ -20,6 +20,11 @@ lia.command.add("warn", {
             return
         end
 
+        if target == client then
+            client:notifyLocalized("cannotWarnSelf")
+            return
+        end
+
         local timestamp = os.date("%Y-%m-%d %H:%M:%S")
         local warnerName = client:Nick()
         local warnerSteamID = client:SteamID()


### PR DESCRIPTION
## Summary
- prevent players from warning themselves
- add translations for self-warning message

## Testing
- `luacheck gamemode/modules/administration/submodules/warns/commands.lua gamemode/languages/english.lua gamemode/languages/spanish.lua gamemode/languages/russian.lua gamemode/languages/portuguese.lua gamemode/languages/italian.lua gamemode/languages/french.lua | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688ee0caffec8327ab467048a6f6e53d