### PR TITLE
Fix agoFormat localization call

### DIFF
--- a/gamemode/modules/administration/submodules/factions/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/factions/libraries/server.lua
@@ -41,7 +41,7 @@ local function SendRoster(client)
                         local lastDiff = os.time() - last
                         local timeSince = lia.time.TimeSince(last)
                         local timeStripped = timeSince:match("^(.-)%sago$") or timeSince
-                        lastOnlineText = string.format(L("agoFormat"), timeStripped, formatDHM(lastDiff))
+                        lastOnlineText = L("agoFormat", timeStripped, formatDHM(lastDiff))
                     end
 
                     local classID = tonumber(v._class) or 0

--- a/gamemode/modules/administration/submodules/players/module.lua
+++ b/gamemode/modules/administration/submodules/players/module.lua
@@ -93,7 +93,7 @@ if CLIENT then
                         local lastDiff = os.time() - last
                         local timeSince = lia.time.TimeSince(last)
                         local timeStripped = timeSince:match("^(.-)%sago$") or timeSince
-                        lastOnlineText = string.format(L("agoFormat"), timeStripped, formatDHM(lastDiff))
+                        lastOnlineText = L("agoFormat", timeStripped, formatDHM(lastDiff))
                     else
                         lastOnlineText = L("unknown")
                     end

--- a/gamemode/modules/teams/commands.lua
+++ b/gamemode/modules/teams/commands.lua
@@ -93,7 +93,7 @@ lia.command.add("roster", {
                         local lastDiff = os.time() - last
                         local timeSince = lia.time.TimeSince(last)
                         local timeStripped = timeSince:match("^(.-)%sago$") or timeSince
-                        lastOnlineText = string.format(L("agoFormat"), timeStripped, formatDHM(lastDiff))
+                        lastOnlineText = L("agoFormat", timeStripped, formatDHM(lastDiff))
                     end
 
                     local classID = tonumber(v._class) or 0
@@ -169,7 +169,7 @@ lia.command.add("factionmanagement", {
                         local lastDiff = os.time() - last
                         local timeSince = lia.time.TimeSince(last)
                         local timeStripped = timeSince:match("^(.-)%sago$") or timeSince
-                        lastOnlineText = string.format(L("agoFormat"), timeStripped, formatDHM(lastDiff))
+                        lastOnlineText = L("agoFormat", timeStripped, formatDHM(lastDiff))
                     end
 
                     local classID = tonumber(v._class) or 0

--- a/gamemode/modules/teams/netcalls/server.lua
+++ b/gamemode/modules/teams/netcalls/server.lua
@@ -36,7 +36,7 @@ net.Receive("RequestRoster", function(_, client)
                     local lastDiff = os.time() - last
                     local timeSince = lia.time.TimeSince(last)
                     local timeStripped = timeSince:match("^(.-)%sago$") or timeSince
-                    lastOnlineText = string.format(L("agoFormat"), timeStripped, formatDHM(lastDiff))
+                    lastOnlineText = L("agoFormat", timeStripped, formatDHM(lastDiff))
                 end
 
                 local classID = tonumber(v._class) or 0


### PR DESCRIPTION
## Summary
- Avoid double string formatting when displaying last online times
- Use `L("agoFormat", ...)` across players, team, and faction modules

## Testing
- `luacheck gamemode/modules/administration/submodules/players/module.lua gamemode/modules/teams/netcalls/server.lua gamemode/modules/administration/submodules/factions/libraries/server.lua gamemode/modules/teams/commands.lua`


------
https://chatgpt.com/codex/tasks/task_e_688f11f511c08327a7826fdfab9915ec