### PR TITLE
Add faction management admin tab

### DIFF
--- a/gamemode/modules/administration/submodules/factions/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/factions/libraries/client.lua
@@ -1,0 +1,41 @@
+local MODULE = MODULE
+local rosterPanel
+local function OpenRoster(panel, data)
+    panel:Clear()
+    local sheet = panel:Add("DPropertySheet")
+    sheet:Dock(FILL)
+    sheet:DockMargin(10, 10, 10, 10)
+    for factionName, members in pairs(data) do
+        local page = sheet:Add("DPanel")
+        page:Dock(FILL)
+        page:DockPadding(10, 10, 10, 10)
+        local list = page:Add("DListView")
+        list:Dock(FILL)
+        list:SetMultiSelect(false)
+        list:AddColumn(L("name", "Name"))
+        for _, member in ipairs(members) do
+            list:AddLine(member)
+        end
+        sheet:AddSheet(factionName, page)
+    end
+end
+
+lia.net.readBigTable("liaFactionRosterData", function(data)
+    if IsValid(rosterPanel) then
+        OpenRoster(rosterPanel, data or {})
+    end
+end)
+
+function MODULE:PopulateAdminTabs(pages)
+    if IsValid(LocalPlayer()) and LocalPlayer():hasPrivilege("Can Manage Factions") then
+        table.insert(pages, {
+            name = L("factionManagement", "Factions"),
+            drawFunc = function(panel)
+                rosterPanel = panel
+                net.Start("liaRequestFactionRoster")
+                net.SendToServer()
+            end
+        })
+    end
+end
+

--- a/gamemode/modules/administration/submodules/factions/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/factions/libraries/server.lua
@@ -1,0 +1,18 @@
+util.AddNetworkString("liaRequestFactionRoster")
+local function SendRoster(client)
+    if not IsValid(client) or not client:hasPrivilege("Can Manage Factions") then return end
+    local data = {}
+    for _, faction in pairs(lia.faction.indices) do
+        local members = {}
+        for _, ply in ipairs(lia.faction.getPlayers(faction.index)) do
+            members[#members + 1] = ply:Name()
+        end
+        data[faction.name] = members
+    end
+    lia.net.writeBigTable(client, "liaFactionRosterData", data)
+end
+
+net.Receive("liaRequestFactionRoster", function(_, client)
+    SendRoster(client)
+end)
+

--- a/gamemode/modules/administration/submodules/factions/module.lua
+++ b/gamemode/modules/administration/submodules/factions/module.lua
@@ -1,0 +1,12 @@
+MODULE.name = L("moduleFactionMgmtName", "Faction Management")
+MODULE.author = "Samael"
+MODULE.discord = "@liliaplayer"
+MODULE.desc = L("moduleFactionMgmtDesc", "View and manage faction rosters")
+MODULE.Privileges = {
+    {
+        Name = L("canManageFactions", "Can Manage Factions"),
+        MinAccess = "admin",
+        Category = L("categoryManagement", "Management"),
+    },
+}
+


### PR DESCRIPTION
## Summary
- Add Faction Management admin module with privilege gating
- Use big table networking to stream faction rosters to the client
- Render each faction's membership in its own sub-sheet

## Testing
- `luacheck gamemode/modules/administration/submodules/factions/...` *(fails: command not found)*
- `luac -p gamemode/modules/administration/submodules/factions/module.lua gamemode/modules/administration/submodules/factions/libraries/client.lua gamemode/modules/administration/submodules/factions/libraries/server.lua`

------
https://chatgpt.com/codex/tasks/task_e_688ee0f9ebe48327b80916d8acb53e27