### PR TITLE
Fix SteamID lookup in flags management

### DIFF
--- a/gamemode/core/libraries/util.lua
+++ b/gamemode/core/libraries/util.lua
@@ -120,7 +120,7 @@ end
 
 function lia.util.findPlayerBySteamID(SteamID)
     for _, client in player.Iterator() do
-        if client:SteamID64() == SteamID then return client end
+        if client:SteamID() == SteamID then return client end
     end
     return nil
 end


### PR DESCRIPTION
## Summary
- Fix SteamID comparison in `findPlayerBySteamID`

## Testing
- `luacheck gamemode/core/libraries/util.lua` *(fails: command not found)*
- `apt-get update && apt-get install -y luacheck` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688f12444bf88327b0dd9946f762405d