### PR TITLE
Quote SteamID strings in database queries

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -406,16 +406,16 @@ end
 
 function GM:PlayerAuthed(client, steamid)
     local steam64 = util.SteamIDTo64(steamid)
-    lia.db.selectOne({"userGroup"}, "players", "steamID = " .. steam64):next(function(data)
+    lia.db.selectOne({"userGroup"}, "players", "steamID = " .. lia.db.convertDataType(steam64)):next(function(data)
         if not IsValid(client) then return end
         local group = data and data.userGroup
         if not group or group == "" then
             group = "user"
-            lia.db.query(Format("UPDATE lia_players SET userGroup = '%s' WHERE steamID = %s", lia.db.escape(group), steam64))
+            lia.db.query(Format("UPDATE lia_players SET userGroup = '%s' WHERE steamID = %s", lia.db.escape(group), lia.db.convertDataType(steam64)))
         end
 
         client:SetUserGroup(group)
-        lia.db.selectOne({"reason"}, "bans", "playerSteamID = " .. steam64):next(function(banData)
+        lia.db.selectOne({"reason"}, "bans", "playerSteamID = " .. lia.db.convertDataType(steam64)):next(function(banData)
             if not IsValid(client) or not banData then return end
             local reason = banData.reason or L("genericReason")
             client:Kick(L("banMessage", 0, reason))
@@ -457,7 +457,7 @@ function GM:PlayerInitialSpawn(client)
         client:setLiliaData("lastIP", address)
         lia.db.updateTable({
             lastIP = address
-        }, nil, "players", "steamID = " .. client:SteamID())
+        }, nil, "players", "steamID = " .. lia.db.convertDataType(client:SteamID()))
 
         net.Start("liaDataSync")
         net.WriteTable(data)
@@ -990,7 +990,7 @@ concommand.Add("plysetgroup", function(ply, _, args)
         if IsValid(target) then
             if lia.administrator.groups[usergroup] then
                 target:SetUserGroup(usergroup)
-                lia.db.query(Format("UPDATE lia_players SET userGroup = '%s' WHERE steamID = %s", lia.db.escape(usergroup), target:SteamID()))
+                lia.db.query(Format("UPDATE lia_players SET userGroup = '%s' WHERE steamID = %s", lia.db.escape(usergroup), lia.db.convertDataType(target:SteamID())))
             else
                 MsgC(Color(200, 20, 20), L("consoleUsergroupNotFound") .. "\n")
             end
@@ -1095,5 +1095,5 @@ end)
 hook.Add("server_removeban", "LiliaLogServerUnban", function(data)
     lia.admin("[UNBAN] " .. data.networkid .. " was unbanned.")
     local steam64 = util.SteamIDTo64(data.networkid)
-    lia.db.query("DELETE FROM lia_bans WHERE playerSteamID = " .. steam64)
+    lia.db.query("DELETE FROM lia_bans WHERE playerSteamID = " .. lia.db.convertDataType(steam64))
 end)

--- a/gamemode/core/libraries/character.lua
+++ b/gamemode/core/libraries/character.lua
@@ -595,7 +595,7 @@ if SERVER then
 
         fields = table.concat(fields, ", ")
         local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
-        local condition = "schema = '" .. lia.db.escape(gamemode) .. "' AND steamID = " .. steamID
+        local condition = "schema = '" .. lia.db.escape(gamemode) .. "' AND steamID = " .. lia.db.convertDataType(steamID)
         if id then condition = condition .. " AND id = " .. id end
         local query = "SELECT " .. fields .. " FROM lia_characters WHERE " .. condition
         lia.db.query(query, function(data)

--- a/gamemode/core/libraries/compatibility/cami.lua
+++ b/gamemode/core/libraries/compatibility/cami.lua
@@ -101,7 +101,7 @@ hook.Add("CAMI.PlayerUsergroupChanged", "liaAdminPlyUGChanged", function(ply, ol
     if not IsValid(ply) then return end
     local newGroup = tostring(new or "user")
     if tostring(ply:GetUserGroup() or "user") ~= newGroup then ply:SetUserGroup(newGroup) end
-    lia.db.query(Format("UPDATE lia_players SET userGroup = '%s' WHERE steamID = %s", lia.db.escape(newGroup), ply:SteamID()))
+    lia.db.query(Format("UPDATE lia_players SET userGroup = '%s' WHERE steamID = %s", lia.db.escape(newGroup), lia.db.convertDataType(ply:SteamID())))
 end)
 
 hook.Add("CAMI.SteamIDUsergroupChanged", "liaAdminSIDUGChanged", function(steamId, old, new, source)
@@ -111,5 +111,5 @@ hook.Add("CAMI.SteamIDUsergroupChanged", "liaAdminSIDUGChanged", function(steamI
     local ply = lia.util.getBySteamID(sid)
     if IsValid(ply) and tostring(ply:GetUserGroup() or "user") ~= newGroup then ply:SetUserGroup(newGroup) end
     local steam64 = util.SteamIDTo64(sid)
-    lia.db.query(Format("UPDATE lia_players SET userGroup = '%s' WHERE steamID = %s", lia.db.escape(newGroup), steam64))
+    lia.db.query(Format("UPDATE lia_players SET userGroup = '%s' WHERE steamID = %s", lia.db.escape(newGroup), lia.db.convertDataType(steam64)))
 end)

--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -424,11 +424,11 @@ if SERVER then
         local name = self:steamName()
         local steamID = self:SteamID()
         local timeStamp = os.date("%Y-%m-%d %H:%M:%S", os.time())
-        lia.db.query("SELECT data, firstJoin, lastJoin, lastIP, lastOnline, totalOnlineTime FROM lia_players WHERE steamID = " .. steamID, function(data)
+        lia.db.query("SELECT data, firstJoin, lastJoin, lastIP, lastOnline, totalOnlineTime FROM lia_players WHERE steamID = " .. lia.db.convertDataType(steamID), function(data)
             if IsValid(self) and data and data[1] and data[1].data then
                 lia.db.updateTable({
                     lastJoin = timeStamp,
-                }, nil, "players", "steamID = " .. steamID)
+                }, nil, "players", "steamID = " .. lia.db.convertDataType(steamID))
 
                 self.firstJoin = data[1].firstJoin or timeStamp
                 self.lastJoin = data[1].lastJoin or timeStamp
@@ -475,7 +475,7 @@ if SERVER then
             lastIP = self:getLiliaData("lastIP", ""),
             lastOnline = currentTime,
             totalOnlineTime = stored + session
-        }, nil, "players", "steamID = " .. steamID)
+        }, nil, "players", "steamID = " .. lia.db.convertDataType(steamID))
     end
 
     function playerMeta:setLiliaData(key, value, noNetworking)


### PR DESCRIPTION
## Summary
- wrap SteamIDs with `lia.db.convertDataType` when loading/saving player data
- quote SteamID values in server hooks and CAMI integration
- ensure character restoration uses escaped SteamIDs

## Testing
- `luacheck .` *(fails: 12244 warnings / 21 errors in 267 files)*

------
https://chatgpt.com/codex/tasks/task_e_688f1bc2a2f48327be7f182e43fc761c