### PR TITLE
Default staff action counts to zero

### DIFF
--- a/gamemode/modules/administration/submodules/staffmanagement/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/staffmanagement/libraries/server.lua
@@ -52,7 +52,18 @@ local function buildSummary()
                     end
                 end
                 local list = {}
-                for _, info in pairs(summary) do list[#list + 1] = info end
+                for _, info in pairs(summary) do
+                    info.warnings = info.warnings or 0
+                    info.tickets = info.tickets or 0
+                    info.kicks = info.kicks or 0
+                    info.kills = info.kills or 0
+                    info.respawns = info.respawns or 0
+                    info.blinds = info.blinds or 0
+                    info.mutes = info.mutes or 0
+                    info.jails = info.jails or 0
+                    info.strips = info.strips or 0
+                    list[#list + 1] = info
+                end
                 d:resolve(list)
             end)
         end)


### PR DESCRIPTION
## Summary
- Initialize all staff action metrics to zero when building the staff management summary

## Testing
- `luacheck gamemode/modules/administration/submodules/staffmanagement/libraries/server.lua`

------
https://chatgpt.com/codex/tasks/task_e_688ef17779c48327937a3d9d7fcfa8be