### PR TITLE
Fix opening Steam profiles from player tab

### DIFF
--- a/gamemode/modules/administration/submodules/players/module.lua
+++ b/gamemode/modules/administration/submodules/players/module.lua
@@ -93,7 +93,12 @@ if CLIENT then
                 end):SetIcon("icon16/page_copy.png")
 
                 menu:AddOption(L("copySteamID", "Copy SteamID"), function() SetClipboardText(steamID) end):SetIcon("icon16/page_copy.png")
-                menu:AddOption(L("openSteamProfile", "Open Steam Profile"), function() gui.OpenURL("https://steamcommunity.com/profiles/" .. util.SteamIDTo64(steamID)) end):SetIcon("icon16/world.png")
+                menu:AddOption(L("openSteamProfile", "Open Steam Profile"), function()
+                    local steamID64 = util.SteamIDTo64(steamID)
+                    if steamID64 and steamID64 ~= "0" then
+                        steamworks.ViewPlayerProfile(steamID64)
+                    end
+                end):SetIcon("icon16/world.png")
             end)
         end
     end)


### PR DESCRIPTION
## Summary
- Ensure "Open Steam Profile" uses Steam overlay via `steamworks.ViewPlayerProfile`

## Testing
- `luac -p gamemode/modules/administration/submodules/players/module.lua`


------
https://chatgpt.com/codex/tasks/task_e_688f07784f0883279ec1f1eb5a829f9b