### PR TITLE
feat: expand charlist info

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -450,6 +450,7 @@ LANGUAGE = {
     cleaningFinished = "You cleaned up %s: %s entities removed.",
     invalidTarget = "Invalid Target!",
     money = "Money",
+    playtime = "Playtime",
     noRagdoll = "You don't have a ragdoll to get up from!",
     invCheckSelf = "This isn't meant for checking your own inventory.",
     noBodygroups = "No bodygroups available for this model.",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -450,6 +450,7 @@ LANGUAGE = {
     cleaningFinished = "Nettoyage : %s entités supprimées.",
     invalidTarget = "Cible invalide !",
     money = "Argent",
+    playtime = "Temps de jeu",
     noRagdoll = "Aucun ragdoll.",
     invCheckSelf = "Pas pour votre propre inventaire.",
     noBodygroups = "Aucun bodygroup.",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -450,6 +450,7 @@ LANGUAGE = {
     cleaningFinished = "Hai pulito %s: %s entità rimosse.",
     invalidTarget = "Target non valido!",
     money = "Denaro",
+    playtime = "Tempo di gioco",
     noRagdoll = "Non hai un ragdoll da cui alzarti!",
     invCheckSelf = "Non è pensato per controllare il tuo stesso inventario.",
     noBodygroups = "Nessun bodygroup disponibile per questo modello.",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -450,6 +450,7 @@ LANGUAGE = {
     cleaningFinished = "Limpeza concluída: %s entidades removidas.",
     invalidTarget = "Alvo inválido!",
     money = "Dinheiro",
+    playtime = "Tempo de jogo",
     noRagdoll = "Não tens ragdoll para te levantares!",
     invCheckSelf = "Não serve para veres o teu inventário.",
     noBodygroups = "Sem bodygroups para este modelo.",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -450,6 +450,7 @@ LANGUAGE = {
     cleaningFinished = "Очистка %s завершена: удалено сущностей %s.",
     invalidTarget = "Неверная цель!",
     money = "Деньги",
+    playtime = "Время в игре",
     noRagdoll = "У вас нет регдолла!",
     invCheckSelf = "Не для проверки своего инвентаря.",
     noBodygroups = "Нет бодигрупп для этой модели.",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -450,6 +450,7 @@ LANGUAGE = {
     cleaningFinished = "Limpiaste %s: %s entidades.",
     invalidTarget = "Objetivo inválido",
     money = "Dinero",
+    playtime = "Tiempo de juego",
     noRagdoll = "No tienes ragdoll.",
     invCheckSelf = "No se usa para tu inventario.",
     noBodygroups = "Sin bodygroups.",


### PR DESCRIPTION
## Summary
- show playtime and money in admin character list
- allow addons to extend charlist data and columns
- add playtime translation across locales

## Testing
- `luac -p gamemode/modules/administration/submodules/charlist/module.lua gamemode/languages/english.lua gamemode/languages/french.lua gamemode/languages/italian.lua gamemode/languages/portuguese.lua gamemode/languages/russian.lua gamemode/languages/spanish.lua`


------
https://chatgpt.com/codex/tasks/task_e_688f0684045c8327966d44c7a03e70ca