### PR TITLE
Remove fallback localization strings

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -1034,7 +1034,7 @@ concommand.Add("lia_wipedb", function(client)
 
     if resetCalled < RealTime() then
         resetCalled = RealTime() + 3
-        MsgC(Color(255, 0, 0), "[Lilia] " .. L("databaseWipeConfirm", "lia_wipedb") .. "\n")
+        MsgC(Color(255, 0, 0), "[Lilia] " .. L("databaseWipeConfirm") .. "\n")
     else
         resetCalled = 0
         MsgC(Color(255, 0, 0), "[Lilia] " .. L("databaseWipeProgress") .. "\n")

--- a/gamemode/modules/administration/submodules/database/module.lua
+++ b/gamemode/modules/administration/submodules/database/module.lua
@@ -5,7 +5,7 @@ MODULE.Privileges = {
     {
         Name = L("View DB Tables"),
         MinAccess = "superadmin",
-        Category = L("categoryDatabase", "Database")
+        Category = L("categoryDatabase")
     }
 }
 

--- a/gamemode/modules/administration/submodules/factions/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/factions/libraries/client.lua
@@ -31,11 +31,11 @@ local function OpenRoster(panel, data)
         local list = page:Add("DListView")
         list:Dock(FILL)
         list:SetMultiSelect(false)
-        list:AddColumn(L("name", "Name"))
-        list:AddColumn(L("steamID", "SteamID"))
-        list:AddColumn(L("class", "Class"))
-        list:AddColumn(L("characterPlaytime", "Character Playtime"))
-        list:AddColumn(L("lastOnline", "Last Online"))
+        list:AddColumn(L("name"))
+        list:AddColumn(L("steamID"))
+        list:AddColumn(L("class"))
+        list:AddColumn(L("characterPlaytime"))
+        list:AddColumn(L("lastOnline"))
         local function populate(filter)
             list:Clear()
             filter = string.lower(filter or "")
@@ -63,9 +63,9 @@ local function OpenRoster(panel, data)
                     end):SetIcon("icon16/user_delete.png")
                 end
 
-                local charSubMenu = menu:AddSubMenu(L("viewCharacterList", "View Character List"))
+                local charSubMenu = menu:AddSubMenu(L("viewCharacterList"))
                 if not characters or #characters == 0 then
-                    charSubMenu:AddOption(L("none", "None"))
+                    charSubMenu:AddOption(L("none"))
                 else
                     for _, name in ipairs(characters) do
                         charSubMenu:AddOption(name)
@@ -83,13 +83,13 @@ local function OpenRoster(panel, data)
                     SetClipboardText(string.sub(rowString, 1, -4))
                 end):SetIcon("icon16/page_copy.png")
 
-                menu:AddOption(L("copyName", "Copy Name"), function()
+                menu:AddOption(L("copyName"), function()
                     local name = ln.rowData and ln.rowData.name or ln:GetColumnText(1) or ""
                     SetClipboardText(name)
                 end):SetIcon("icon16/page_copy.png")
 
-                menu:AddOption(L("copySteamID", "Copy SteamID"), function() SetClipboardText(steamID) end):SetIcon("icon16/page_copy.png")
-                menu:AddOption(L("openSteamProfile", "Open Steam Profile"), function() gui.OpenURL("https://steamcommunity.com/profiles/" .. steamID) end):SetIcon("icon16/world.png")
+                menu:AddOption(L("copySteamID"), function() SetClipboardText(steamID) end):SetIcon("icon16/page_copy.png")
+                menu:AddOption(L("openSteamProfile"), function() gui.OpenURL("https://steamcommunity.com/profiles/" .. steamID) end):SetIcon("icon16/world.png")
             end)
         end
 
@@ -114,7 +114,7 @@ end)
 function MODULE:PopulateAdminTabs(pages)
     if IsValid(LocalPlayer()) and LocalPlayer():hasPrivilege("Can Manage Factions") then
         table.insert(pages, {
-            name = L("factionManagement", "Factions"),
+            name = L("factionManagement"),
             drawFunc = function(panel)
                 rosterPanel = panel
                 net.Start("liaRequestFactionRoster")

--- a/gamemode/modules/administration/submodules/factions/module.lua
+++ b/gamemode/modules/administration/submodules/factions/module.lua
@@ -1,12 +1,12 @@
-MODULE.name = L("moduleFactionMgmtName", "Faction Management")
+MODULE.name = L("moduleFactionMgmtName")
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.desc = L("moduleFactionMgmtDesc", "View and manage faction rosters")
+MODULE.desc = L("moduleFactionMgmtDesc")
 MODULE.Privileges = {
     {
-        Name = L("canManageFactions", "Can Manage Factions"),
+        Name = L("canManageFactions"),
         MinAccess = "admin",
-        Category = L("categoryFactions", "Factions"),
+        Category = L("categoryFactions"),
     },
 }
 

--- a/gamemode/modules/administration/submodules/flags/module.lua
+++ b/gamemode/modules/administration/submodules/flags/module.lua
@@ -9,7 +9,7 @@ MODULE.Privileges = {
     {
         Name = L("canAccessFlagManagement"),
         MinAccess = "superadmin",
-        Category = L("categoryFlags", "Flags"),
+        Category = L("categoryFlags"),
     }
 }
 

--- a/gamemode/modules/administration/submodules/players/module.lua
+++ b/gamemode/modules/administration/submodules/players/module.lua
@@ -1,7 +1,7 @@
-MODULE.name = L("modulePlayerListName", "Player List")
+MODULE.name = L("modulePlayerListName")
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.desc = L("modulePlayerListDesc", "View player accounts and characters.")
+MODULE.desc = L("modulePlayerListDesc")
 if CLIENT then
     local panelRef
     local charMenuContext
@@ -62,14 +62,14 @@ if CLIENT then
             return col
         end
 
-        addSizedColumn(L("steamName", "Steam Name"))
-        addSizedColumn(L("steamID", "SteamID"))
-        addSizedColumn(L("usergroup", "Usergroup"))
-        addSizedColumn(L("firstJoin", "First Join"))
-        addSizedColumn(L("lastOnline", "Last Online"))
-        addSizedColumn(L("playtime", "Playtime"))
-        addSizedColumn(L("characters", "Characters"))
-        addSizedColumn(L("warnings", "Warnings"))
+        addSizedColumn(L("steamName"))
+        addSizedColumn(L("steamID"))
+        addSizedColumn(L("usergroup"))
+        addSizedColumn(L("firstJoin"))
+        addSizedColumn(L("lastOnline"))
+        addSizedColumn(L("playtime"))
+        addSizedColumn(L("characters"))
+        addSizedColumn(L("warnings"))
         local function populate(filter)
             list:Clear()
             filter = string.lower(filter or "")
@@ -108,9 +108,9 @@ if CLIENT then
             if not IsValid(line) or not line.steamID then return end
             local parentList = self
             requestPlayerCharacters(line.steamID, line, function(menu, ln, steamID, characters)
-                local charSubMenu = menu:AddSubMenu(L("viewCharacterList", "View Character List"))
+                local charSubMenu = menu:AddSubMenu(L("viewCharacterList"))
                 if not characters or #characters == 0 then
-                    charSubMenu:AddOption(L("none", "None"))
+                    charSubMenu:AddOption(L("none"))
                 else
                     for _, name in ipairs(characters) do
                         charSubMenu:AddOption(name)
@@ -128,8 +128,8 @@ if CLIENT then
                     SetClipboardText(string.sub(rowString, 1, -4))
                 end):SetIcon("icon16/page_copy.png")
 
-                menu:AddOption(L("copySteamID", "Copy SteamID"), function() SetClipboardText(steamID) end):SetIcon("icon16/page_copy.png")
-                menu:AddOption(L("openSteamProfile", "Open Steam Profile"), function() gui.OpenURL("https://steamcommunity.com/profiles/" .. steamID) end):SetIcon("icon16/world.png")
+                menu:AddOption(L("copySteamID"), function() SetClipboardText(steamID) end):SetIcon("icon16/page_copy.png")
+                menu:AddOption(L("openSteamProfile"), function() gui.OpenURL("https://steamcommunity.com/profiles/" .. steamID) end):SetIcon("icon16/world.png")
             end)
         end
     end)
@@ -137,7 +137,7 @@ if CLIENT then
     function MODULE:PopulateAdminTabs(pages)
         if not IsValid(LocalPlayer()) or not LocalPlayer():IsAdmin() then return end
         table.insert(pages, {
-            name = L("players", "Players"),
+            name = L("players"),
             drawFunc = function(panel)
                 panelRef = panel
                 net.Start("liaRequestPlayers")

--- a/gamemode/modules/administration/submodules/staffmanagement/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/staffmanagement/libraries/client.lua
@@ -18,7 +18,7 @@ lia.net.readBigTable("liaStaffSummary", function(data)
     end
     addSizedColumn("Player")
     addSizedColumn("Player Steam ID")
-    addSizedColumn(L("usergroup", "Usergroup"))
+    addSizedColumn(L("usergroup"))
     addSizedColumn("Warning Count")
     addSizedColumn("Ticket Count")
     addSizedColumn("Kick Count")

--- a/gamemode/modules/administration/submodules/tickets/module.lua
+++ b/gamemode/modules/administration/submodules/tickets/module.lua
@@ -35,7 +35,7 @@ if CLIENT then
         addSizedColumn(L("timestamp"))
         addSizedColumn(L("requester"))
         addSizedColumn(L("admin"))
-        addSizedColumn(L("Ticket Message", "Message"))
+        addSizedColumn(L("Ticket Message"))
 
         local function populate(filter)
             list:Clear()
@@ -96,7 +96,7 @@ if CLIENT then
     function MODULE:PopulateAdminTabs(pages)
         if not IsValid(LocalPlayer()) or not (LocalPlayer():hasPrivilege(L("alwaysSeeTickets")) or LocalPlayer():isStaffOnDuty()) then return end
         table.insert(pages, {
-            name = L("tickets", "Tickets"),
+            name = L("tickets"),
             drawFunc = function(panel)
                 ticketPanel = panel
                 net.Start("liaRequestActiveTickets")

--- a/gamemode/modules/administration/submodules/warns/commands.lua
+++ b/gamemode/modules/administration/submodules/warns/commands.lua
@@ -81,11 +81,11 @@ lia.command.add("viewwarns", {
                     field = "timestamp"
                 },
                 {
-                    name = L("Admin", "Admin"),
+                    name = L("Admin"),
                     field = "admin"
                 },
                 {
-                    name = L("Warning Message", "Warning Message"),
+                    name = L("Warning Message"),
                     field = "warningMessage"
                 }
             }, warningList, {

--- a/gamemode/modules/administration/submodules/warns/module.lua
+++ b/gamemode/modules/administration/submodules/warns/module.lua
@@ -32,9 +32,9 @@ if CLIENT then
         end
 
         addSizedColumn(L("timestamp"))
-        addSizedColumn(L("Warned", "Warned"))
-        addSizedColumn(L("Admin", "Admin"))
-        addSizedColumn(L("Warning Message", "Warning Message"))
+        addSizedColumn(L("Warned"))
+        addSizedColumn(L("Admin"))
+        addSizedColumn(L("Warning Message"))
 
         local function populate(filter)
             list:Clear()


### PR DESCRIPTION
## Summary
- remove hardcoded fallback text from admin UIs to rely on translation keys

## Testing
- `luacheck gamemode/core/hooks/server.lua gamemode/modules/administration/submodules/database/module.lua gamemode/modules/administration/submodules/factions/libraries/client.lua gamemode/modules/administration/submodules/factions/module.lua gamemode/modules/administration/submodules/flags/module.lua gamemode/modules/administration/submodules/players/module.lua gamemode/modules/administration/submodules/staffmanagement/libraries/client.lua gamemode/modules/administration/submodules/tickets/module.lua gamemode/modules/administration/submodules/warns/commands.lua gamemode/modules/administration/submodules/warns/module.lua` *(fails: expected '=' near 'end')*

------
https://chatgpt.com/codex/tasks/task_e_6890016b65708327aede887f94e16d56