### PR TITLE
Show current voice mode below voice panels

### DIFF
--- a/gamemode/core/derma/panels/voice.lua
+++ b/gamemode/core/derma/panels/voice.lua
@@ -76,6 +76,12 @@ local function CreateVoicePanelList()
     g_VoicePanelList:SetSize(270, ScrH() - 200)
     g_VoicePanelList:SetPos(ScrW() - 320, 100)
     g_VoicePanelList:SetPaintBackground(false)
+    function g_VoicePanelList:Paint(w, h)
+        local pnl = VoicePanels[LocalPlayer()]
+        if not IsValid(pnl) then return end
+        local vt = LocalPlayer():getNetVar("VoiceType", "Talking")
+        draw.SimpleText(L("voiceModeStatus", L(vt:lower())), "liaMediumFont", w / 2, h, color_white, TEXT_ALIGN_CENTER, TEXT_ALIGN_BOTTOM)
+    end
 end
 
 timer.Create("VoiceClean", 1, 0, function()

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -655,6 +655,7 @@ LANGUAGE = {
     changeToTalk = "Change voice mode to Talking range.",
     changeToYell = "Change voice mode to Yelling range.",
     voiceModeSet = "Voice range set to %s.",
+    voiceModeStatus = "You are %s.",
     whispering = "Whispering",
     talking = "Talking",
     yelling = "Yelling",


### PR DESCRIPTION
## Summary
- display a "You are <voice mode>" message at the bottom of the voice panel list when speaking
- add localization string `voiceModeStatus` for the message

## Testing
- `luacheck gamemode --no-global --no-max-line-length --no-self --no-max-code-line-length --no-max-string-line-length --no-max-comment-line-length --no-max-cyclomatic-complexity` *(fails: 11 warnings, 19 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68905962af70832794845fb73b6a86d6