### PR TITLE
Fix char list missing online sheets

### DIFF
--- a/gamemode/modules/administration/submodules/charlist/module.lua
+++ b/gamemode/modules/administration/submodules/charlist/module.lua
@@ -19,12 +19,13 @@ LEFT JOIN lia_chardata AS d ON d.charID = c.id AND d.key = 'charBanInfo']], func
             for _, row in ipairs(data or {}) do
                 local stored = lia.char.loaded[row.id]
                 local isBanned = tonumber(row.banned) == 1
+                local steamID = tostring(row.steamID)
                 local entry = {
                     ID = row.id,
                     Name = row.name,
                     Desc = row.desc,
                     Faction = row.faction,
-                    SteamID = row.steamID,
+                    SteamID = steamID,
                     LastUsed = stored and "Online" or row.lastJoinTime,
                     Banned = isBanned,
                     PlayTime = tonumber(row.playtime) or 0,
@@ -42,8 +43,8 @@ LEFT JOIN lia_chardata AS d ON d.charID = c.id AND d.key = 'charBanInfo']], func
                 end
                 hook.Run("CharListEntry", entry, row)
                 payload.all[#payload.all + 1] = entry
-                payload.players[row.steamID] = payload.players[row.steamID] or {}
-                table.insert(payload.players[row.steamID], entry)
+                payload.players[steamID] = payload.players[steamID] or {}
+                table.insert(payload.players[steamID], entry)
             end
 
             lia.net.writeBigTable(client, "liaFullCharList", payload)
@@ -173,7 +174,7 @@ else
                     self.sheet:AddSheet(L("allCharacters"), allPanel)
 
                     for steamID, chars in pairs(data.players or {}) do
-                        local ply = lia.util.getBySteamID(steamID)
+                        local ply = lia.util.getBySteamID(tostring(steamID))
                         if IsValid(ply) then
                             local pnl = self.sheet:Add("DPanel")
                             pnl:Dock(FILL)


### PR DESCRIPTION
## Summary
- Ensure SteamIDs are treated as strings when building charlist data
- Convert SteamID keys to strings when resolving player tabs

## Testing
- `luacheck gamemode/modules/administration/submodules/charlist/module.lua` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: Unable to locate package luacheck)*
- `pip install luacheck` *(fails: No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_688f16686b4483278ff1e5874bbfc6f3