### PR TITLE
feat: add row context actions in DB browser

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -327,6 +327,7 @@ LANGUAGE = {
     selectClassPrompt = "Select Class",
     typeFieldPrompt = "Type %s",
     copyRow = "Copy Row",
+    viewEntry = "View Decoded Entry",
     copySteamID = "Copy Steam ID",
     copyLogMessage = "Copy Log Message",
     copy = "Copy",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -327,6 +327,7 @@ LANGUAGE = {
     selectClassPrompt = "Choisir une classe",
     typeFieldPrompt = "Entrer %s",
     copyRow = "Copier la ligne",
+    viewEntry = "Voir l'entrée décodée",
     copySteamID = "Copier Steam ID",
     copyLogMessage = "Copier message du log",
     copy = "Copier",

--- a/gamemode/languages/italian.lua
+++ b/gamemode/languages/italian.lua
@@ -327,6 +327,7 @@ LANGUAGE = {
     selectClassPrompt = "Seleziona Classe",
     typeFieldPrompt = "Digita %s",
     copyRow = "Copia Riga",
+    viewEntry = "Visualizza voce decodificata",
     copySteamID = "Copia Steam ID",
     copyLogMessage = "Copia Messaggio Log",
     copy = "Copia",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -327,6 +327,7 @@ LANGUAGE = {
     selectClassPrompt = "Selecciona classe",
     typeFieldPrompt = "Escreve %s",
     copyRow = "Copiar linha",
+    viewEntry = "Ver entrada decodificada",
     copySteamID = "Copiar Steam ID",
     copyLogMessage = "Copiar Mensagem do Log",
     copy = "Copiar",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -327,6 +327,7 @@ LANGUAGE = {
     selectClassPrompt = "Выберите класс",
     typeFieldPrompt = "Введите %s",
     copyRow = "Копировать строку",
+    viewEntry = "Просмотреть декодированную запись",
     copySteamID = "Скопировать Steam ID",
     copyLogMessage = "Скопировать сообщение лога",
     copy = "Копировать",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -327,6 +327,7 @@ LANGUAGE = {
     selectClassPrompt = "Seleccionar clase",
     typeFieldPrompt = "Escribe %s",
     copyRow = "Copiar fila",
+    viewEntry = "Ver entrada decodificada",
     copySteamID = "Copiar Steam ID",
     copyLogMessage = "Copiar Mensaje del Log",
     copy = "Copiar",

--- a/gamemode/modules/administration/netcalls/client.lua
+++ b/gamemode/modules/administration/netcalls/client.lua
@@ -102,6 +102,27 @@ net.Receive("liaDBTableData", function()
 
     local _, list = lia.util.CreateTableUI(tbl, columns, data)
     if IsValid(list) then
+        function list:OnRowRightClick(_, line)
+            if not IsValid(line) or not line.rowData then return end
+            local rowData = line.rowData
+            local menu = DermaMenu()
+            menu:AddOption(L("copyRow"), function()
+                local rowString = ""
+                for key, value in pairs(rowData) do
+                    value = tostring(value or L("na"))
+                    rowString = rowString .. key:gsub("^%l", string.upper) .. " " .. value .. " | "
+                end
+
+                SetClipboardText(string.sub(rowString, 1, -4))
+            end)
+
+            menu:AddOption(L("viewEntry"), function()
+                openRowInfo(rowData)
+            end)
+
+            menu:Open()
+        end
+
         function list:OnRowSelected(_, line)
             openRowInfo(line.rowData)
         end


### PR DESCRIPTION
## Summary
- allow viewing decoded row data via right-click in DB browser
- add View Decoded Entry translations in all languages

## Testing
- `luacheck gamemode/modules/administration/netcalls/client.lua gamemode/languages/english.lua gamemode/languages/russian.lua gamemode/languages/french.lua gamemode/languages/spanish.lua gamemode/languages/portuguese.lua gamemode/languages/italian.lua`


------
https://chatgpt.com/codex/tasks/task_e_688f192627d08327a44cb1f1ab76932d