### PR TITLE
refactor: use localization function directly

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -417,8 +417,8 @@ function GM:PlayerAuthed(client, steamid)
         client:SetUserGroup(group)
         lia.db.selectOne({"reason"}, "bans", "playerSteamID = " .. lia.db.convertDataType(steam64)):next(function(banData)
             if not IsValid(client) or not banData then return end
-            local reason = banData.reason or L("genericReason")
-            client:Kick(L("banMessage", 0, reason))
+            local reason = banData.reason
+            client:Kick(L("banMessage", 0, reason or L("genericReason")))
         end)
     end)
 end
@@ -1051,8 +1051,12 @@ concommand.Add("list_entities", function(client)
     if not IsValid(client) then
         lia.information(L("entitiesOnServer"))
         for _, entity in ents.Iterator() do
-            local className = entity:GetClass() or L("unknown")
-            entityCount[className] = (entityCount[className] or 0) + 1
+            local className = entity:GetClass()
+            if className then
+                entityCount[className] = (entityCount[className] or 0) + 1
+            else
+                entityCount[L("unknown")] = (entityCount[L("unknown")] or 0) + 1
+            end
             totalEntities = totalEntities + 1
         end
 

--- a/gamemode/core/libraries/chatbox.lua
+++ b/gamemode/core/libraries/chatbox.lua
@@ -51,8 +51,15 @@ function lia.chat.register(chatType, data)
     data.color = data.color or Color(242, 230, 160)
     data.format = data.format or "%s: \"%s\""
     data.onChatAdd = data.onChatAdd or function(speaker, text, anonymous)
-        local name = anonymous and L("someone") or hook.Run("GetDisplayedName", speaker, chatType) or IsValid(speaker) and speaker:Name() or "Console"
-        chat.AddText(lia.chat.timestamp(false), data.color, L(data.format, name, text))
+        chat.AddText(
+            lia.chat.timestamp(false),
+            data.color,
+            L(
+                data.format,
+                anonymous and L("someone") or hook.Run("GetDisplayedName", speaker, chatType) or IsValid(speaker) and speaker:Name() or "Console",
+                text
+            )
+        )
     end
 
     if CLIENT and data.prefix then

--- a/gamemode/core/libraries/compatibility/advdupe.lua
+++ b/gamemode/core/libraries/compatibility/advdupe.lua
@@ -37,7 +37,9 @@ hook.Add("CanTool", "liaAdvDupe", function(client, _, tool)
 end)
 
 lia.log.addType("dupeCrashAttempt", function(client)
-    local name = IsValid(client) and client:Name() or L("unknown")
-    local steamID = IsValid(client) and client:SteamID() or L("na")
-    return L("dupeCrashAttemptLog", name, steamID)
+    return L(
+        "dupeCrashAttemptLog",
+        IsValid(client) and client:Name() or L("unknown"),
+        IsValid(client) and client:SteamID() or L("na")
+    )
 end, "Security")

--- a/gamemode/core/libraries/compatibility/advdupe2.lua
+++ b/gamemode/core/libraries/compatibility/advdupe2.lua
@@ -35,7 +35,9 @@ hook.Add("CanTool", "liaAdvDupe2", function(client, _, tool)
 end)
 
 lia.log.addType("dupeCrashAttempt", function(client)
-    local name = IsValid(client) and client:Name() or L("unknown")
-    local steamID = IsValid(client) and client:SteamID() or L("na")
-    return L("dupeCrashAttemptLog", name, steamID)
+    return L(
+        "dupeCrashAttemptLog",
+        IsValid(client) and client:Name() or L("unknown"),
+        IsValid(client) and client:SteamID() or L("na")
+    )
 end, "Security")

--- a/gamemode/core/libraries/loader.lua
+++ b/gamemode/core/libraries/loader.lua
@@ -580,8 +580,7 @@ for _, file in ipairs(ConditionalFiles) do
 end
 
 if #loadedCompatibility > 0 then
-    local message = #loadedCompatibility == 1 and L("compatibilityLoadedSingle", loadedCompatibility[1]) or L("compatibilityLoadedMultiple", table.concat(loadedCompatibility, ", "))
-    lia.bootstrap(L("compatibility"), message)
+    lia.bootstrap(L("compatibility"), #loadedCompatibility == 1 and L("compatibilityLoadedSingle", loadedCompatibility[1]) or L("compatibilityLoadedMultiple", table.concat(loadedCompatibility, ", ")))
 end
 
 if game.IsDedicated() then concommand.Remove("gm_save") end

--- a/gamemode/core/libraries/logger.lua
+++ b/gamemode/core/libraries/logger.lua
@@ -157,8 +157,7 @@ lia.log.types = {
     },
     ["itemAdded"] = {
         func = function(client, itemName)
-            local ownerName = IsValid(client) and client:Name() or L("unknown")
-            return string.format("Item '%s' added to %s's inventory.", itemName, ownerName)
+            return string.format("Item '%s' added to %s's inventory.", itemName, IsValid(client) and client:Name() or L("unknown"))
         end,
         category = "Items"
     },
@@ -330,47 +329,41 @@ lia.log.types = {
     },
     ["vendorAccess"] = {
         func = function(client, vendor)
-            local vendorName = vendor:getNetVar("name") or L("unknown")
-            return string.format("%s accessed vendor %s", client:Name(), vendorName)
+            return string.format("%s accessed vendor %s", client:Name(), vendor:getNetVar("name") or L("unknown"))
         end,
         category = "Items"
     },
     ["vendorExit"] = {
         func = function(client, vendor)
-            local vendorName = vendor:getNetVar("name") or L("unknown")
-            return string.format("%s exited vendor %s", client:Name(), vendorName)
+            return string.format("%s exited vendor %s", client:Name(), vendor:getNetVar("name") or L("unknown"))
         end,
         category = "Items"
     },
     ["vendorSell"] = {
         func = function(client, item, vendor)
-            local vendorName = vendor:getNetVar("name") or L("unknown")
-            return string.format("%s sold a %s to %s", client:Name(), item, vendorName)
+            return string.format("%s sold a %s to %s", client:Name(), item, vendor:getNetVar("name") or L("unknown"))
         end,
         category = "Items"
     },
     ["vendorEdit"] = {
         func = function(client, vendor, key)
-            local vendorName = vendor:getNetVar("name") or L("unknown")
-            return string.format("%s edited vendor %s with key %s", client:Name(), vendorName, key)
+            return string.format("%s edited vendor %s with key %s", client:Name(), vendor:getNetVar("name") or L("unknown"), key)
         end,
         category = "Items"
     },
     ["vendorBuy"] = {
         func = function(client, item, vendor, isFailed)
-            local vendorName = vendor:getNetVar("name") or L("unknown")
             if isFailed then
-                return string.format("%s tried to buy a %s from %s but it failed. They likely had no space!", client:Name(), item, vendorName)
+                return string.format("%s tried to buy a %s from %s but it failed. They likely had no space!", client:Name(), item, vendor:getNetVar("name") or L("unknown"))
             else
-                return string.format("%s bought a %s from %s", client:Name(), item, vendorName)
+                return string.format("%s bought a %s from %s", client:Name(), item, vendor:getNetVar("name") or L("unknown"))
             end
         end,
         category = "Items"
     },
     ["restockvendor"] = {
         func = function(client, vendor)
-            local vendorName = IsValid(vendor) and (vendor:getNetVar("name") or L("unknown")) or L("unknown")
-            return string.format("%s restocked vendor %s", client:Name(), vendorName)
+            return string.format("%s restocked vendor %s", client:Name(), IsValid(vendor) and (vendor:getNetVar("name") or L("unknown")) or L("unknown"))
         end,
         category = "Items"
     },
@@ -380,8 +373,7 @@ lia.log.types = {
     },
     ["resetvendormoney"] = {
         func = function(client, vendor, amount)
-            local vendorName = IsValid(vendor) and (vendor:getNetVar("name") or L("unknown")) or L("unknown")
-            return string.format("%s set vendor %s money to %s", client:Name(), vendorName, lia.currency.get(amount))
+            return string.format("%s set vendor %s money to %s", client:Name(), IsValid(vendor) and (vendor:getNetVar("name") or L("unknown")) or L("unknown"), lia.currency.get(amount))
         end,
         category = "Items"
     },
@@ -391,8 +383,7 @@ lia.log.types = {
     },
     ["restockvendormoney"] = {
         func = function(client, vendor, amount)
-            local vendorName = IsValid(vendor) and (vendor:getNetVar("name") or L("unknown")) or L("unknown")
-            return string.format("%s restocked vendor %s money to %s", client:Name(), vendorName, lia.currency.get(amount))
+            return string.format("%s restocked vendor %s money to %s", client:Name(), IsValid(vendor) and (vendor:getNetVar("name") or L("unknown")) or L("unknown"), lia.currency.get(amount))
         end,
         category = "Items"
     },

--- a/gamemode/core/libraries/util.lua
+++ b/gamemode/core/libraries/util.lua
@@ -643,10 +643,9 @@ else
         local listView = vgui.Create("DListView", frame)
         listView:Dock(FILL)
         for _, colInfo in ipairs(columns) do
-            local columnName = colInfo.name or L("na")
-            local col = listView:AddColumn(columnName)
+            local col = listView:AddColumn(colInfo.name or L("na"))
             surface.SetFont(col.Header:GetFont())
-            local textW = surface.GetTextSize(columnName)
+            local textW = surface.GetTextSize(colInfo.name or L("na"))
             local minWidth = textW + 16
             col:SetMinWidth(minWidth)
             col:SetWidth(colInfo.width or minWidth)
@@ -655,8 +654,7 @@ else
         for _, row in ipairs(data) do
             local lineData = {}
             for _, colInfo in ipairs(columns) do
-                local fieldName = colInfo.field or L("na")
-                table.insert(lineData, row[fieldName] or L("na"))
+                table.insert(lineData, row[colInfo.field] or L("na"))
             end
 
             local line = listView:AddLine(unpack(lineData))

--- a/gamemode/core/libraries/workshop.lua
+++ b/gamemode/core/libraries/workshop.lua
@@ -277,24 +277,22 @@ else
                 local function populate()
                     for id, fi in pairs(info) do
                         if fi then
-                            local title = fi.title or L("idPrefix", id)
                             local percent = "0%"
                             if totalSize > 0 then
                                 percent = string.format("%.2f%%", (fi.size or 0) / totalSize * 100)
                             end
-                            local desc = fi.size and L("addonSize", formatSize(fi.size), percent) or ""
                             local url = fi.previewurl or ""
                             if sheet.AddPreviewRow then
                                 sheet:AddPreviewRow({
-                                    title = title,
-                                    desc = desc,
+                                    title = fi.title or L("idPrefix", id),
+                                    desc = fi.size and L("addonSize", formatSize(fi.size), percent) or "",
                                     url = url,
                                     size = 64
                                 })
                             elseif sheet.AddTextRow then
                                 sheet:AddTextRow({
-                                    title = title,
-                                    desc = desc,
+                                    title = fi.title or L("idPrefix", id),
+                                    desc = fi.size and L("addonSize", formatSize(fi.size), percent) or "",
                                     compact = true
                                 })
                             end

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -2001,8 +2001,8 @@ lia.command.add("getmodel", {
             return
         end
 
-        local model = entity:GetModel() or L("noModelFound")
-        client:ChatPrint(L("modelIs", model))
+        local model = entity:GetModel()
+        client:ChatPrint(model and L("modelIs", model) or L("noModelFound"))
     end
 })
 

--- a/gamemode/modules/administration/submodules/itemspawner/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/itemspawner/libraries/client.lua
@@ -36,8 +36,7 @@
                 local ply = character:getPlayer()
                 if IsValid(ply) then
                     local steamID = ply:SteamID() or ""
-                    local name = character:getName() or L("unknown")
-                    combo:AddChoice(string.format("[%s] [%s]", name, steamID), steamID)
+                    combo:AddChoice(string.format("[%s] [%s]", character:getName() or L("unknown"), steamID), steamID)
                 end
             end
 

--- a/gamemode/modules/administration/submodules/players/module.lua
+++ b/gamemode/modules/administration/submodules/players/module.lua
@@ -77,7 +77,6 @@ if CLIENT then
                 local steamName = v.steamName or ""
                 local steamID = v.steamID or ""
                 local userGroup = v.userGroup or ""
-                local firstJoin = v.firstJoin or L("unknown")
                 local lastOnlineText
                 if IsValid(player.GetBySteamID(steamID)) then
                     lastOnlineText = L("onlineNow")
@@ -97,7 +96,7 @@ if CLIENT then
                 local charCount = tonumber(v.characterCount) or 0
                 local warnings = tonumber(v.warnings) or 0
                 if filter == "" or steamName:lower():find(filter, 1, true) or steamID:lower():find(filter, 1, true) or userGroup:lower():find(filter, 1, true) then
-                    local line = list:AddLine(steamName, steamID, userGroup, firstJoin, lastOnlineText, playtime, charCount, warnings)
+                    local line = list:AddLine(steamName, steamID, userGroup, v.firstJoin or L("unknown"), lastOnlineText, playtime, charCount, warnings)
                     line.steamID = v.steamID
                 end
             end

--- a/gamemode/modules/chatbox/libraries/shared.lua
+++ b/gamemode/modules/chatbox/libraries/shared.lua
@@ -286,7 +286,6 @@ lia.chat.register("me's", {
     format = "mePossessiveFormat",
     onCanHear = lia.config.get("ChatRange", 280),
     onChatAdd = function(speaker, text, anonymous)
-        local speako = anonymous and L("someone") or hook.Run("GetDisplayedName", speaker, "ic") or IsValid(speaker) and speaker:Name() or language.GetPhrase("#Console")
         local texCol = lia.config.get("ChatColor")
         if LocalPlayer():getTracedEntity() == speaker then texCol = lia.config.get("ChatListenColor") end
         texCol = Color(texCol.r, texCol.g, texCol.b)
@@ -297,7 +296,7 @@ lia.chat.register("me's", {
             nameCol = Color(tempCol.r + 40, tempCol.b + 60, tempCol.g + 40)
         end
 
-        chat.AddText(nameCol, L("mePossessiveFormat", speako, ""), texCol, text)
+        chat.AddText(nameCol, L("mePossessiveFormat", anonymous and L("someone") or hook.Run("GetDisplayedName", speaker, "ic") or IsValid(speaker) and speaker:Name() or language.GetPhrase("#Console"), ""), texCol, text)
     end,
     prefix = {"/me's", "/action's"},
     font = "liaChatFontItalics",
@@ -310,7 +309,6 @@ lia.chat.register("mefarfar", {
     desc = "mefarfarDesc",
     format = "emoteFormat",
     onChatAdd = function(speaker, text, anonymous)
-        local speako = anonymous and L("someone") or hook.Run("GetDisplayedName", speaker, "ic") or IsValid(speaker) and speaker:Name() or language.GetPhrase("#Console")
         local texCol = lia.config.get("ChatColor")
         if LocalPlayer():getTracedEntity() == speaker then texCol = lia.config.get("ChatListenColor") end
         texCol = Color(texCol.r + 45, texCol.g + 45, texCol.b + 45)
@@ -321,7 +319,7 @@ lia.chat.register("mefarfar", {
             nameCol = Color(tempCol.r + 40, tempCol.b + 60, tempCol.g + 40)
         end
 
-        chat.AddText(nameCol, L("emoteFormat", speako, ""), texCol, text)
+        chat.AddText(nameCol, L("emoteFormat", anonymous and L("someone") or hook.Run("GetDisplayedName", speaker, "ic") or IsValid(speaker) and speaker:Name() or language.GetPhrase("#Console"), ""), texCol, text)
     end,
     onCanHear = lia.config.get("ChatRange", 280) * 4,
     prefix = {"/mefarfar", "/actionyy", "/meyy"},

--- a/gamemode/modules/doors/commands.lua
+++ b/gamemode/modules/doors/commands.lua
@@ -319,7 +319,6 @@ lia.command.add("doorinfo", {
         local door = client:getTracedEntity()
         if IsValid(door) and door:isDoor() then
             local disabled = door:getNetVar("disabled", false)
-            local name = door:getNetVar("title", door:getNetVar("name", L("doorTitle")))
             local price = door:getNetVar("price", 0)
             local noSell = door:getNetVar("noSell", false)
             local factionsRaw = door:getNetVar("factions", "[]")
@@ -330,7 +329,6 @@ lia.command.add("doorinfo", {
                 if info then table.insert(factionNames, info.name) end
             end
 
-            local factionsString = not table.IsEmpty(factionNames) and table.concat(factionNames, ", ") or L("none")
             local classesDataRaw = door:getNetVar("classes", "[]")
             local classesTable = util.JSONToTable(classesDataRaw) or {}
             local classNames = {}
@@ -339,8 +337,6 @@ lia.command.add("doorinfo", {
                 local info = lia.class.list[idx]
                 if info then table.insert(classNames, info.name) end
             end
-
-            local classesString = not table.IsEmpty(classNames) and table.concat(classNames, ", ") or L("none")
             local hidden = door:getNetVar("hidden", false)
             local locked = door:getNetVar("locked", false)
             local doorData = {
@@ -350,7 +346,7 @@ lia.command.add("doorinfo", {
                 },
                 {
                     property = L("name"),
-                    value = tostring(name)
+                    value = tostring(door:getNetVar("title", door:getNetVar("name", L("doorTitle"))))
                 },
                 {
                     property = L("price"),
@@ -362,11 +358,11 @@ lia.command.add("doorinfo", {
                 },
                 {
                     property = L("doorInfoFactions"),
-                    value = tostring(factionsString)
+                    value = tostring(not table.IsEmpty(factionNames) and table.concat(factionNames, ", ") or L("none"))
                 },
                 {
                     property = L("classes"),
-                    value = tostring(classesString)
+                    value = tostring(not table.IsEmpty(classNames) and table.concat(classNames, ", ") or L("none"))
                 },
                 {
                     property = L("doorInfoHidden"),

--- a/gamemode/modules/inventory/submodules/vendor/derma/client.lua
+++ b/gamemode/modules/inventory/submodules/vendor/derma/client.lua
@@ -67,7 +67,6 @@ function PANEL:Init()
     self.left:SetDraggable(false)
     self.left.Paint = function()
         if not IsValid(liaVendorEnt) then return end
-        local name = liaVendorEnt:getNetVar("name", L("vendorDefaultName"))
         local scale = liaVendorEnt:getNetVar("scale", 0.5)
         local money = liaVendorEnt:getMoney() and lia.currency.get(liaVendorEnt:getMoney()) or "∞"
         local count = table.Count(self.items.vendor)
@@ -77,14 +76,13 @@ function PANEL:Init()
         surface.SetDrawColor(0, 0, 14, 150)
         surface.DrawRect(0, 0, sw * 0.26, sh * 0.033)
         surface.DrawOutlinedRect(0, 0, sw * 0.26, sh * 0.033)
-        draw.DrawText(name, "liaMediumFont", sw * 0.005, sh * 0.003, color_white, TEXT_ALIGN_LEFT)
+        draw.DrawText(liaVendorEnt:getNetVar("name") or L("vendorDefaultName"), "liaMediumFont", sw * 0.005, sh * 0.003, color_white, TEXT_ALIGN_LEFT)
         draw.DrawText(L("money"), "liaSmallFont", sw * 0.1, sh * 0.05, color_white, TEXT_ALIGN_LEFT)
         draw.DrawText(money, "liaSmallFont", sw * 0.2, sh * 0.05, color_white, TEXT_ALIGN_RIGHT)
         draw.DrawText(L("vendorSellScale"), "liaSmallFont", sw * 0.1, sh * 0.07, color_white, TEXT_ALIGN_LEFT)
         draw.DrawText(math.ceil(scale * 100) .. "%", "liaSmallFont", sw * 0.2, sh * 0.07, color_white, TEXT_ALIGN_RIGHT)
         draw.DrawText(L("vendorItemCount"), "liaSmallFont", sw * 0.1, sh * 0.09, color_white, TEXT_ALIGN_LEFT)
-        local txt = count == 0 and L("vendorNoItems") or count == 1 and L("vendorOneItem") or L("vendorItems", count)
-        draw.DrawText(txt, "liaSmallFont", sw * 0.2, sh * 0.09, color_white, TEXT_ALIGN_RIGHT)
+        draw.DrawText(count == 0 and L("vendorNoItems") or count == 1 and L("vendorOneItem") or L("vendorItems", count), "liaSmallFont", sw * 0.2, sh * 0.09, color_white, TEXT_ALIGN_RIGHT)
     end
 
     self.right = self:Add("DFrame")
@@ -109,19 +107,18 @@ function PANEL:Init()
         draw.DrawText(faction, "liaSmallFont", sw * 0.201, sh * 0.05, color_white, TEXT_ALIGN_RIGHT)
         local class = char:getClass()
         local invCount = char:getInv():getItemCount()
-        local disp = invCount == 0 and L("vendorNoItems") or invCount == 1 and L("vendorOneItem") or L("vendorItems", invCount)
         if lia.class.list[class] then
             draw.DrawText(L("class"), "liaSmallFont", sw * 0.085, sh * 0.07, color_white, TEXT_ALIGN_LEFT)
             draw.DrawText(lia.class.list[class].name, "liaSmallFont", sw * 0.2, sh * 0.07, color_white, TEXT_ALIGN_RIGHT)
             draw.DrawText(L("money"), "liaSmallFont", sw * 0.085, sh * 0.09, color_white, TEXT_ALIGN_LEFT)
             draw.DrawText(lia.currency.get(char:getMoney()), "liaSmallFont", sw * 0.2, sh * 0.09, color_white, TEXT_ALIGN_RIGHT)
             draw.DrawText(L("vendorItemCount"), "liaSmallFont", sw * 0.085, sh * 0.11, color_white, TEXT_ALIGN_LEFT)
-            draw.DrawText(disp, "liaSmallFont", sw * 0.2, sh * 0.11, color_white, TEXT_ALIGN_RIGHT)
+            draw.DrawText(invCount == 0 and L("vendorNoItems") or invCount == 1 and L("vendorOneItem") or L("vendorItems", invCount), "liaSmallFont", sw * 0.2, sh * 0.11, color_white, TEXT_ALIGN_RIGHT)
         else
             draw.DrawText(L("money"), "liaSmallFont", sw * 0.085, sh * 0.07, color_white, TEXT_ALIGN_LEFT)
             draw.DrawText(lia.currency.get(char:getMoney()), "liaSmallFont", sw * 0.2, sh * 0.07, color_white, TEXT_ALIGN_RIGHT)
             draw.DrawText(L("vendorItemCount"), "liaSmallFont", sw * 0.085, sh * 0.09, color_white, TEXT_ALIGN_LEFT)
-            draw.DrawText(disp, "liaSmallFont", sw * 0.2, sh * 0.09, color_white, TEXT_ALIGN_RIGHT)
+            draw.DrawText(invCount == 0 and L("vendorNoItems") or invCount == 1 and L("vendorOneItem") or L("vendorItems", invCount), "liaSmallFont", sw * 0.2, sh * 0.09, color_white, TEXT_ALIGN_RIGHT)
         end
     end
 
@@ -319,8 +316,12 @@ function PANEL:GetItemCategoryList()
     for id in pairs(data) do
         local itm = lia.item.list[id]
         if itm then
-            local cat = itm.category or L("misc")
-            out[cat:sub(1, 1):upper() .. cat:sub(2)] = true
+            local cat = itm.category
+            if cat then
+                out[cat:sub(1, 1):upper() .. cat:sub(2)] = true
+            else
+                out[L("misc"):sub(1, 1):upper() .. L("misc"):sub(2)] = true
+            end
         end
     end
     return out
@@ -341,8 +342,12 @@ function PANEL:applyCategoryFilter()
     if not istable(data) then data = liaVendorEnt:getNetVar("items", {}) end
     for id in SortedPairs(data) do
         local itm = lia.item.list[id]
-        local cat = itm and itm.category or L("misc")
-        cat = cat:sub(1, 1):upper() .. cat:sub(2)
+        local cat = itm and itm.category
+        if cat then
+            cat = cat:sub(1, 1):upper() .. cat:sub(2)
+        else
+            cat = L("misc"):sub(1, 1):upper() .. L("misc"):sub(2)
+        end
         if not self.currentCategory or self.currentCategory == L("vendorShowAll") or cat == self.currentCategory then
             local mode = liaVendorEnt:getTradeMode(id)
             if mode ~= VENDOR_BUYONLY then self:updateItem(id, "vendor") end
@@ -525,8 +530,7 @@ function PANEL:updateAction()
         priceSuffix = string.format("%s %s", price, lia.currency.singular)
     end
 
-    local actionText = self.isSelling and L("vendorSellAction", priceSuffix) or L("vendorBuyAction", priceSuffix)
-    self.action:SetText(actionText)
+    self.action:SetText(self.isSelling and L("vendorSellAction", priceSuffix) or L("vendorBuyAction", priceSuffix))
     self.action.DoClick = function()
         if self.isSelling then
             self:sellItemToVendor()
@@ -585,8 +589,7 @@ function PANEL:updateLabel()
         priceSuffix = string.format("%s %s", price, lia.currency.singular)
     end
 
-    local actionText = self.isSelling and L("vendorSellAction", priceSuffix) or L("vendorBuyAction", priceSuffix)
-    self.action:SetText(actionText)
+    self.action:SetText(self.isSelling and L("vendorSellAction", priceSuffix) or L("vendorBuyAction", priceSuffix))
 end
 
 vgui.Register("VendorItem", PANEL, "DPanel")
@@ -724,9 +727,8 @@ function PANEL:Init()
     end
 
     local currentPreset = entity:getNetVar("preset", "none")
-    local presetLabel = currentPreset == "none" and L("none") or currentPreset
-    self.preset:SetValue(presetLabel)
-    self.preset:ChooseOption(presetLabel)
+    self.preset:SetValue(currentPreset == "none" and L("none") or currentPreset)
+    self.preset:ChooseOption(currentPreset == "none" and L("none") or currentPreset)
     self.preset.OnSelect = function(_, _, value)
         if value == L("none") then value = "none" end
         lia.vendor.editor.preset(value)
@@ -904,8 +906,7 @@ function PANEL:ReloadItemList(filter)
         if filter and not itemName:lower():find(filter:lower(), 1, true) then continue end
         local mode = entity.items[k] and entity.items[k][VENDOR_MODE]
         local current, max = entity:getStock(k)
-        local category = v.category or L("none")
-        local panel = self.items:AddLine(itemName, self:getModeText(mode), entity:getPrice(k), max and current .. "/" .. max or "-", category)
+        local panel = self.items:AddLine(itemName, self:getModeText(mode), entity:getPrice(k), max and current .. "/" .. max or "-", v.category or L("none"))
         panel.item = k
         self.lines[k] = panel
     end

--- a/gamemode/modules/inventory/submodules/vendor/libraries/server.lua
+++ b/gamemode/modules/inventory/submodules/vendor/libraries/server.lua
@@ -1,9 +1,9 @@
 ﻿function MODULE:OnCharTradeVendor(client, vendor, item, isSellingToVendor, _, _, isFailed)
-    local vendorName = vendor:getNetVar("name") or L("unknown")
+    local vendorName = vendor:getNetVar("name")
     if not isSellingToVendor then
-        lia.log.add(client, "vendorBuy", item and (item:getName() or item.name) or "", vendorName, isFailed)
+        lia.log.add(client, "vendorBuy", item and (item:getName() or item.name) or "", vendorName or L("unknown"), isFailed)
     else
-        lia.log.add(client, "vendorSell", item and (item:getName() or item.name) or "", vendorName)
+        lia.log.add(client, "vendorSell", item and (item:getName() or item.name) or "", vendorName or L("unknown"))
     end
 end
 

--- a/gamemode/modules/spawns/libraries/client.lua
+++ b/gamemode/modules/spawns/libraries/client.lua
@@ -33,12 +33,11 @@ function MODULE:HUDPaint()
     lia.util.drawText(L(txtKey), x + 2, y + 2, Color(0, 0, 0, ceil(shadowFade * 255)), 0, 0, "liaHugeFont")
     lia.util.drawText(L(txtKey), x, y, Color(255, 255, 255, ceil(shadowFade * 255)), 0, 0, "liaHugeFont")
     if not hideKey then
-        local dt = left > 0 and L("respawnIn", left) or L("respawnKey", input.GetKeyName(KEY_SPACE))
         surface.SetFont("liaMediumFont")
-        local dw = select(1, surface.GetTextSize(dt))
+        local dw = select(1, surface.GetTextSize(left > 0 and L("respawnIn", left) or L("respawnKey", input.GetKeyName(KEY_SPACE))))
         local dx, dy = (ScrW() - dw) / 2, y + h + 10
-        lia.util.drawText(dt, dx + 1, dy + 1, Color(0, 0, 0, 255), 0, 0, "liaMediumFont")
-        lia.util.drawText(dt, dx, dy, Color(255, 255, 255, 255), 0, 0, "liaMediumFont")
+        lia.util.drawText(left > 0 and L("respawnIn", left) or L("respawnKey", input.GetKeyName(KEY_SPACE)), dx + 1, dy + 1, Color(0, 0, 0, 255), 0, 0, "liaMediumFont")
+        lia.util.drawText(left > 0 and L("respawnIn", left) or L("respawnKey", input.GetKeyName(KEY_SPACE)), dx, dy, Color(255, 255, 255, 255), 0, 0, "liaMediumFont")
     end
 
     if left <= 0 and input.IsKeyDown(KEY_SPACE) then

--- a/gamemode/modules/spawns/libraries/server.lua
+++ b/gamemode/modules/spawns/libraries/server.lua
@@ -131,9 +131,8 @@ function MODULE:PlayerDeath(client, _, attacker)
         if lia.config.get("DeathPopupEnabled", true) then
             local dateStr = lia.time.GetDate()
             local attackerChar = attacker:getChar()
-            local charId = attackerChar and tostring(attackerChar:getID()) or L("na")
             local steamId = tostring(attacker:SteamID())
-            ClientAddText(client, Color(255, 0, 0), "[" .. string.upper(L("death")) .. "]: ", Color(255, 255, 255), dateStr, " - ", L("killedBy"), " ", Color(255, 215, 0), L("characterID"), ": ", Color(255, 255, 255), charId, " (", Color(0, 255, 0), steamId, Color(255, 255, 255), ")")
+            ClientAddText(client, Color(255, 0, 0), "[" .. string.upper(L("death")) .. "]: ", Color(255, 255, 255), dateStr, " - ", L("killedBy"), " ", Color(255, 215, 0), L("characterID"), ": ", Color(255, 255, 255), attackerChar and tostring(attackerChar:getID()) or L("na"), " (", Color(0, 255, 0), steamId, Color(255, 255, 255), ")")
         end
     end
 


### PR DESCRIPTION
## Summary
- avoid storing localized strings in temporary variables across UI and server logic
- invoke `L()` directly in vendor, player management, and chat modules

## Testing
- `luac -p gamemode/modules/administration/commands.lua`
- `luac -p gamemode/core/hooks/server.lua` *(fails: syntax error near 'end' due to unsupported 'continue')*

------
https://chatgpt.com/codex/tasks/task_e_688fe7ed3f0c8327b1f7b97c759d1b16