### PR TITLE
Add modify flags option to admin stick

### DIFF
--- a/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
@@ -447,6 +447,19 @@ local function IncludeFlagManagement(tgt, menu, stores)
             AdminStickIsOpen = false
         end):SetIcon(f.icon)
     end
+
+    fm:AddOption(L("modifyFlags"), function()
+        local char = tgt:getChar()
+        local currentFlags = char and char:getFlags() or ""
+        cl:requestString(L("modifyFlags"), L("modifyFlagsDesc"), function(text)
+            text = string.gsub(text or "", "%s", "")
+            net.Start("liaModifyFlags")
+            net.WriteString(tgt:SteamID())
+            net.WriteString(text)
+            net.SendToServer()
+        end, currentFlags)
+        AdminStickIsOpen = false
+    end):SetIcon("icon16/flag_orange.png")
 end
 
 local function AddCommandToMenu(menu, data, key, tgt, name, stores)


### PR DESCRIPTION
## Summary
- allow admins to modify a player's entire flag string from the admin stick menu

## Testing
- `luacheck gamemode/modules/administration/submodules/adminstick/libraries/client.lua`

------
https://chatgpt.com/codex/tasks/task_e_688f001a17948327908e012a5305ac30