### PR TITLE
Use lia.error for error logging

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -1048,9 +1048,9 @@ concommand.Add("database_list", function(ply)
     if IsValid(ply) then return end
     lia.db.GetCharacterTable(function(columns)
         if #columns == 0 then
-            print(L("dbColumnsNone"))
+            lia.error(L("dbColumnsNone"))
         else
-            print(L("dbColumnsList", table.concat(columns, ", ")))
+            lia.information(L("dbColumnsList", table.concat(columns, ", ")))
         end
     end)
 end)

--- a/gamemode/core/libraries/thirdparty/sh_deferred.lua
+++ b/gamemode/core/libraries/thirdparty/sh_deferred.lua
@@ -173,7 +173,7 @@ function Promise:_handle(value)
             if UNHANDLED_PROMISES[self.rejectionHandlerID] and not DEBUG_IGNOREUNHANDLED then
                 UNHANDLED_PROMISES[self.rejectionHandlerID] = nil
                 lia.error("Unhandled rejection: " .. tostring(self.reason or "") .. "\n")
-                print(trace)
+                lia.error(trace)
             end
         end)
     end

--- a/gamemode/core/libraries/thirdparty/sh_net.lua
+++ b/gamemode/core/libraries/thirdparty/sh_net.lua
@@ -195,7 +195,7 @@ do
             if not k then continue end
             tv = sub(str, index, index)
             index = index + 1
-            if not self[tv] then print("did not find type: " .. tv) end
+            if not self[tv] then lia.error("did not find type: " .. tv) end
             index, v = self[tv](self, index, str, cache)
             cur[k] = v
         end

--- a/gamemode/core/meta/character.lua
+++ b/gamemode/core/meta/character.lua
@@ -168,7 +168,7 @@ function characterMeta:setData(k, v, noReplication, receiver)
                         charID = self:getID(),
                         key = nk,
                         value = encoded
-                    }, "chardata", function(success, err) if not success then print(L("failedInsertCharData", err)) end end)
+                    }, "chardata", function(success, err) if not success then lia.error(L("failedInsertCharData", err)) end end)
                 end
             end
         else
@@ -180,7 +180,7 @@ function characterMeta:setData(k, v, noReplication, receiver)
                     charID = self:getID(),
                     key = k,
                     value = encoded
-                }, "chardata", function(success, err) if not success then print(L("failedInsertCharData", err)) end end)
+                }, "chardata", function(success, err) if not success then lia.error(L("failedInsertCharData", err)) end end)
             end
         end
     end

--- a/gamemode/modules/inventory/libraries/server.lua
+++ b/gamemode/modules/inventory/libraries/server.lua
@@ -105,7 +105,7 @@ function MODULE:HandleItemTransferRequest(client, itemID, x, y, invID)
     local function fail(err)
         client.invTransferTransaction = nil
         if err then
-            print(err)
+            lia.error(err)
             debug.Trace()
         end
 

--- a/gamemode/modules/mainmenu/libraries/server.lua
+++ b/gamemode/modules/mainmenu/libraries/server.lua
@@ -54,7 +54,7 @@ function MODULE:PlayerLoadedChar(client, character)
 
             net.Send(client)
         else
-            print(L("noDataCharID", charID))
+            lia.error(L("noDataCharID", charID))
         end
     end)
 

--- a/gamemode/modules/teams/libraries/server.lua
+++ b/gamemode/modules/teams/libraries/server.lua
@@ -5,7 +5,7 @@
         if info.OnSet then info:OnSet(client) end
         if oldClass ~= class and info.OnTransferred then info:OnTransferred(client, oldClass) end
     else
-        print("[" .. L("error") .. "] " .. L("invalidClassError", tostring(class)))
+        lia.error(L("invalidClassError", tostring(class)))
     end
 
     if info2 and info2.OnLeave then info2:OnLeave(client) end

--- a/gmacreator.lua
+++ b/gmacreator.lua
@@ -91,7 +91,7 @@ do
             if normalized:match(allow_pattern) then
                 for _, block_pattern in ipairs(blocklist) do
                     if normalized:match(block_pattern) then
-                        print(L("gmaFileBlocked"), normalized)
+                        lia.error(L("gmaFileBlocked") .. " " .. normalized)
                         goto cont
                     end
                 end
@@ -105,7 +105,7 @@ do
             end
         end
 
-        print(L("gmaFileNotWhitelisted", normalized))
+        lia.error(L("gmaFileNotWhitelisted", normalized))
         ::cont::
     end
 


### PR DESCRIPTION
## Summary
- replace `print` with `lia.error` for error messages
- adjust database column listing to use `lia.error`/`lia.information`

## Testing
- `luacheck .` *(fails: many warnings/errors)*

------
https://chatgpt.com/codex/tasks/task_e_68901f3ed4888327a2f1c2f506129490