### PR TITLE
refactor: avoid storing localization in locals

### DIFF
--- a/gamemode/core/libraries/commands.lua
+++ b/gamemode/core/libraries/commands.lua
@@ -371,8 +371,7 @@ else
                 ctrl = vgui.Create("DComboBox", panel)
                 ctrl:SetValue(L("selectItemPrompt"))
                 for uniqueID, item in SortedPairsByMemberValue(lia.item.list, "name") do
-                    local itemName = item.getName and item:getName() or L(item.name)
-                    ctrl:AddChoice(itemName, uniqueID)
+                    ctrl:AddChoice(item.getName and item:getName() or L(item.name), uniqueID)
                 end
             elseif fieldType == "faction" then
                 ctrl = vgui.Create("DComboBox", panel)

--- a/gamemode/core/netcalls/client.lua
+++ b/gamemode/core/netcalls/client.lua
@@ -296,8 +296,7 @@ net.Receive("actBar", function()
 
     local text = net.ReadString()
     local time = net.ReadFloat()
-    local display = text:sub(1, 1) == "@" and L(text:sub(2)) or text
-    lia.bar.drawAction(display, time)
+    lia.bar.drawAction(text:sub(1, 1) == "@" and L(text:sub(2)) or text, time)
 end)
 
 net.Receive("OpenInvMenu", function()

--- a/gamemode/modules/doors/libraries/client.lua
+++ b/gamemode/modules/doors/libraries/client.lua
@@ -10,12 +10,11 @@
         local x, y = pos.x, pos.y
         local owner = entity:GetDTEntity(0)
         local classesRaw = entity:getNetVar("classes")
-        local name = entity:getNetVar("title", entity:getNetVar("name", IsValid(owner) and L("doorTitleOwned") or (not classesRaw or classesRaw == "[]") and not entity:getNetVar("factions") and L("doorTitle") or ""))
         local factions = entity:getNetVar("factions", "[]")
         local classes = classesRaw
         local price = entity:getNetVar("price", 0)
         local ownable = not entity:getNetVar("noSell", false)
-        lia.util.drawText(name, x, y, ColorAlpha(color_white, alpha), 1, 1)
+        lia.util.drawText(entity:getNetVar("title", entity:getNetVar("name", IsValid(owner) and L("doorTitleOwned") or (not classesRaw or classesRaw == "[]") and not entity:getNetVar("factions") and L("doorTitle") or "")), x, y, ColorAlpha(color_white, alpha), 1, 1)
         y = y + 20
         if ownable then
             lia.util.drawText(L("priceLabel", lia.currency.get(price)), x, y, ColorAlpha(color_white, alpha), 1, 1)

--- a/gamemode/modules/inventory/submodules/vendor/derma/client.lua
+++ b/gamemode/modules/inventory/submodules/vendor/derma/client.lua
@@ -902,11 +902,11 @@ function PANEL:ReloadItemList(filter)
     self.lines = {}
     self.items:Clear()
     for k, v in SortedPairsByMemberValue(lia.item.list, "name") do
-        local itemName = v.getName and v:getName() or L(v.name)
-        if filter and not itemName:lower():find(filter:lower(), 1, true) then continue end
+        local name = v.getName and v:getName() or v.name
+        if filter and not (v.getName and name or L(name)):lower():find(filter:lower(), 1, true) then continue end
         local mode = entity.items[k] and entity.items[k][VENDOR_MODE]
         local current, max = entity:getStock(k)
-        local panel = self.items:AddLine(itemName, self:getModeText(mode), entity:getPrice(k), max and current .. "/" .. max or "-", v.category or L("none"))
+        local panel = self.items:AddLine(v.getName and name or L(name), self:getModeText(mode), entity:getPrice(k), max and current .. "/" .. max or "-", v.category or L("none"))
         panel.item = k
         self.lines[k] = panel
     end


### PR DESCRIPTION
## Summary
- call L directly in act bar draw
- remove local itemName for vendor listings
- inline door title translation
- simplify command item option names

## Testing
- `luacheck .` *(fails: 12303 warnings / 21 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688fef7a17e88327bc6d789fdb49acbc