### PR TITLE
Fix playtime display for online faction members

### DIFF
--- a/gamemode/modules/administration/submodules/factions/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/factions/libraries/server.lua
@@ -46,12 +46,21 @@ local function SendRoster(client)
 
                     local classID = tonumber(v._class) or 0
                     local classData = lia.class.list[classID]
+                    local playTime = tonumber(v.playtime) or 0
+                    if isOnline then
+                        local char = lia.char.loaded[charID]
+                        if char then
+                            local loginTime = char:getLoginTime() or os.time()
+                            playTime = char:getPlayTime() + os.time() - loginTime
+                        end
+                    end
+
                     members[#members + 1] = {
                         name = v.name,
                         id = charID,
                         steamID = v.steamID,
                         class = classData and classData.name or L("none"),
-                        playTime = formatDHM(tonumber(v.playtime) or 0),
+                        playTime = formatDHM(playTime),
                         lastOnline = lastOnlineText
                     }
                 end

--- a/gamemode/modules/teams/commands.lua
+++ b/gamemode/modules/teams/commands.lua
@@ -98,13 +98,22 @@ lia.command.add("roster", {
 
                     local classID = tonumber(v._class) or 0
                     local classData = lia.class.list[classID]
+                    local playTime = tonumber(v.playtime) or 0
+                    if isOnline then
+                        local char = lia.char.loaded[charID]
+                        if char then
+                            local loginTime = char:getLoginTime() or os.time()
+                            playTime = char:getPlayTime() + os.time() - loginTime
+                        end
+                    end
+
                     table.insert(characters, {
                         id = charID,
                         name = v.name,
                         faction = v.faction,
                         steamID = v.steamID,
                         class = classData and classData.name or L("none"),
-                        playTime = formatDHM(tonumber(v.playtime) or 0),
+                        playTime = formatDHM(playTime),
                         lastOnline = lastOnlineText
                     })
                 end
@@ -174,13 +183,22 @@ lia.command.add("factionmanagement", {
 
                     local classID = tonumber(v._class) or 0
                     local classData = lia.class.list[classID]
+                    local playTime = tonumber(v.playtime) or 0
+                    if isOnline then
+                        local char = lia.char.loaded[charID]
+                        if char then
+                            local loginTime = char:getLoginTime() or os.time()
+                            playTime = char:getPlayTime() + os.time() - loginTime
+                        end
+                    end
+
                     table.insert(characters, {
                         id = charID,
                         name = v.name,
                         faction = v.faction,
                         steamID = v.steamID,
                         class = classData and classData.name or L("none"),
-                        playTime = formatDHM(tonumber(v.playtime) or 0),
+                        playTime = formatDHM(playTime),
                         lastOnline = lastOnlineText
                     })
                 end

--- a/gamemode/modules/teams/netcalls/server.lua
+++ b/gamemode/modules/teams/netcalls/server.lua
@@ -41,13 +41,22 @@ net.Receive("RequestRoster", function(_, client)
 
                 local classID = tonumber(v._class) or 0
                 local classData = lia.class.list[classID]
+                local playTime = tonumber(v.playtime) or 0
+                if isOnline then
+                    local char = lia.char.loaded[charID]
+                    if char then
+                        local loginTime = char:getLoginTime() or os.time()
+                        playTime = char:getPlayTime() + os.time() - loginTime
+                    end
+                end
+
                 table.insert(characters, {
                     id = charID,
                     name = v.name,
                     faction = v.faction,
                     steamID = v.steamID,
                     class = classData and classData.name or L("none"),
-                    playTime = formatDHM(tonumber(v.playtime) or 0),
+                    playTime = formatDHM(playTime),
                     lastOnline = lastOnlineText
                 })
             end


### PR DESCRIPTION
## Summary
- include current session time when reporting faction member playtime so online players no longer show 0
- apply the same playtime calculation across faction roster requests and admin commands

## Testing
- `luacheck gamemode/modules/administration/submodules/factions/libraries/server.lua gamemode/modules/teams/netcalls/server.lua gamemode/modules/teams/commands.lua | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688f121e40f88327bc4fd3c5ada3f395