### PR TITLE
feat: add session time player function

### DIFF
--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -734,6 +734,10 @@ if SERVER then
         return diff + RealTime() - (self.liaJoinTime or RealTime())
     end
 
+    function playerMeta:getSessionTime()
+        return RealTime() - (self.liaJoinTime or RealTime())
+    end
+
     function playerMeta:getTotalOnlineTime()
         local stored = self:getLiliaData("totalOnlineTime", 0)
         return stored + RealTime() - (self.liaJoinTime or RealTime())


### PR DESCRIPTION
## Summary
- add `Player:getSessionTime` for the time in the current session

## Testing
- `luacheck .` (fails: accessing undefined variable net, 12247 warnings / 21 errors in 267 files)


------
https://chatgpt.com/codex/tasks/task_e_688f0117c3488327abc73c02513b1e6f