### PR TITLE
Ensure Lilia data updates persist automatically

### DIFF
--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -414,7 +414,6 @@ if SERVER then
             whitelists[SCHEMA.folder] = whitelists[SCHEMA.folder] or {}
             whitelists[SCHEMA.folder][data.uniqueID] = whitelisted and true or nil
             self:setLiliaData("whitelists", whitelists)
-            self:saveLiliaData()
             return true
         end
         return false
@@ -466,8 +465,8 @@ if SERVER then
         local timeStamp = os.date("%Y-%m-%d %H:%M:%S", currentTime)
         local stored = self:getLiliaData("totalOnlineTime", 0)
         local session = RealTime() - (self.liaJoinTime or RealTime())
-        self:setLiliaData("totalOnlineTime", stored + session, true)
-        self:setLiliaData("lastOnline", currentTime, true)
+        self:setLiliaData("totalOnlineTime", stored + session, true, true)
+        self:setLiliaData("lastOnline", currentTime, true, true)
         lia.db.updateTable({
             steamName = name,
             lastJoin = timeStamp,
@@ -478,7 +477,7 @@ if SERVER then
         }, nil, "players", "steamID = " .. steamID)
     end
 
-    function playerMeta:setLiliaData(key, value, noNetworking)
+    function playerMeta:setLiliaData(key, value, noNetworking, noSave)
         self.liaData = self.liaData or {}
         self.liaData[key] = value
         if not noNetworking then
@@ -486,6 +485,9 @@ if SERVER then
             net.WriteString(key)
             net.WriteType(value)
             net.Send(self)
+        end
+        if not noSave then
+            self:saveLiliaData()
         end
     end
 


### PR DESCRIPTION
## Summary
- Automatically save Lilia data whenever `setLiliaData` is called
- Use a `noSave` flag to avoid recursion when saving
- Remove redundant manual save in `setWhitelisted`

## Testing
- `luacheck gamemode/core/meta/player.lua` *(fails: "expected '=' near 'end'")*

------
https://chatgpt.com/codex/tasks/task_e_688f1c44bb7c8327b9826fd74fdb0f59