### PR TITLE
Allow faction managers to view roster context menu

### DIFF
--- a/gamemode/modules/administration/submodules/players/module.lua
+++ b/gamemode/modules/administration/submodules/players/module.lua
@@ -161,7 +161,7 @@ FROM lia_players
     end)
 
     net.Receive("liaRequestPlayerCharacters", function(_, client)
-        if not client:IsAdmin() then return end
+        if not (client:IsAdmin() or client:hasPrivilege("Can Manage Factions")) then return end
         local steamID = net.ReadString()
         if not steamID or steamID == "" then return end
         local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()


### PR DESCRIPTION
## Summary
- Permit players with the **Can Manage Factions** privilege to request character lists
- Fix faction roster right-click actions for non-admin faction managers

## Testing
- `luac -p gamemode/modules/administration/submodules/players/module.lua`


------
https://chatgpt.com/codex/tasks/task_e_688f1f3c4c6c8327bed5754d3cb77c79