### PR TITLE
Enable kicking players from faction management

### DIFF
--- a/gamemode/modules/administration/submodules/factions/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/factions/libraries/client.lua
@@ -21,16 +21,24 @@ local function OpenRoster(panel, data)
             list:Clear()
             filter = string.lower(filter or "")
             for _, member in ipairs(members) do
-                if filter == "" or string.lower(member):find(filter, 1, true) then
-                    list:AddLine(member)
+                if filter == "" or string.lower(member.name):find(filter, 1, true) then
+                    local line = list:AddLine(member.name)
+                    line.rowData = member
                 end
             end
         end
         search.OnChange = function() populate(search:GetValue()) end
         populate("")
         function list:OnRowRightClick(_, line)
-            if not IsValid(line) then return end
+            if not IsValid(line) or not line.rowData then return end
             local menu = DermaMenu()
+            menu:AddOption(L("kick"), function()
+                Derma_Query(L("kickConfirm"), L("confirm"), L("yes"), function()
+                    net.Start("KickCharacter")
+                    net.WriteInt(line.rowData.id, 32)
+                    net.SendToServer()
+                end, L("no"))
+            end):SetIcon("icon16/user_delete.png")
             menu:AddOption(L("copyRow"), function()
                 local rowString = ""
                 for i, column in ipairs(self.Columns or {}) do

--- a/gamemode/modules/administration/submodules/factions/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/factions/libraries/server.lua
@@ -4,7 +4,10 @@ local function SendRoster(client)
     for _, faction in pairs(lia.faction.indices) do
         local members = {}
         for _, ply in ipairs(lia.faction.getPlayers(faction.index)) do
-            members[#members + 1] = ply:Name()
+            local char = ply:getChar()
+            if char then
+                members[#members + 1] = {name = ply:Name(), id = char:getID()}
+            end
         end
         data[faction.name] = members
     end


### PR DESCRIPTION
## Summary
- Send character IDs in faction management roster data
- Add UI action to kick players from faction management, moving them to default faction
- Allow privileged administrators to kick characters across factions

## Testing
- `luacheck gamemode/modules/administration/submodules/factions/libraries/server.lua gamemode/modules/administration/submodules/factions/libraries/client.lua gamemode/modules/teams/libraries/server.lua`

------
https://chatgpt.com/codex/tasks/task_e_688efb7f6928832788546b5e3eb6df22