### PR TITLE
fix: ensure ticket admin tab honors privilege

### DIFF
--- a/gamemode/modules/administration/submodules/tickets/module.lua
+++ b/gamemode/modules/administration/submodules/tickets/module.lua
@@ -92,7 +92,7 @@ if CLIENT then
     end)
 
     function MODULE:PopulateAdminTabs(pages)
-        if not IsValid(LocalPlayer()) or not (LocalPlayer():hasPrivilege("Always See Tickets") or LocalPlayer():isStaffOnDuty()) then return end
+        if not IsValid(LocalPlayer()) or not (LocalPlayer():hasPrivilege(L("alwaysSeeTickets")) or LocalPlayer():isStaffOnDuty()) then return end
         table.insert(pages, {
             name = L("tickets", "Tickets"),
             drawFunc = function(panel)

--- a/gamemode/modules/administration/submodules/tickets/netcalls/client.lua
+++ b/gamemode/modules/administration/submodules/tickets/netcalls/client.lua
@@ -16,7 +16,7 @@ net.Receive("TicketSystem", function()
     local pl = net.ReadEntity()
     local msg = net.ReadString()
     local claimed = net.ReadEntity()
-    if LocalPlayer():isStaffOnDuty() or LocalPlayer():hasPrivilege("Always See Tickets") then
+    if LocalPlayer():isStaffOnDuty() or LocalPlayer():hasPrivilege(L("alwaysSeeTickets")) then
         MODULE:TicketFrame(pl, msg, claimed)
     end
 end)

--- a/gamemode/modules/administration/submodules/tickets/netcalls/server.lua
+++ b/gamemode/modules/administration/submodules/tickets/netcalls/server.lua
@@ -16,9 +16,9 @@ net.Receive("TicketSystemClaim", function(_, client)
         return
     end
 
-    if (client:hasPrivilege("Always See Tickets") or client:isStaffOnDuty()) and not requester.CaseClaimed then
+    if (client:hasPrivilege(L("alwaysSeeTickets")) or client:isStaffOnDuty()) and not requester.CaseClaimed then
         for _, v in player.Iterator() do
-            if v:hasPrivilege("Always See Tickets") or v:isStaffOnDuty() then
+            if v:hasPrivilege(L("alwaysSeeTickets")) or v:isStaffOnDuty() then
                 net.Start("TicketSystemClaim")
                 net.WriteEntity(client)
                 net.WriteEntity(requester)
@@ -43,7 +43,7 @@ net.Receive("TicketSystemClose", function(_, client)
     if not requester or not IsValid(requester) or requester.CaseClaimed ~= client then return end
     if timer.Exists("ticketsystem-" .. requester:SteamID()) then timer.Remove("ticketsystem-" .. requester:SteamID()) end
     for _, v in player.Iterator() do
-        if v:hasPrivilege("Always See Tickets") or v:isStaffOnDuty() then
+        if v:hasPrivilege(L("alwaysSeeTickets")) or v:isStaffOnDuty() then
             net.Start("TicketSystemClose")
             net.WriteEntity(requester)
             net.Send(v)
@@ -56,7 +56,7 @@ net.Receive("TicketSystemClose", function(_, client)
 end)
 
 net.Receive("liaRequestActiveTickets", function(_, client)
-    if not (client:hasPrivilege("Always See Tickets") or client:isStaffOnDuty()) then return end
+    if not (client:hasPrivilege(L("alwaysSeeTickets")) or client:isStaffOnDuty()) then return end
     local tickets = {}
     for _, data in pairs(MODULE.ActiveTickets or {}) do
         tickets[#tickets + 1] = data


### PR DESCRIPTION
## Summary
- fix ticket admin tab privilege check to use translated privilege name
- align client/server ticket net handlers with new privilege check

## Testing
- `luac -p gamemode/modules/administration/submodules/tickets/module.lua`
- `tail -c +4 gamemode/modules/administration/submodules/tickets/netcalls/client.lua | luac -p -`
- `tail -c +4 gamemode/modules/administration/submodules/tickets/netcalls/server.lua | luac -p -`


------
https://chatgpt.com/codex/tasks/task_e_688f1d7659008327b2d45a80e9483048