### PR TITLE
Remove CAMI admin logs

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -277,7 +277,6 @@ function lia.administrator.createGroup(groupName, info)
     lia.administrator.groups[groupName] = info
     lia.administrator.applyInheritance(groupName)
     camiRegisterUsergroup(groupName, info._info.inheritance or "user")
-    if CAMI then lia.admin(string.format("[CAMI] Usergroup created: %s inherits %s", groupName, info._info.inheritance or "user")) end
     hook.Run("OnUsergroupCreated", groupName, lia.administrator.groups[groupName])
     if SERVER then lia.administrator.save() end
 end
@@ -295,7 +294,6 @@ function lia.administrator.removeGroup(groupName)
 
     lia.administrator.groups[groupName] = nil
     camiUnregisterUsergroup(groupName)
-    if CAMI then lia.admin(string.format("[CAMI] Usergroup removed: %s", groupName)) end
     hook.Run("OnUsergroupRemoved", groupName)
     if SERVER then lia.administrator.save() end
 end
@@ -322,7 +320,6 @@ function lia.administrator.renameGroup(oldName, newName)
     camiUnregisterUsergroup(oldName)
     local inh = lia.administrator.groups[newName]._info and lia.administrator.groups[newName]._info.inheritance or "user"
     camiRegisterUsergroup(newName, inh)
-    if CAMI then lia.admin(string.format("[CAMI] Usergroup renamed: %s -> %s", oldName, newName)) end
     hook.Run("OnUsergroupRenamed", oldName, newName)
     if SERVER then lia.administrator.save() end
 end
@@ -416,10 +413,7 @@ if SERVER then
         local new = tostring(newGroup or "user")
         if old == new then return end
         ply:SetUserGroup(new)
-        if CAMI then
-            CAMI.SignalUserGroupChanged(ply, old, new, source or "Lilia")
-            lia.admin(string.format("[CAMI] Player usergroup changed: %s (%s) %s -> %s", ply:Nick(), ply:SteamID(), old, new))
-        end
+        if CAMI then CAMI.SignalUserGroupChanged(ply, old, new, source or "Lilia") end
     end
 
     function lia.administrator.setSteamIDUsergroup(steamId, newGroup, source)
@@ -429,10 +423,7 @@ if SERVER then
         local old = IsValid(ply) and tostring(ply:GetUserGroup() or "user") or "user"
         local new = tostring(newGroup or "user")
         if IsValid(ply) then ply:SetUserGroup(new) end
-        if CAMI then
-            CAMI.SignalSteamIDUserGroupChanged(sid, old, new, source or "Lilia")
-            lia.admin(string.format("[CAMI] SteamID usergroup changed: %s %s -> %s", sid, old, new))
-        end
+        if CAMI then CAMI.SignalSteamIDUserGroupChanged(sid, old, new, source or "Lilia") end
     end
 else
     function lia.administrator.execCommand(cmd, victim, dur, reason)

--- a/gamemode/core/libraries/compatibility/cami.lua
+++ b/gamemode/core/libraries/compatibility/cami.lua
@@ -23,12 +23,6 @@ local function defaultAccessHandler(actor, privilege, callback, _, extra)
 
     if istable(extra) and (extra.isUse or extra.IsUse or extra.use) then if IsValid(actor) and actor:IsFrozen() then allow = false end end
     if isfunction(callback) then callback(allow, "lia") end
-    if IsValid(actor) then
-        local who = string.format("%s (%s)", actor:Nick(), actor:SteamID())
-        lia.admin(string.format("[CAMI] Access check: %s privilege=\"%s\" allow=%s", who, tostring(privilege), tostring(allow)))
-    else
-        lia.admin(string.format("[CAMI] Access check: non-player privilege=\"%s\" allow=%s", tostring(privilege), tostring(allow)))
-    end
     return true
 end
 
@@ -52,7 +46,6 @@ hook.Add("CAMI.OnUsergroupRegistered", "liaAdminUGAdded", function(usergroup, so
         end
     end
 
-    lia.admin(string.format("[CAMI] OnUsergroupRegistered: %s inherits %s (source=%s)", n, ug.Inherits or "user", tostring(source)))
 end)
 
 hook.Add("CAMI.OnUsergroupUnregistered", "liaAdminUGRemoved", function(usergroup, source)
@@ -67,7 +60,6 @@ hook.Add("CAMI.OnUsergroupUnregistered", "liaAdminUGRemoved", function(usergroup
         end
     end
 
-    lia.admin(string.format("[CAMI] OnUsergroupUnregistered: %s (source=%s)", n, tostring(source)))
 end)
 
 hook.Add("CAMI.OnPrivilegeRegistered", "liaAdminPrivAdded", function(priv)
@@ -86,7 +78,6 @@ hook.Add("CAMI.OnPrivilegeRegistered", "liaAdminPrivAdded", function(priv)
         lia.administrator.sync()
     end
 
-    lia.admin(string.format("[CAMI] OnPrivilegeRegistered: %s min=%s", name, min))
 end)
 
 hook.Add("CAMI.OnPrivilegeUnregistered", "liaAdminPrivRemoved", function(priv)
@@ -104,7 +95,6 @@ hook.Add("CAMI.OnPrivilegeUnregistered", "liaAdminPrivRemoved", function(priv)
         lia.administrator.sync()
     end
 
-    lia.admin(string.format("[CAMI] OnPrivilegeUnregistered: %s", name))
 end)
 
 hook.Add("CAMI.PlayerUsergroupChanged", "liaAdminPlyUGChanged", function(ply, old, new, source)
@@ -112,7 +102,6 @@ hook.Add("CAMI.PlayerUsergroupChanged", "liaAdminPlyUGChanged", function(ply, ol
     local newGroup = tostring(new or "user")
     if tostring(ply:GetUserGroup() or "user") ~= newGroup then ply:SetUserGroup(newGroup) end
     lia.db.query(Format("UPDATE lia_players SET userGroup = '%s' WHERE steamID = %s", lia.db.escape(newGroup), ply:SteamID64()))
-    lia.admin(string.format("[CAMI] PlayerUsergroupChanged: %s (%s) %s -> %s (source=%s)", ply:Nick(), ply:SteamID(), tostring(old or "user"), newGroup, tostring(source)))
 end)
 
 hook.Add("CAMI.SteamIDUsergroupChanged", "liaAdminSIDUGChanged", function(steamId, old, new, source)
@@ -123,5 +112,4 @@ hook.Add("CAMI.SteamIDUsergroupChanged", "liaAdminSIDUGChanged", function(steamI
     if IsValid(ply) and tostring(ply:GetUserGroup() or "user") ~= newGroup then ply:SetUserGroup(newGroup) end
     local steam64 = util.SteamIDTo64(sid)
     lia.db.query(Format("UPDATE lia_players SET userGroup = '%s' WHERE steamID = %s", lia.db.escape(newGroup), steam64))
-    lia.admin(string.format("[CAMI] SteamIDUsergroupChanged: %s %s -> %s (source=%s)", sid, tostring(old or "user"), newGroup, tostring(source)))
 end)

--- a/gamemode/core/libraries/compatibility/sam.lua
+++ b/gamemode/core/libraries/compatibility/sam.lua
@@ -156,13 +156,11 @@ hook.Add("SAM.RankPermissionGiven", "liaSAMHandlePermissionGiven", function(rank
     end
 
     if SERVER then lia.administrator.addPermission(rankName, permission, true) end
-    lia.admin(string.format("[CAMI] Permission '%s' granted to rank '%s'", permission, rankName))
 end)
 
 hook.Add("SAM.RankPermissionTaken", "liaSAMHandlePermissionTaken", function(rankName, permission)
     if not rankName or not permission then return end
     if SERVER then lia.administrator.removePermission(rankName, permission, true) end
-    lia.admin(string.format("[CAMI] Permission '%s' revoked from rank '%s'", permission, rankName))
 end)
 
 lia.command.add("cleardecals", {

--- a/gamemode/core/libraries/compatibility/serverguard.lua
+++ b/gamemode/core/libraries/compatibility/serverguard.lua
@@ -138,13 +138,11 @@ hook.Add("serverguard.RankPermissionGiven", "liaServerGuardHandlePermissionGiven
     end
 
     if SERVER then lia.administrator.addPermission(rankName, permission, true) end
-    lia.admin(string.format("[CAMI] Permission '%s' granted to rank '%s'", permission, rankName))
 end)
 
 hook.Add("serverguard.RankPermissionTaken", "liaServerGuardHandlePermissionTaken", function(rankName, permission)
     if not rankName or not permission then return end
     if SERVER then lia.administrator.removePermission(rankName, permission, true) end
-    lia.admin(string.format("[CAMI] Permission '%s' revoked from rank '%s'", permission, rankName))
 end)
 
 hook.Add("CAMI.OnPrivilegeRegistered", "serverguard.CAMI.OnPrivilegeRegistered", OnPrivilegeRegistered)

--- a/gamemode/core/libraries/compatibility/ulx.lua
+++ b/gamemode/core/libraries/compatibility/ulx.lua
@@ -9,10 +9,8 @@ hook.Add("ULibGroupAccessChanged", "liaULXCAMI", function(group_name, access, re
         end
 
         if SERVER then lia.administrator.addPermission(group_name, access, true) end
-        lia.admin(string.format("[CAMI] Permission '%s' granted to group '%s'", access, group_name))
     else
         if SERVER then lia.administrator.removePermission(group_name, access, true) end
-        if CAMI then lia.admin(string.format("[CAMI] Permission '%s' revoked from group '%s'", access, group_name)) end
     end
 end)
 


### PR DESCRIPTION
## Summary
- strip CAMI-related admin logging from compatibility hooks and admin library

## Testing
- `luac -p gamemode/core/libraries/compatibility/ulx.lua`
- `luac -p gamemode/core/libraries/compatibility/serverguard.lua`
- `luac -p gamemode/core/libraries/compatibility/cami.lua`
- `luac -p gamemode/core/libraries/compatibility/sam.lua` (fails: unexpected symbol near '')
- `luac -p gamemode/core/libraries/admin.lua` (fails: unexpected symbol near '')

------
https://chatgpt.com/codex/tasks/task_e_688f04c86d108327b344bc5f6e0167ec