### PR TITLE
Remove redundant string.format around L

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -1056,10 +1056,10 @@ concommand.Add("list_entities", function(client)
         end
 
         for className, count in pairs(entityCount) do
-            lia.information(string.format(L("entityClassCount"), className, count))
+            lia.information(L("entityClassCount", className, count))
         end
 
-        lia.information(string.format(L("totalEntities"), totalEntities))
+        lia.information(L("totalEntities", totalEntities))
     end
 end)
 

--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -863,7 +863,7 @@ else
             delBtn:SetText(L("deleteGroup"))
             createBtn.DoClick = promptCreateGroup
             renameBtn.DoClick = function()
-                Derma_StringRequest(L("renameGroup"), string.format(L("renameGroupPrompt"), g), g, function(txt)
+                Derma_StringRequest(L("renameGroup"), L("renameGroupPrompt", g), g, function(txt)
                     txt = string.Trim(txt or "")
                     if txt ~= "" and txt ~= g then
                         net.Start("liaGroupsRename")
@@ -875,7 +875,7 @@ else
             end
 
             delBtn.DoClick = function()
-                Derma_Query(string.format(L("deleteGroupPrompt"), g), L("confirm"), L("yes"), function()
+                Derma_Query(L("deleteGroupPrompt", g), L("confirm"), L("yes"), function()
                     net.Start("liaGroupsRemove")
                     net.WriteString(g)
                     net.SendToServer()

--- a/gamemode/core/libraries/workshop.lua
+++ b/gamemode/core/libraries/workshop.lua
@@ -278,7 +278,7 @@ else
                 local function populate()
                     for id, fi in pairs(info) do
                         if fi then
-                            local title = fi.title or string.format(L("idPrefix"), id)
+                            local title = fi.title or L("idPrefix", id)
                             local percent = "0%"
                             if totalSize > 0 then
                                 percent = string.format("%.2f%%", (fi.size or 0) / totalSize * 100)


### PR DESCRIPTION
## Summary
- drop unnecessary `string.format` calls that wrapped `L` because `L` already formats arguments

## Testing
- `luacheck . | tail -n 2`

------
https://chatgpt.com/codex/tasks/task_e_688f13e8a9ec8327ad6843bd8c17350e