### PR TITLE
Remove lingering delete character confirmation popup

### DIFF
--- a/gamemode/core/derma/mainmenu/character.lua
+++ b/gamemode/core/derma/mainmenu/character.lua
@@ -301,6 +301,7 @@ end
 
 function PANEL:backToMainMenu()
     self:clickSound()
+    if IsValid(lia.gui.charConfirm) then lia.gui.charConfirm:Remove() end
     if IsValid(self.infoFrame) then self.infoFrame:Remove() end
     if IsValid(self.leftArrow) then
         self.leftArrow:Remove()


### PR DESCRIPTION
## Summary
- ensure delete-character confirmation is removed when returning to the main menu

## Testing
- `tail -c +4 gamemode/core/derma/mainmenu/character.lua | luac -p -`


------
https://chatgpt.com/codex/tasks/task_e_688f079770888327b14c083a4c0acd13