### PR TITLE
feat(admin): expand player context options

### DIFF
--- a/gamemode/modules/administration/submodules/factions/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/factions/libraries/server.lua
@@ -6,7 +6,7 @@ local function SendRoster(client)
         for _, ply in ipairs(lia.faction.getPlayers(faction.index)) do
             local char = ply:getChar()
             if char then
-                members[#members + 1] = {name = ply:Name(), id = char:getID()}
+                members[#members + 1] = {name = ply:Name(), id = char:getID(), steamID = ply:SteamID()}
             end
         end
         data[faction.name] = members


### PR DESCRIPTION
## Summary
- allow admin player and faction lists to copy steam IDs and open Steam profiles
- centralize character list requests for reuse

## Testing
- `luacheck gamemode/modules/administration/submodules/players/module.lua gamemode/modules/administration/submodules/factions/libraries/client.lua gamemode/modules/administration/submodules/factions/libraries/server.lua` *(fails: command not found: luacheck)*

------
https://chatgpt.com/codex/tasks/task_e_688f00166e788327858f99e6cb195ba8