### PR TITLE
fix: handle invalid char ban data

### DIFF
--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -253,8 +253,12 @@ lia.command.add("charlist", {
 
                 local banInfo = info.charBanInfo
                 if not banInfo and row.charBanInfo and row.charBanInfo ~= "" then
-                    local decoded = pon.decode(row.charBanInfo)
-                    banInfo = decoded and decoded[1] or {}
+                    local ok, decoded = pcall(pon.decode, row.charBanInfo)
+                    if ok then
+                        banInfo = decoded and decoded[1] or {}
+                    else
+                        banInfo = util.JSONToTable(row.charBanInfo) or {}
+                    end
                 end
 
                 local entry = {

--- a/gamemode/modules/administration/submodules/charlist/module.lua
+++ b/gamemode/modules/administration/submodules/charlist/module.lua
@@ -39,8 +39,12 @@ LEFT JOIN lia_chardata AS d ON d.charID = c.id AND d.key = 'charBanInfo']], func
                 if isBanned then
                     local banInfo = {}
                     if row.charBanInfo and row.charBanInfo ~= "" then
-                        local decoded = pon.decode(row.charBanInfo)
-                        banInfo = decoded and decoded[1] or {}
+                        local ok, decoded = pcall(pon.decode, row.charBanInfo)
+                        if ok then
+                            banInfo = decoded and decoded[1] or {}
+                        else
+                            banInfo = util.JSONToTable(row.charBanInfo) or {}
+                        end
                     end
                     entry.BanningAdminName = banInfo.name or ""
                     entry.BanningAdminSteamID = banInfo.steamID or ""


### PR DESCRIPTION
## Summary
- avoid crashes in charlist when `charBanInfo` contains malformed data
- fall back to JSON decoding when PON decoding fails

## Testing
- `luacheck gamemode/modules/administration/commands.lua gamemode/modules/administration/submodules/charlist/module.lua`

------
https://chatgpt.com/codex/tasks/task_e_68904b16fda88327938586b8e22ce381