### PR TITLE
Display usergroup in staff actions list

### DIFF
--- a/gamemode/modules/administration/submodules/staffmanagement/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/staffmanagement/libraries/client.lua
@@ -18,6 +18,7 @@ lia.net.readBigTable("liaStaffSummary", function(data)
     end
     addSizedColumn("Player")
     addSizedColumn("Player Steam ID")
+    addSizedColumn(L("usergroup", "Usergroup"))
     addSizedColumn("Warning Count")
     addSizedColumn("Ticket Count")
     addSizedColumn("Kick Count")
@@ -35,6 +36,7 @@ lia.net.readBigTable("liaStaffSummary", function(data)
             local entries = {
                 info.player or "",
                 info.steamID or "",
+                info.usergroup or "",
                 info.warnings or 0,
                 info.tickets or 0,
                 info.kicks or 0,

--- a/gamemode/modules/administration/submodules/staffmanagement/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/staffmanagement/libraries/server.lua
@@ -6,6 +6,7 @@ local function buildSummary()
         summary[id] = summary[id] or {
             player = name or "",
             steamID = id,
+            usergroup = "",
             warnings = 0,
             tickets = 0,
             kicks = 0,
@@ -27,48 +28,58 @@ local function buildSummary()
                 entry.warnings = tonumber(row.count) or 0
             end
         end
-        lia.db.query([[SELECT admin AS name, adminSteamID AS steamID, COUNT(*) AS count FROM lia_ticketclaims GROUP BY adminSteamID]], function(ticketRows)
-            for _, row in ipairs(ticketRows or {}) do
-                local steamID = row.steamID or row.adminSteamID
-                if steamID and steamID ~= "" then
-                    local entry = ensureEntry(steamID, row.name)
-                    entry.tickets = tonumber(row.count) or 0
-                end
-            end
-            lia.db.query([[SELECT staffName AS name, staffSteamID AS steamID, action, COUNT(*) AS count FROM lia_staffactions GROUP BY staffSteamID, action]], function(actionRows)
-                for _, row in ipairs(actionRows or {}) do
-                    local steamID = row.steamID or row.staffSteamID
+            lia.db.query([[SELECT admin AS name, adminSteamID AS steamID, COUNT(*) AS count FROM lia_ticketclaims GROUP BY adminSteamID]], function(ticketRows)
+                for _, row in ipairs(ticketRows or {}) do
+                    local steamID = row.steamID or row.adminSteamID
                     if steamID and steamID ~= "" then
                         local entry = ensureEntry(steamID, row.name)
-                        local count = tonumber(row.count) or 0
-                        if row.action == "plykick" then entry.kicks = count
-                        elseif row.action == "plykill" then entry.kills = count
-                        elseif row.action == "plyrespawn" then entry.respawns = count
-                        elseif row.action == "plyblind" then entry.blinds = count
-                        elseif row.action == "plymute" then entry.mutes = count
-                        elseif row.action == "plyjail" then entry.jails = count
-                        elseif row.action == "plystrip" then entry.strips = count
-                        end
+                        entry.tickets = tonumber(row.count) or 0
                     end
                 end
-                local list = {}
-                for _, info in pairs(summary) do
-                    info.warnings = info.warnings or 0
-                    info.tickets = info.tickets or 0
-                    info.kicks = info.kicks or 0
-                    info.kills = info.kills or 0
-                    info.respawns = info.respawns or 0
-                    info.blinds = info.blinds or 0
-                    info.mutes = info.mutes or 0
-                    info.jails = info.jails or 0
-                    info.strips = info.strips or 0
-                    list[#list + 1] = info
-                end
-                d:resolve(list)
-            end)
-        end)
-    end)
-    return d
+                lia.db.query([[SELECT staffName AS name, staffSteamID AS steamID, action, COUNT(*) AS count FROM lia_staffactions GROUP BY staffSteamID, action]], function(actionRows)
+                    for _, row in ipairs(actionRows or {}) do
+                        local steamID = row.steamID or row.staffSteamID
+                        if steamID and steamID ~= "" then
+                            local entry = ensureEntry(steamID, row.name)
+                            local count = tonumber(row.count) or 0
+                            if row.action == "plykick" then entry.kicks = count
+                            elseif row.action == "plykill" then entry.kills = count
+                            elseif row.action == "plyrespawn" then entry.respawns = count
+                            elseif row.action == "plyblind" then entry.blinds = count
+                            elseif row.action == "plymute" then entry.mutes = count
+                            elseif row.action == "plyjail" then entry.jails = count
+                            elseif row.action == "plystrip" then entry.strips = count
+                            end
+                        end
+                    end
+                    lia.db.query([[SELECT steamName AS name, steamID, userGroup FROM lia_players]], function(playerRows)
+                        for _, row in ipairs(playerRows or {}) do
+                            local steamID = row.steamID
+                            if steamID and steamID ~= "" then
+                                local entry = ensureEntry(steamID, row.name)
+                                entry.usergroup = row.userGroup or ""
+                            end
+                        end
+                        local list = {}
+                        for _, info in pairs(summary) do
+                            info.warnings = info.warnings or 0
+                            info.tickets = info.tickets or 0
+                            info.kicks = info.kicks or 0
+                            info.kills = info.kills or 0
+                            info.respawns = info.respawns or 0
+                            info.blinds = info.blinds or 0
+                            info.mutes = info.mutes or 0
+                            info.jails = info.jails or 0
+                            info.strips = info.strips or 0
+                            info.usergroup = info.usergroup or ""
+                            list[#list + 1] = info
+                        end
+                        d:resolve(list)
+                      end)
+                  end)
+              end)
+          end)
+      return d
 end
 net.Receive("liaRequestStaffSummary", function(_, client)
     if not client:hasPrivilege("View Staff Management") then return end


### PR DESCRIPTION
## Summary
- show each staff member's usergroup in the staff action summary
- fetch usergroup info from the database when building the summary

## Testing
- `luacheck gamemode/modules/administration/submodules/staffmanagement/libraries/server.lua gamemode/modules/administration/submodules/staffmanagement/libraries/client.lua`

------
https://chatgpt.com/codex/tasks/task_e_688efb7682e88327b647ae14bbbb7b07