### PR TITLE
Prefer SteamID for player checks

### DIFF
--- a/gamemode/core/libraries/util.lua
+++ b/gamemode/core/libraries/util.lua
@@ -9,10 +9,12 @@ end
 
 function lia.util.getBySteamID(steamID)
     if not isstring(steamID) or steamID == "" then return end
+    local sid = steamID
+    if steamID:match("^%d+$") and #steamID >= 17 then
+        sid = util.SteamIDFrom64(steamID)
+    end
     for _, client in player.Iterator() do
-        local sid = client:SteamID()
-        local sid64 = client:SteamID64()
-        if (sid == steamID or sid64 == steamID) and client:getChar() then return client end
+        if client:SteamID() == sid and client:getChar() then return client end
     end
 end
 


### PR DESCRIPTION
## Summary
- resolve players by SteamID and convert SteamID64 on demand
- keep KnownCheaters list keyed by STEAMID64 IDs

## Testing
- `luacheck gamemode/core/libraries/util.lua gamemode/modules/protection/libraries/server.lua` *(fails: expected '=' near 'end')*

------
https://chatgpt.com/codex/tasks/task_e_688fe90a44148327a2629be625ac1d19