### PR TITLE
Strip lia prefix from database sheet labels

### DIFF
--- a/gamemode/modules/administration/submodules/database/module.lua
+++ b/gamemode/modules/administration/submodules/database/module.lua
@@ -74,7 +74,8 @@ else
                                 list:AddLine(unpack(lineData))
                             end
                         end
-                        self.sheet:AddSheet(tbl, pnl)
+                        local sheetName = tbl:gsub("^lia_", "")
+                        self.sheet:AddSheet(sheetName, pnl)
                     end
                 end
                 net.Start("liaRequestDatabaseView")


### PR DESCRIPTION
## Summary
- Remove `lia_` prefix from displayed sheet names in Database View

## Testing
- `luacheck gamemode/modules/administration/submodules/database/module.lua`


------
https://chatgpt.com/codex/tasks/task_e_688f05521b4c8327a3d2e4cf24ffb2c8