### PR TITLE
fix: avoid client requestString call

### DIFF
--- a/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
@@ -451,13 +451,13 @@ local function IncludeFlagManagement(tgt, menu, stores)
     fm:AddOption(L("modifyFlags"), function()
         local char = tgt:getChar()
         local currentFlags = char and char:getFlags() or ""
-        cl:requestString(L("modifyFlags"), L("modifyFlagsDesc"), function(text)
+        Derma_StringRequest(L("modifyFlags"), L("modifyFlagsDesc"), currentFlags, function(text)
             text = string.gsub(text or "", "%s", "")
             net.Start("liaModifyFlags")
             net.WriteString(tgt:SteamID())
             net.WriteString(text)
             net.SendToServer()
-        end, currentFlags)
+        end)
         AdminStickIsOpen = false
     end):SetIcon("icon16/flag_orange.png")
 end

--- a/gamemode/modules/administration/submodules/flags/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/flags/libraries/client.lua
@@ -61,14 +61,14 @@ lia.net.readBigTable("liaAllFlags", function(data)
         menu:AddOption(L("modifyFlags"), function()
             local steamID = line:GetColumnText(2) or ""
             local currentFlags = line:GetColumnText(3) or ""
-            LocalPlayer():requestString(L("modifyFlags"), L("modifyFlagsDesc"), function(text)
+            Derma_StringRequest(L("modifyFlags"), L("modifyFlagsDesc"), currentFlags, function(text)
                 text = string.gsub(text or "", "%s", "")
                 net.Start("liaModifyFlags")
                 net.WriteString(steamID)
                 net.WriteString(text)
                 net.SendToServer()
                 line:SetColumnText(3, text)
-            end, currentFlags)
+            end)
         end):SetIcon("icon16/flag_orange.png")
         menu:Open()
     end


### PR DESCRIPTION
## Summary
- avoid calling server-side `requestString` from client flag UIs by using `Derma_StringRequest`

## Testing
- `luacheck gamemode/modules/administration/submodules/flags/libraries/client.lua gamemode/modules/administration/submodules/adminstick/libraries/client.lua | tail -n 2`


------
https://chatgpt.com/codex/tasks/task_e_688f05252fd0832799ceed473dcd8187