### PR TITLE
Filter charlist to show only online characters

### DIFF
--- a/gamemode/modules/administration/submodules/permissions/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/client.lua
@@ -112,10 +112,6 @@ net.Receive("DisplayCharList", function()
 
     local columns = {
         {
-            name = L("id"),
-            field = "ID"
-        },
-        {
             name = L("name"),
             field = "Name"
         },
@@ -176,7 +172,7 @@ net.Receive("DisplayCharList", function()
 
             line.CharID = rowData and rowData.ID
             if rowData and rowData.extraDetails then
-                local colIndex = 11
+                local colIndex = 10
                 for _, name in ipairs(extraOrder) do
                     line:SetColumnText(colIndex, tostring(rowData.extraDetails[name] or ""))
                     colIndex = colIndex + 1


### PR DESCRIPTION
## Summary
- show only online characters in admin charlist and use players' current in-game names
- drop the character ID column from the charlist UI

## Testing
- `luacheck gamemode/modules/administration/commands.lua gamemode/modules/administration/submodules/permissions/libraries/client.lua` *(fails: expected '=' near 'end')*

------
https://chatgpt.com/codex/tasks/task_e_688f000e15e88327bb2c06bb4c808845