### PR TITLE
fix: rebuild property sheet to prevent CloseTab error

### DIFF
--- a/gamemode/modules/administration/submodules/charlist/module.lua
+++ b/gamemode/modules/administration/submodules/charlist/module.lua
@@ -70,13 +70,12 @@ else
                 panel.sheet = panel:Add("DPropertySheet")
                 panel.sheet:Dock(FILL)
                 function panel:buildSheets(data)
-                    -- Clear existing tabs without removing the tab scroller
-                    for _, v in ipairs(self.sheet.Items or {}) do
-                        if IsValid(v.Tab) then
-                            self.sheet:CloseTab(v.Tab, true)
-                        end
+                    -- Recreate the property sheet to avoid CloseTab errors
+                    if IsValid(self.sheet) then
+                        self.sheet:Remove()
                     end
-                    self.sheet.Items = {}
+                    self.sheet = self:Add("DPropertySheet")
+                    self.sheet:Dock(FILL)
 
                     local function formatPlayTime(secs)
                         local h = math.floor(secs / 3600)


### PR DESCRIPTION
## Summary
- rebuild the admin character list property sheet when refreshing
- avoids errors from `DPropertySheet:CloseTab` when removing last tab

## Testing
- `luacheck gamemode/modules/administration/submodules/charlist/module.lua`


------
https://chatgpt.com/codex/tasks/task_e_688f180bcba8832794796c71134b454d