### PR TITLE
Handle admin sheet buildSheets check

### DIFF
--- a/gamemode/modules/administration/netcalls/client.lua
+++ b/gamemode/modules/administration/netcalls/client.lua
@@ -621,7 +621,12 @@ local function openDecodedTable(tableName, columns, data)
     lia.util.CreateTableUI(L("decodedTableTitle", tableName), columnDefs, decodedRows)
 end
 
-lia.net.readBigTable("liaDatabaseViewData", function(data) if IsValid(panelRef) then panelRef:buildSheets(data) end end)
+lia.net.readBigTable("liaDatabaseViewData", function(data)
+    if not IsValid(panelRef) or not isfunction(panelRef.buildSheets) then return end
+
+    panelRef:buildSheets(data)
+end)
+
 lia.net.readBigTable("liaStaffSummary", function(data)
     if not IsValid(panelRef) or not data then return end
     panelRef:Clear()
@@ -817,6 +822,7 @@ lia.net.readBigTable("liaAllPlayers", function(players)
 end)
 
 lia.net.readBigTable("liaFullCharList", function(data)
-    if not IsValid(panelRef) or not data then return end
+    if not IsValid(panelRef) or not data or not isfunction(panelRef.buildSheets) then return end
+
     panelRef:buildSheets(data)
 end)


### PR DESCRIPTION
## Summary
- prevent nil `buildSheets` calls when loading admin network data

## Testing
- `luacheck gamemode/modules/administration/netcalls/client.lua` *(fails: 380 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68905a4bc5f88327a9008357607a1839