### PR TITLE
Add detailed roster entries

### DIFF
--- a/gamemode/modules/administration/submodules/factions/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/factions/libraries/client.lua
@@ -30,12 +30,16 @@ local function OpenRoster(panel, data)
         list:Dock(FILL)
         list:SetMultiSelect(false)
         list:AddColumn(L("name", "Name"))
+        list:AddColumn(L("steamID", "SteamID"))
+        list:AddColumn(L("class", "Class"))
+        list:AddColumn(L("playtime", "Playtime"))
+        list:AddColumn(L("lastOnline", "Last Online"))
         local function populate(filter)
             list:Clear()
             filter = string.lower(filter or "")
             for _, member in ipairs(members) do
                 if filter == "" or string.lower(member.name):find(filter, 1, true) then
-                    local line = list:AddLine(member.name)
+                    local line = list:AddLine(member.name, member.steamID or "", member.class or L("none"), member.playTime or "", member.lastOnline or "")
                     line.rowData = member
                 end
             end

--- a/gamemode/modules/administration/submodules/factions/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/factions/libraries/server.lua
@@ -1,17 +1,72 @@
+local function formatDHM(seconds)
+    seconds = math.max(seconds or 0, 0)
+    local days = math.floor(seconds / 86400)
+    seconds = seconds % 86400
+    local hours = math.floor(seconds / 3600)
+    seconds = seconds % 3600
+    local minutes = math.floor(seconds / 60)
+    return L("daysHoursMinutes", days, hours, minutes)
+end
+
 local function SendRoster(client)
     if not IsValid(client) or not client:hasPrivilege("Can Manage Factions") then return end
     local data = {}
+    local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
+    local pending = 0
     for _, faction in pairs(lia.faction.indices) do
-        local members = {}
-        for _, ply in ipairs(lia.faction.getPlayers(faction.index)) do
-            local char = ply:getChar()
-            if char then
-                members[#members + 1] = {name = ply:Name(), id = char:getID(), steamID = ply:SteamID()}
+        pending = pending + 1
+        local fields = table.concat({
+            "lia_characters.name",
+            "lia_characters.id",
+            "lia_characters.steamID",
+            "lia_characters.playtime",
+            "lia_characters.lastJoinTime",
+            "lia_players.lastOnline",
+            "lia_characters._class"
+        }, ",")
+        local condition = "lia_characters.schema = '" .. lia.db.escape(gamemode) .. "' AND lia_characters.faction = " .. lia.db.convertDataType(faction.uniqueID)
+        local query = "SELECT " .. fields .. " FROM lia_characters LEFT JOIN lia_players ON lia_characters.steamID = lia_players.steamID WHERE " .. condition
+        lia.db.query(query, function(result)
+            local members = {}
+            if result then
+                for _, v in ipairs(result) do
+                    local charID = tonumber(v.id)
+                    local isOnline = lia.char.loaded[charID] ~= nil
+                    local lastOnlineText
+                    if isOnline then
+                        lastOnlineText = L("onlineNow")
+                    else
+                        local last = tonumber(v.lastOnline)
+                        if not isnumber(last) then last = os.time(lia.time.toNumber(v.lastJoinTime)) end
+                        local lastDiff = os.time() - last
+                        local timeSince = lia.time.TimeSince(last)
+                        local timeStripped = timeSince:match("^(.-)%sago$") or timeSince
+                        lastOnlineText = string.format(L("agoFormat"), timeStripped, formatDHM(lastDiff))
+                    end
+
+                    local classID = tonumber(v._class) or 0
+                    local classData = lia.class.list[classID]
+                    members[#members + 1] = {
+                        name = v.name,
+                        id = charID,
+                        steamID = v.steamID,
+                        class = classData and classData.name or L("none"),
+                        playTime = formatDHM(tonumber(v.playtime) or 0),
+                        lastOnline = lastOnlineText
+                    }
+                end
             end
-        end
-        data[faction.name] = members
+
+            data[faction.name] = members
+            pending = pending - 1
+            if pending <= 0 then
+                lia.net.writeBigTable(client, "liaFactionRosterData", data)
+            end
+        end)
     end
-    lia.net.writeBigTable(client, "liaFactionRosterData", data)
+    if pending == 0 then
+        lia.net.writeBigTable(client, "liaFactionRosterData", data)
+    end
 end
 
 net.Receive("liaRequestFactionRoster", function(_, client)

--- a/gamemode/modules/teams/commands.lua
+++ b/gamemode/modules/teams/commands.lua
@@ -57,7 +57,7 @@ lia.command.add("roster", {
 
         local isLeader = client:hasPrivilege("Manage Faction Members") or character:hasFlags("V")
         if not isLeader then return end
-        local fields = "lia_characters.name, lia_characters.faction, lia_characters.id, lia_characters.steamID, lia_characters.lastJoinTime, lia_players.totalOnlineTime, lia_players.lastOnline, lia_characters._class"
+        local fields = "lia_characters.name, lia_characters.faction, lia_characters.id, lia_characters.steamID, lia_characters.lastJoinTime, lia_players.lastOnline, lia_characters._class, lia_characters.playtime"
         if not character then
             client:notifyLocalized("charDataMissingClient", client:Name())
             return
@@ -104,8 +104,8 @@ lia.command.add("roster", {
                         faction = v.faction,
                         steamID = v.steamID,
                         class = classData and classData.name or L("none"),
-                        lastOnline = lastOnlineText,
-                        hoursPlayed = formatDHM(tonumber(v.totalOnlineTime) or 0)
+                        playTime = formatDHM(tonumber(v.playtime) or 0),
+                        lastOnline = lastOnlineText
                     })
                 end
             else
@@ -125,7 +125,7 @@ lia.command.add("factionmanagement", {
     desc = "factionManagementDesc",
     syntax = "[faction Faction]",
     onRun = function(client, arguments)
-        local fields = "lia_characters.name, lia_characters.faction, lia_characters.id, lia_characters.steamID, lia_characters.lastJoinTime, lia_players.totalOnlineTime, lia_players.lastOnline, lia_characters._class"
+        local fields = "lia_characters.name, lia_characters.faction, lia_characters.id, lia_characters.steamID, lia_characters.lastJoinTime, lia_players.lastOnline, lia_characters._class, lia_characters.playtime"
         local faction
         local arg = table.concat(arguments, " ")
         if arg ~= "" then
@@ -180,8 +180,8 @@ lia.command.add("factionmanagement", {
                         faction = v.faction,
                         steamID = v.steamID,
                         class = classData and classData.name or L("none"),
-                        lastOnline = lastOnlineText,
-                        hoursPlayed = formatDHM(tonumber(v.totalOnlineTime) or 0)
+                        playTime = formatDHM(tonumber(v.playtime) or 0),
+                        lastOnline = lastOnlineText
                     })
                 end
             else
@@ -218,6 +218,7 @@ lia.command.add("plywhitelist", {
         end
     end
 })
+
 
 lia.command.add("plyunwhitelist", {
     adminOnly = true,

--- a/gamemode/modules/teams/netcalls/client.lua
+++ b/gamemode/modules/teams/netcalls/client.lua
@@ -27,16 +27,16 @@ net.Receive("CharacterInfo", function()
         local rows = {}
         local originals = {}
         for _, data in ipairs(characterData) do
-            rows[#rows + 1] = {data.name, data.class or L("none"), data.lastOnline, data.hoursPlayed}
+            rows[#rows + 1] = {data.name, data.steamID, data.class or L("none"), data.playTime, data.lastOnline}
             originals[#originals + 1] = data
         end
 
         local row = sheet:AddListViewRow({
-            columns = {L("name"), L("class"), L("lastOnline"), L("hoursPlayed")},
+            columns = {L("name"), L("steamID"), L("class"), L("playtime"), L("lastOnline")},
             data = rows,
             getLineText = function(line)
                 local s = ""
-                for i = 1, 4 do
+                for i = 1, 5 do
                     local v = line:GetValue(i)
                     if v then s = s .. " " .. tostring(v) end
                 end
@@ -91,9 +91,10 @@ net.Receive("CharacterInfo", function()
 
     local columns = {
         {name = L("name"), field = "name"},
+        {name = L("steamID"), field = "steamID"},
         {name = L("class"), field = "class"},
-        {name = L("lastOnline"), field = "lastOnline"},
-        {name = L("hoursPlayed"), field = "hoursPlayed"}
+        {name = L("playtime"), field = "playTime"},
+        {name = L("lastOnline"), field = "lastOnline"}
     }
 
     local actions = {}

--- a/gamemode/modules/teams/netcalls/server.lua
+++ b/gamemode/modules/teams/netcalls/server.lua
@@ -13,7 +13,7 @@ net.Receive("RequestRoster", function(_, client)
     if not character then return end
     local isLeader = client:hasPrivilege("Manage Faction Members") or character:hasFlags("V")
     if not isLeader then return end
-    local fields = "lia_characters.name, lia_characters.faction, lia_characters.id, lia_characters.steamID, lia_characters.lastJoinTime, lia_players.totalOnlineTime, lia_players.lastOnline, lia_characters._class"
+    local fields = "lia_characters.name, lia_characters.faction, lia_characters.id, lia_characters.steamID, lia_characters.lastJoinTime, lia_players.lastOnline, lia_characters._class, lia_characters.playtime"
     local factionIndex = character:getFaction()
     if not factionIndex then return end
     local faction = lia.faction.indices[factionIndex]
@@ -47,8 +47,8 @@ net.Receive("RequestRoster", function(_, client)
                     faction = v.faction,
                     steamID = v.steamID,
                     class = classData and classData.name or L("none"),
-                    lastOnline = lastOnlineText,
-                    hoursPlayed = formatDHM(tonumber(v.totalOnlineTime) or 0)
+                    playTime = formatDHM(tonumber(v.playtime) or 0),
+                    lastOnline = lastOnlineText
                 })
             end
         end


### PR DESCRIPTION
## Summary
- show SteamID, class, playtime, and last online in faction management roster
- expand roster command and UI to display SteamID, class, character playtime, and last online

## Testing
- `luacheck gamemode/modules/administration/submodules/factions/libraries/server.lua gamemode/modules/administration/submodules/factions/libraries/client.lua gamemode/modules/teams/netcalls/server.lua gamemode/modules/teams/netcalls/client.lua gamemode/modules/teams/commands.lua` *(fails: warnings about undefined globals)*

------
https://chatgpt.com/codex/tasks/task_e_688f08f02ee48327b89b8b04b5356b08