### PR TITLE
Standardize ticket claim timestamp format

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -391,7 +391,7 @@ CREATE TABLE IF NOT EXISTS lia_logs (
     steamID varchar
 );
 CREATE TABLE IF NOT EXISTS lia_ticketclaims (
-    timestamp integer,
+    timestamp datetime,
     requester text,
     requesterSteamID text,
     admin text,
@@ -559,7 +559,7 @@ CREATE TABLE IF NOT EXISTS `lia_logs` (
     primary key (`id`)
 );
 CREATE TABLE IF NOT EXISTS `lia_ticketclaims` (
-    `timestamp` int not null,
+    `timestamp` datetime not null,
     `requester` varchar(64) not null collate 'utf8mb4_general_ci',
     `requesterSteamID` varchar(64) not null collate 'utf8mb4_general_ci',
     `admin` varchar(64) not null collate 'utf8mb4_general_ci',

--- a/gamemode/modules/administration/submodules/tickets/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/tickets/libraries/server.lua
@@ -13,7 +13,8 @@ local function buildClaimTable(rows)
 
         local info = caseclaims[adminID]
         info.claims = info.claims + 1
-        if row.timestamp > info.lastclaim then info.lastclaim = row.timestamp end
+        local rowTime = isnumber(row.timestamp) and row.timestamp or os.time(lia.time.toNumber(row.timestamp))
+        if rowTime > info.lastclaim then info.lastclaim = rowTime end
         local reqPly = lia.util.getBySteamID(row.requesterSteamID)
         info.claimedFor[row.requesterSteamID] = IsValid(reqPly) and reqPly:Nick() or row.requester
     end
@@ -32,7 +33,7 @@ end
 function MODULE:TicketSystemClaim(admin, requester)
     local ticket = MODULE.ActiveTickets[requester:SteamID()]
     lia.db.insertTable({
-        timestamp = os.time(),
+        timestamp = os.date("%Y-%m-%d %H:%M:%S"),
         requester = requester:Nick(),
         requesterSteamID = requester:SteamID(),
         admin = admin:Nick(),


### PR DESCRIPTION
## Summary
- store ticket claim timestamps as formatted datetime strings
- convert ticket claim timestamps to unix time for comparisons
- define `datetime` column for ticket claim timestamps in database schema

## Testing
- `luacheck gamemode/modules/administration/submodules/tickets/libraries/server.lua gamemode/core/libraries/database.lua | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688f19856b0083278ffc235e7cc71e03