### PR TITLE
Use meta playtime for admin lists

### DIFF
--- a/gamemode/modules/administration/submodules/charlist/module.lua
+++ b/gamemode/modules/administration/submodules/charlist/module.lua
@@ -20,6 +20,11 @@ LEFT JOIN lia_chardata AS d ON d.charID = c.id AND d.key = 'charBanInfo']], func
                 local stored = lia.char.loaded[row.id]
                 local isBanned = tonumber(row.banned) == 1
                 local steamID = tostring(row.steamID)
+                local playTime = tonumber(row.playtime) or 0
+                if stored then
+                    local loginTime = stored:getLoginTime() or os.time()
+                    playTime = stored:getPlayTime() + os.time() - loginTime
+                end
                 local entry = {
                     ID = row.id,
                     Name = row.name,
@@ -28,7 +33,7 @@ LEFT JOIN lia_chardata AS d ON d.charID = c.id AND d.key = 'charBanInfo']], func
                     SteamID = steamID,
                     LastUsed = stored and "Online" or row.lastJoinTime,
                     Banned = isBanned,
-                    PlayTime = tonumber(row.playtime) or 0,
+                    PlayTime = playTime,
                     Money = tonumber(row.money) or 0
                 }
                 if isBanned then


### PR DESCRIPTION
## Summary
- Use player meta to show session-inclusive playtime in admin player list
- Fetch live character playtime for character overview

## Testing
- `luacheck gamemode/modules/administration/submodules/players/module.lua gamemode/modules/administration/submodules/charlist/module.lua`

------
https://chatgpt.com/codex/tasks/task_e_68903e3c634c832786c4deca3c39146f