### PR TITLE
fix: correct ban and kick localization parameters

### DIFF
--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -588,7 +588,7 @@ if SERVER then
             evidence = ""
         }, nil, "bans")
 
-        self:Kick(L("banMessage", self, duration or 0, reason or L("genericReason", self)))
+        self:Kick(L("banMessage", duration or 0, reason or L("genericReason")))
     end
 
     function playerMeta:setAction(text, time, callback)

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -307,7 +307,7 @@ lia.command.add("plykick", {
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
-            target:Kick(L("kickMessage", target, arguments[2] or L("genericReason")))
+            target:Kick(L("kickMessage", arguments[2] or L("genericReason")))
             client:notifyLocalized("plyKicked")
             lia.log.add(client, "plyKick", target:Name())
             lia.db.insertTable({


### PR DESCRIPTION
## Summary
- fix plyban's Kick message to pass correct duration and reason
- remove erroneous player argument from plykick's localization

## Testing
- `luacheck gamemode/core/meta/player.lua gamemode/modules/administration/commands.lua | head -n 20` *(fails: expected '=' near 'end')*


------
https://chatgpt.com/codex/tasks/task_e_689040f7999483278de6307a3dc8e2bb