### PR TITLE
Add optimized Character List admin tab with per-player sheets

### DIFF
--- a/gamemode/modules/administration/submodules/charlist/module.lua
+++ b/gamemode/modules/administration/submodules/charlist/module.lua
@@ -84,7 +84,7 @@ else
                         pnl:Dock(FILL)
                         pnl.Paint = function() end
                         createList(pnl, chars)
-                        local ply = player.GetBySteamID(steamID)
+                        local ply = player.GetBySteamID64(steamID)
                         local title = IsValid(ply) and ply:Nick() or steamID
                         self.sheet:AddSheet(title, pnl)
                     end


### PR DESCRIPTION
## Summary
- Provide an admin-side Character List view that requests all characters at once and sends the data via `lia.net.writeBigTable`.
- Automatically generate a sheet for "All Characters" plus separate sub-sheets for each player, resolving player names via SteamID64.

## Testing
- `luac -p gamemode/modules/administration/submodules/charlist/module.lua` *(fails: command not found)*
- `luacheck gamemode/modules/administration/submodules/charlist/module.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688eeba106f0832788f21a6725ad4e31