### PR TITLE
Remove Copy Row option from logs

### DIFF
--- a/gamemode/modules/administration/submodules/logging/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/logging/libraries/client.lua
@@ -47,11 +47,6 @@ local function OpenLogsUI(panel, categorizedLogs)
             local menu = DermaMenu()
             if data.steamID and data.steamID ~= "" then menu:AddOption(L("copySteamID"), function() SetClipboardText(data.steamID) end) end
             menu:AddOption(L("copyLogMessage"), function() SetClipboardText(data.message or "") end)
-            menu:AddOption(L("copyRow"), function()
-                local text = "[" .. data.timestamp .. "] " .. data.message
-                if data.steamID and data.steamID ~= "" then text = text .. " [" .. data.steamID .. "]" end
-                SetClipboardText(text)
-            end)
 
             menu:Open()
         end


### PR DESCRIPTION
## Summary
- remove the Copy Row option from the logs interface

## Testing
- `lua -p gamemode/modules/administration/submodules/logging/libraries/client.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ef85e1c108327995ede8dddba8949