### PR TITLE
feat: add character ban options to admin character list

### DIFF
--- a/gamemode/modules/administration/submodules/charlist/module.lua
+++ b/gamemode/modules/administration/submodules/charlist/module.lua
@@ -158,7 +158,10 @@ else
                                         end
                                     end
                                 end
-                                if match then list:AddLine(unpack(values)) end
+                                if match then
+                                    local line = list:AddLine(unpack(values))
+                                    line.CharID = row.ID
+                                end
                             end
                         end
 
@@ -182,6 +185,30 @@ else
                                 end
                                 SetClipboardText(string.sub(rowString, 1, -4))
                             end):SetIcon("icon16/page_copy.png")
+
+                            if line.CharID then
+                                if LocalPlayer():hasPrivilege("Manage Characters") then
+                                    menu:AddOption(L("banCharacter"), function()
+                                        LocalPlayer():ConCommand([[say "/charban ]] .. line.CharID .. [["]])
+                                    end):SetIcon("icon16/cancel.png")
+                                    menu:AddOption(L("unbanCharacter"), function()
+                                        LocalPlayer():ConCommand([[say "/charunban ]] .. line.CharID .. [["]])
+                                    end):SetIcon("icon16/accept.png")
+                                end
+
+                                if LocalPlayer():hasPrivilege("Ban Offline") then
+                                    menu:AddOption(L("banCharacterOffline"), function()
+                                        LocalPlayer():ConCommand([[say "/charbanoffline ]] .. line.CharID .. [["]])
+                                    end):SetIcon("icon16/cancel.png")
+                                end
+
+                                if LocalPlayer():hasPrivilege("Unban Offline") then
+                                    menu:AddOption(L("unbanCharacterOffline"), function()
+                                        LocalPlayer():ConCommand([[say "/charunbanoffline ]] .. line.CharID .. [["]])
+                                    end):SetIcon("icon16/accept.png")
+                                end
+                            end
+
                             menu:Open()
                         end
                     end

--- a/gamemode/modules/administration/submodules/permissions/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/client.lua
@@ -181,20 +181,35 @@ net.Receive("DisplayCharList", function()
         end
 
         listView.OnRowRightClick = function(_, _, ln)
-            if ln and ln.CharID and (LocalPlayer():hasPrivilege("Unban Offline") or LocalPlayer():hasPrivilege("Ban Offline")) then
-                local dMenu = DermaMenu()
-                if LocalPlayer():hasPrivilege("Unban Offline") then
-                    local opt1 = dMenu:AddOption(L("banCharacter"), function() LocalPlayer():ConCommand([[say "/charbanoffline ]] .. ln.CharID .. [["]]) end)
-                    opt1:SetIcon("icon16/cancel.png")
-                end
-
-                if LocalPlayer():hasPrivilege("Ban Offline") then
-                    local opt2 = dMenu:AddOption(L("unbanCharacter"), function() LocalPlayer():ConCommand([[say "/charunbanoffline ]] .. ln.CharID .. [["]]) end)
-                    opt2:SetIcon("icon16/accept.png")
-                end
-
-                dMenu:Open()
+            if not (ln and ln.CharID) then return end
+            if not (LocalPlayer():hasPrivilege("Manage Characters") or LocalPlayer():hasPrivilege("Ban Offline") or LocalPlayer():hasPrivilege("Unban Offline")) then return end
+            local dMenu = DermaMenu()
+            if LocalPlayer():hasPrivilege("Manage Characters") then
+                local opt1 = dMenu:AddOption(L("banCharacter"), function()
+                    LocalPlayer():ConCommand([[say "/charban ]] .. ln.CharID .. [["]])
+                end)
+                opt1:SetIcon("icon16/cancel.png")
+                local opt2 = dMenu:AddOption(L("unbanCharacter"), function()
+                    LocalPlayer():ConCommand([[say "/charunban ]] .. ln.CharID .. [["]])
+                end)
+                opt2:SetIcon("icon16/accept.png")
             end
+
+            if LocalPlayer():hasPrivilege("Ban Offline") then
+                local opt3 = dMenu:AddOption(L("banCharacterOffline"), function()
+                    LocalPlayer():ConCommand([[say "/charbanoffline ]] .. ln.CharID .. [["]])
+                end)
+                opt3:SetIcon("icon16/cancel.png")
+            end
+
+            if LocalPlayer():hasPrivilege("Unban Offline") then
+                local opt4 = dMenu:AddOption(L("unbanCharacterOffline"), function()
+                    LocalPlayer():ConCommand([[say "/charunbanoffline ]] .. ln.CharID .. [["]])
+                end)
+                opt4:SetIcon("icon16/accept.png")
+            end
+
+            dMenu:Open()
         end
     end
 end)


### PR DESCRIPTION
## Summary
- allow banning and unbanning characters directly from the Character List admin tab
- expose charban/charunban and offline variants in the character list command UI

## Testing
- `luacheck gamemode/modules/administration/submodules/charlist/module.lua | tail -n 5`
- `luacheck gamemode/modules/administration/submodules/permissions/libraries/client.lua | tail -n 5` *(fails: expected '=' near 'end')*


------
https://chatgpt.com/codex/tasks/task_e_68904dd65be08327a88dac4d417d0099