### PR TITLE
Localize weapon generation defaults

### DIFF
--- a/gamemode/core/libraries/item.lua
+++ b/gamemode/core/libraries/item.lua
@@ -488,8 +488,9 @@ function lia.item.generateWeapons()
         local baseType = isGrenade and "base_grenade" or "base_weapons"
         local ITEM = lia.item.register(className, baseType, nil, nil, true)
         ITEM.name = override.name or wep.PrintName or className
-        ITEM.desc = override.desc or "A Weapon"
-        ITEM.category = override.category or "Weapons"
+        ITEM.desc = override.desc or L("weaponsDesc")
+        -- assign a localized category based on weapon type
+        ITEM.category = override.category or (isGrenade and L("itemCatGrenades") or L("itemCatWeapons"))
         ITEM.model = override.model or wep.WorldModel or wep.WM or "models/props_c17/suitcase_passenger_physics.mdl"
         ITEM.class = override.class or className
         local size = lia.item.holdTypeSizeMapping[holdType] or {
@@ -500,7 +501,6 @@ function lia.item.generateWeapons()
         ITEM.width = override.width or size.width
         ITEM.height = override.height or size.height
         ITEM.weaponCategory = override.weaponCategory or lia.item.holdTypeToWeaponCategory[holdType] or "primary"
-        ITEM.category = isGrenade and "grenade" or "weapons"
     end
 end
 


### PR DESCRIPTION
## Summary
- use localized descriptions and categories when auto-generating weapon items

## Testing
- `luacheck gamemode/core/libraries/item.lua` *(fails: expected '=' near 'end')*

------
https://chatgpt.com/codex/tasks/task_e_689006a84cd4832794671320429a8f6f