### PR TITLE
Show only online player sheets in charlist

### DIFF
--- a/gamemode/modules/administration/submodules/charlist/module.lua
+++ b/gamemode/modules/administration/submodules/charlist/module.lua
@@ -147,13 +147,14 @@ else
                     self.sheet:AddSheet(L("allCharacters"), allPanel)
 
                     for steamID, chars in pairs(data.players or {}) do
-                        local pnl = self.sheet:Add("DPanel")
-                        pnl:Dock(FILL)
-                        pnl.Paint = function() end
-                        createList(pnl, chars)
                         local ply = lia.util.getBySteamID(steamID)
-                        local title = IsValid(ply) and ply:Nick() or steamID
-                        self.sheet:AddSheet(title, pnl)
+                        if IsValid(ply) then
+                            local pnl = self.sheet:Add("DPanel")
+                            pnl:Dock(FILL)
+                            pnl.Paint = function() end
+                            createList(pnl, chars)
+                            self.sheet:AddSheet(ply:Nick(), pnl)
+                        end
                     end
                 end
 


### PR DESCRIPTION
## Summary
- Filter charlist tabs to include only online players
- Name player tabs using in-game nicknames

## Testing
- `luacheck gamemode/modules/administration/submodules/charlist/module.lua` *(fails: 59 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688f08f880b083279c5db237800add60