### PR TITLE
feat: track character playtime

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -1,6 +1,12 @@
 ﻿local GM = GM or GAMEMODE
 function GM:CharPreSave(character)
     local client = character:getPlayer()
+    local loginTime = character:getLoginTime()
+    if loginTime and loginTime > 0 then
+        local total = character:getPlayTime()
+        character:setPlayTime(total + os.time() - loginTime)
+        character:setLoginTime(os.time())
+    end
     if not character:getInv() then return end
     for _, v in pairs(character:getInv():getItems()) do
         if v.OnSave then v:call("OnSave", client) end

--- a/gamemode/core/libraries/character.lua
+++ b/gamemode/core/libraries/character.lua
@@ -320,6 +320,14 @@ lia.char.registerVar("loginTime", {
     noDisplay = true
 })
 
+lia.char.registerVar("playTime", {
+    field = "playtime",
+    fieldType = "integer",
+    default = 0,
+    isLocal = true,
+    noDisplay = true
+})
+
 lia.char.registerVar("var", {
     default = {},
     noDisplay = true,

--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -730,6 +730,11 @@ if SERVER then
     function playerMeta:getPlayTime()
         local hookResult = hook.Run("getPlayTime", self)
         if hookResult ~= nil then return hookResult end
+        local char = self:getChar()
+        if char then
+            local loginTime = char:getLoginTime() or os.time()
+            return char:getPlayTime() + os.time() - loginTime
+        end
         local diff = os.time(lia.time.toNumber(self.lastJoin)) - os.time(lia.time.toNumber(self.firstJoin))
         return diff + RealTime() - (self.liaJoinTime or RealTime())
     end
@@ -937,6 +942,11 @@ else
     function playerMeta:getPlayTime()
         local hookResult = hook.Run("getPlayTime", self)
         if hookResult ~= nil then return hookResult end
+        local char = self:getChar()
+        if char then
+            local loginTime = char:getLoginTime() or os.time()
+            return char:getPlayTime() + os.time() - loginTime
+        end
         local diff = os.time(lia.time.toNumber(lia.lastJoin)) - os.time(lia.time.toNumber(lia.firstJoin))
         return diff + RealTime() - (lia.joinTime or 0)
     end


### PR DESCRIPTION
## Summary
- track playtime per character using new `playTime` variable
- accumulate session time during character saves
- compute playtime from character data on players

## Testing
- `luacheck gamemode/core/libraries/character.lua gamemode/core/hooks/server.lua gamemode/core/meta/player.lua` *(errors: "expected '=' near 'end'")*

------
https://chatgpt.com/codex/tasks/task_e_688f04ea7f1c832793447095e2843bb7