### PR TITLE
Remove prop ESP feature

### DIFF
--- a/gamemode/core/libraries/option.lua
+++ b/gamemode/core/libraries/option.lua
@@ -499,16 +499,6 @@ lia.option.add("espItems", "ESP Items", "Enable ESP for items", false, nil, {
     end
 })
 
-lia.option.add("espProps", "ESP Props", "Enable ESP for props", false, nil, {
-    category = "ESP",
-    isQuick = true,
-    visible = function()
-        local ply = LocalPlayer()
-        if not IsValid(ply) then return false end
-        return ply:isStaffOnDuty() or ply:hasPrivilege("No Clip Outside Staff Character")
-    end
-})
-
 lia.option.add("espEntities", "ESP Entities", "Enable ESP for entities", false, nil, {
     category = "ESP",
     isQuick = true,
@@ -546,20 +536,6 @@ lia.option.add("espItemsColor", "ESP Items Color", "Sets the ESP color for items
 lia.option.add("espEntitiesColor", "ESP Entities Color", "Sets the ESP color for entities", {
     r = 255,
     g = 255,
-    b = 0,
-    a = 255
-}, nil, {
-    category = "ESP",
-    visible = function()
-        local ply = LocalPlayer()
-        if not IsValid(ply) then return false end
-        return ply:isStaffOnDuty() or ply:hasPrivilege("No Clip Outside Staff Character")
-    end
-})
-
-lia.option.add("espPropsColor", "ESP Props Color", "Sets the ESP color for props", {
-    r = 255,
-    g = 0,
     b = 0,
     a = 255
 }, nil, {

--- a/gamemode/modules/administration/submodules/permissions/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/client.lua
@@ -33,10 +33,6 @@ function MODULE:HUDPaint()
             kind = "Items"
             label = L("item") .. ": " .. (ent.getItemTable and ent:getItemTable().name or L("unknown"))
             baseColor = lia.config.get("espItemsColor") or Color(255, 255, 255)
-        elseif ent.isProp and ent:isProp() and lia.option.get("espProps", false) then
-            kind = "Props"
-            label = L("prop") .. " " .. L("model") .. ": " .. (ent:GetModel() or L("unknown"))
-            baseColor = lia.config.get("espPropsColor") or Color(255, 255, 255)
         elseif ESP_DrawnEntities[ent:GetClass()] and lia.option.get("espEntities", false) then
             kind = "Entities"
             label = L("entity") .. " " .. L("class") .. ": " .. (ent:GetClass() or L("unknown"))


### PR DESCRIPTION
## Summary
- stop props from being drawn in staff ESP
- drop `espProps` and `espPropsColor` options

## Testing
- `luacheck gamemode/modules/administration/submodules/permissions/libraries/client.lua gamemode/core/libraries/option.lua` *(fails: expected '=' near 'end')*


------
https://chatgpt.com/codex/tasks/task_e_689056b101e08327a131f3e4956f3cc9