### PR TITLE
feat: add staff management admin tab

### DIFF
--- a/gamemode/modules/administration/submodules/staffmanagement/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/staffmanagement/libraries/client.lua
@@ -1,0 +1,52 @@
+local panelRef
+lia.net.readBigTable("liaStaffSummary", function(data)
+    if not IsValid(panelRef) or not data then return end
+    panelRef:Clear()
+    local list = panelRef:Add("DListView")
+    list:Dock(FILL)
+    local function addSizedColumn(text)
+        local col = list:AddColumn(text)
+        surface.SetFont(col.Header:GetFont())
+        local w = surface.GetTextSize(col.Header:GetText())
+        col:SetMinWidth(w + 16)
+        col:SetWidth(w + 16)
+        return col
+    end
+    addSizedColumn("Player")
+    addSizedColumn("Player Steam ID")
+    addSizedColumn("Warning Count")
+    addSizedColumn("Ticket Count")
+    addSizedColumn("Kick Count")
+    addSizedColumn("Kill Count")
+    addSizedColumn("Respawn Count")
+    addSizedColumn("Blind Count")
+    addSizedColumn("Mute Count")
+    addSizedColumn("Jail Count")
+    addSizedColumn("Strip Count")
+    for _, info in ipairs(data) do
+        list:AddLine(
+            info.player or "",
+            info.steamID or "",
+            info.warnings or 0,
+            info.tickets or 0,
+            info.kicks or 0,
+            info.kills or 0,
+            info.respawns or 0,
+            info.blinds or 0,
+            info.mutes or 0,
+            info.jails or 0,
+            info.strips or 0
+        )
+    end
+end)
+function MODULE:PopulateAdminTabs(pages)
+    if not IsValid(LocalPlayer()) or not LocalPlayer():hasPrivilege("View Staff Management") then return end
+    table.insert(pages, {
+        name = "Staff Management",
+        drawFunc = function(panel)
+            panelRef = panel
+            net.Start("liaRequestStaffSummary")
+            net.SendToServer()
+        end
+    })
+end

--- a/gamemode/modules/administration/submodules/staffmanagement/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/staffmanagement/libraries/server.lua
@@ -1,0 +1,67 @@
+local MODULE = MODULE
+local function buildSummary()
+    local d = deferred.new()
+    local summary = {}
+    local function ensureEntry(id, name)
+        summary[id] = summary[id] or {
+            player = name or "",
+            steamID = id,
+            warnings = 0,
+            tickets = 0,
+            kicks = 0,
+            kills = 0,
+            respawns = 0,
+            blinds = 0,
+            mutes = 0,
+            jails = 0,
+            strips = 0
+        }
+        if name and name ~= "" then summary[id].player = name end
+        return summary[id]
+    end
+    lia.db.query([[SELECT warner AS name, warnerSteamID AS steamID, COUNT(*) AS count FROM lia_warnings GROUP BY warnerSteamID]], function(warnRows)
+        for _, row in ipairs(warnRows or {}) do
+            local steamID = row.steamID or row.warnerSteamID
+            if steamID and steamID ~= "" then
+                local entry = ensureEntry(steamID, row.name)
+                entry.warnings = tonumber(row.count) or 0
+            end
+        end
+        lia.db.query([[SELECT admin AS name, adminSteamID AS steamID, COUNT(*) AS count FROM lia_ticketclaims GROUP BY adminSteamID]], function(ticketRows)
+            for _, row in ipairs(ticketRows or {}) do
+                local steamID = row.steamID or row.adminSteamID
+                if steamID and steamID ~= "" then
+                    local entry = ensureEntry(steamID, row.name)
+                    entry.tickets = tonumber(row.count) or 0
+                end
+            end
+            lia.db.query([[SELECT staffName AS name, staffSteamID AS steamID, action, COUNT(*) AS count FROM lia_staffactions GROUP BY staffSteamID, action]], function(actionRows)
+                for _, row in ipairs(actionRows or {}) do
+                    local steamID = row.steamID or row.staffSteamID
+                    if steamID and steamID ~= "" then
+                        local entry = ensureEntry(steamID, row.name)
+                        local count = tonumber(row.count) or 0
+                        if row.action == "plykick" then entry.kicks = count
+                        elseif row.action == "plykill" then entry.kills = count
+                        elseif row.action == "plyrespawn" then entry.respawns = count
+                        elseif row.action == "plyblind" then entry.blinds = count
+                        elseif row.action == "plymute" then entry.mutes = count
+                        elseif row.action == "plyjail" then entry.jails = count
+                        elseif row.action == "plystrip" then entry.strips = count
+                        end
+                    end
+                end
+                local list = {}
+                for _, info in pairs(summary) do list[#list + 1] = info end
+                d:resolve(list)
+            end)
+        end)
+    end)
+    return d
+end
+net.Receive("liaRequestStaffSummary", function(_, client)
+    if not client:hasPrivilege("View Staff Management") then return end
+    buildSummary():next(function(data)
+        lia.net.writeBigTable(client, "liaStaffSummary", data)
+    end)
+end)

--- a/gamemode/modules/administration/submodules/staffmanagement/module.lua
+++ b/gamemode/modules/administration/submodules/staffmanagement/module.lua
@@ -1,0 +1,11 @@
+MODULE.name = "Staff Management"
+MODULE.author = "Samael"
+MODULE.discord = "@liliaplayer"
+MODULE.desc = "Overview of staff actions"
+MODULE.Privileges = {
+    {
+        Name = "View Staff Management",
+        MinAccess = "superadmin",
+        Category = "Staff"
+    }
+}


### PR DESCRIPTION
## Summary
- add a Staff Management admin tab with privilege guard
- show counts of warnings, tickets, and staff actions for each player
- send large datasets with `lia.net.writeBigTable`

## Testing
- `luacheck gamemode/modules/administration/submodules/staffmanagement` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: Unable to locate package luacheck)*


------
https://chatgpt.com/codex/tasks/task_e_688ee0de5aa88327987602106f449113