### PR TITLE
refactor: use lia.util.getBySteamID

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -425,7 +425,7 @@ if SERVER then
     function lia.administrator.setSteamIDUsergroup(steamId, newGroup, source)
         local sid = tostring(steamId or "")
         if sid == "" then return end
-        local ply = player.GetBySteamID and player.GetBySteamID(sid)
+        local ply = lia.util.getBySteamID(sid)
         local old = IsValid(ply) and tostring(ply:GetUserGroup() or "user") or "user"
         local new = tostring(newGroup or "user")
         if IsValid(ply) then ply:SetUserGroup(new) end

--- a/gamemode/core/libraries/compatibility/cami.lua
+++ b/gamemode/core/libraries/compatibility/cami.lua
@@ -119,7 +119,7 @@ hook.Add("CAMI.SteamIDUsergroupChanged", "liaAdminSIDUGChanged", function(steamI
     local sid = tostring(steamId or "")
     if sid == "" then return end
     local newGroup = tostring(new or "user")
-    local ply = player.GetBySteamID and player.GetBySteamID(sid)
+    local ply = lia.util.getBySteamID(sid)
     if IsValid(ply) and tostring(ply:GetUserGroup() or "user") ~= newGroup then ply:SetUserGroup(newGroup) end
     local steam64 = util.SteamIDTo64(sid)
     lia.db.query(Format("UPDATE lia_players SET userGroup = '%s' WHERE steamID = %s", lia.db.escape(newGroup), steam64))

--- a/gamemode/core/libraries/util.lua
+++ b/gamemode/core/libraries/util.lua
@@ -33,7 +33,7 @@ function lia.util.findPlayer(client, identifier)
     end
 
     if string.match(identifier, "^STEAM_%d+:%d+:%d+$") then
-        local ply = player.GetBySteamID(identifier)
+        local ply = lia.util.getBySteamID(identifier)
         if IsValid(ply) then return ply end
         if isValidClient then client:notifyLocalized("plyNoExist") end
         return nil
@@ -42,7 +42,7 @@ function lia.util.findPlayer(client, identifier)
     if string.match(identifier, "^%d+$") and #identifier >= 17 then
         local sid = util.SteamIDFrom64(identifier)
         if sid then
-            local ply = player.GetBySteamID(sid)
+            local ply = lia.util.getBySteamID(sid)
             if IsValid(ply) then return ply end
         end
 

--- a/gamemode/modules/administration/submodules/charlist/module.lua
+++ b/gamemode/modules/administration/submodules/charlist/module.lua
@@ -84,7 +84,7 @@ else
                         pnl:Dock(FILL)
                         pnl.Paint = function() end
                         createList(pnl, chars)
-                        local ply = player.GetBySteamID64(steamID)
+                        local ply = lia.util.getBySteamID(steamID)
                         local title = IsValid(ply) and ply:Nick() or steamID
                         self.sheet:AddSheet(title, pnl)
                     end

--- a/gamemode/modules/administration/submodules/tickets/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/tickets/libraries/server.lua
@@ -14,12 +14,12 @@ local function buildClaimTable(rows)
         local info = caseclaims[adminID]
         info.claims = info.claims + 1
         if row.timestamp > info.lastclaim then info.lastclaim = row.timestamp end
-        local reqPly = player.GetBySteamID(row.requesterSteamID)
+        local reqPly = lia.util.getBySteamID(row.requesterSteamID)
         info.claimedFor[row.requesterSteamID] = IsValid(reqPly) and reqPly:Nick() or row.requester
     end
 
     for adminID, info in pairs(caseclaims) do
-        local ply = player.GetBySteamID(adminID)
+        local ply = lia.util.getBySteamID(adminID)
         if IsValid(ply) then info.name = ply:Nick() end
     end
     return caseclaims

--- a/gamemode/modules/administration/submodules/tickets/module.lua
+++ b/gamemode/modules/administration/submodules/tickets/module.lua
@@ -35,7 +35,7 @@ if CLIENT then
         for _, t in pairs(tickets) do
             local admin = L("unassignedLabel")
             if t.admin then
-                local adminPly = player.GetBySteamID(t.admin)
+                local adminPly = lia.util.getBySteamID(t.admin)
                 if IsValid(adminPly) then
                     admin = adminPly:Nick()
                 else
@@ -45,7 +45,7 @@ if CLIENT then
 
             local requester = t.requester or ""
             if requester ~= "" then
-                  local requesterPly = player.GetBySteamID(requester)
+                  local requesterPly = lia.util.getBySteamID(requester)
                 if IsValid(requesterPly) then requester = requesterPly:Nick() end
             end
 


### PR DESCRIPTION
## Summary
- use lia.util.getBySteamID instead of player.GetBySteamID/GetBySteamID64 across modules

## Testing
- `luacheck gamemode/core/libraries/admin.lua gamemode/core/libraries/compatibility/cami.lua gamemode/core/libraries/util.lua gamemode/modules/administration/submodules/charlist/module.lua gamemode/modules/administration/submodules/tickets/libraries/server.lua gamemode/modules/administration/submodules/tickets/module.lua`


------
https://chatgpt.com/codex/tasks/task_e_688eeced16a08327a15691801972c3d1