### PR TITLE
Merge player and admin identifiers in warnings

### DIFF
--- a/gamemode/modules/administration/submodules/warns/commands.lua
+++ b/gamemode/modules/administration/submodules/warns/commands.lua
@@ -66,8 +66,7 @@ lia.command.add("viewwarns", {
                 table.insert(warningList, {
                     index = index,
                     timestamp = warn.timestamp or L("na"),
-                    warner = warn.warner or L("na"),
-                    warnerSteamID = warn.warnerSteamID or L("na"),
+                    admin = string.format("%s (%s)", warn.warner or L("na"), warn.warnerSteamID or L("na")),
                     warningMessage = warn.message or L("na")
                 })
             end
@@ -82,12 +81,8 @@ lia.command.add("viewwarns", {
                     field = "timestamp"
                 },
                 {
-                    name = L("Warner", "Warner"),
-                    field = "warner"
-                },
-                {
-                    name = L("Warner Steam ID", "Warner Steam ID"),
-                    field = "warnerSteamID"
+                    name = L("Admin", "Admin"),
+                    field = "admin"
                 },
                 {
                     name = L("Warning Message", "Warning Message"),

--- a/gamemode/modules/administration/submodules/warns/module.lua
+++ b/gamemode/modules/administration/submodules/warns/module.lua
@@ -33,9 +33,7 @@ if CLIENT then
 
         addSizedColumn(L("timestamp"))
         addSizedColumn(L("Warned", "Warned"))
-        addSizedColumn(L("Warned Steam ID", "Warned Steam ID"))
-        addSizedColumn(L("Warner", "Warner"))
-        addSizedColumn(L("Warner Steam ID", "Warner Steam ID"))
+        addSizedColumn(L("Admin", "Admin"))
         addSizedColumn(L("Warning Message", "Warning Message"))
 
         local function populate(filter)
@@ -44,10 +42,8 @@ if CLIENT then
             for _, warn in ipairs(warnings) do
                 local entries = {
                     warn.timestamp or "",
-                    warn.warned or "",
-                    warn.warnedSteamID or "",
-                    warn.warner or "",
-                    warn.warnerSteamID or "",
+                    string.format("%s (%s)", warn.warned or "", warn.warnedSteamID or ""),
+                    string.format("%s (%s)", warn.warner or "", warn.warnerSteamID or ""),
                     warn.message or ""
                 }
                 local match = false


### PR DESCRIPTION
## Summary
- Combine warned name and SteamID into one "Warned" column
- Combine admin name and SteamID into one "Admin" column

## Testing
- `luac -p gamemode/modules/administration/submodules/warns/module.lua`
- `tail -c +4 gamemode/modules/administration/submodules/warns/commands.lua > /tmp/commands_no_bom.lua`
- `luac -p /tmp/commands_no_bom.lua`


------
https://chatgpt.com/codex/tasks/task_e_688ef877ab308327b33f79061cc51518