### PR TITLE
Use SteamID instead of SteamID64

### DIFF
--- a/gamemode/core/libraries/compatibility/cami.lua
+++ b/gamemode/core/libraries/compatibility/cami.lua
@@ -110,6 +110,5 @@ hook.Add("CAMI.SteamIDUsergroupChanged", "liaAdminSIDUGChanged", function(steamI
     local newGroup = tostring(new or "user")
     local ply = lia.util.getBySteamID(sid)
     if IsValid(ply) and tostring(ply:GetUserGroup() or "user") ~= newGroup then ply:SetUserGroup(newGroup) end
-    local steam64 = util.SteamIDTo64(sid)
-    lia.db.query(Format("UPDATE lia_players SET userGroup = '%s' WHERE steamID = %s", lia.db.escape(newGroup), lia.db.convertDataType(steam64)))
+    lia.db.query(Format("UPDATE lia_players SET userGroup = '%s' WHERE steamID = %s", lia.db.escape(newGroup), lia.db.convertDataType(sid)))
 end)

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -264,7 +264,7 @@ lia.command.add("charlist", {
 
             net.Start("DisplayCharList")
             net.WriteTable(sendData)
-            net.WriteString(steam64)
+            net.WriteString(steamID)
             net.Send(client)
         end)
     end


### PR DESCRIPTION
## Summary
- prefer `SteamID` over `SteamID64` throughout most systems
- keep `SteamID64` only where timers require it
- restore `lia.util.getBySteamID` dual support and revert SteamID64 in hook IDs and cheater config

## Testing
- `luacheck gamemode/core/libraries/util.lua gamemode/core/meta/player.lua gamemode/core/hooks/server.lua gamemode/core/libraries/compatibility/cami.lua gamemode/modules/protection/libraries/server.lua gamemode/modules/administration/commands.lua` *(fails: Total: 704 warnings / 3 errors in 6 files)*

------
https://chatgpt.com/codex/tasks/task_e_688f1fb1ad388327808e11c25f4d8f48