### PR TITLE
fix: preserve property sheet tabs

### DIFF
--- a/gamemode/modules/administration/submodules/charlist/module.lua
+++ b/gamemode/modules/administration/submodules/charlist/module.lua
@@ -53,7 +53,14 @@ else
                 panel.sheet = panel:Add("DPropertySheet")
                 panel.sheet:Dock(FILL)
                 function panel:buildSheets(data)
-                    self.sheet:Clear()
+                    -- Clear existing tabs without removing the tab scroller
+                    for _, v in ipairs(self.sheet.Items or {}) do
+                        if IsValid(v.Tab) then
+                            self.sheet:CloseTab(v.Tab, true)
+                        end
+                    end
+                    self.sheet.Items = {}
+
                     local columns = {
                         {name = L("id"), field = "ID"},
                         {name = L("name"), field = "Name"},


### PR DESCRIPTION
## Summary
- avoid tearing down DPropertySheet's tab scroller when rebuilding the character list

## Testing
- `luacheck gamemode/modules/administration/submodules/charlist/module.lua`


------
https://chatgpt.com/codex/tasks/task_e_688eef5b3a588327bcfb7a3cd07aa862