### PR TITLE
Fix admin tabs not rendering until selected

### DIFF
--- a/gamemode/modules/f1menu/libraries/client.lua
+++ b/gamemode/modules/f1menu/libraries/client.lua
@@ -153,8 +153,23 @@ function MODULE:CreateMenuButtons(tabs)
                 local panel = sheet:Add("DPanel")
                 panel:Dock(FILL)
                 panel.Paint = function() end
-                if page.drawFunc then page.drawFunc(panel) end
-                sheet:AddSheet(page.name, panel)
+                local sheetData = sheet:AddSheet(page.name, panel)
+
+                if page.drawFunc then
+                    sheetData.Tab.liaPagePanel = panel
+                    sheetData.Tab.liaOnSelect = page.drawFunc
+                end
+            end
+
+            function sheet:OnActiveTabChanged(_, newTab)
+                if IsValid(newTab) and newTab.liaOnSelect then
+                    newTab.liaOnSelect(newTab.liaPagePanel)
+                end
+            end
+
+            local initial = sheet:GetActiveTab()
+            if IsValid(initial) and initial.liaOnSelect then
+                initial.liaOnSelect(initial.liaPagePanel)
             end
         end
     end


### PR DESCRIPTION
## Summary
- Defer admin tab draw functions until the tab is selected, preventing stale panel references that left admin pages blank
- Trigger initial draw for the active admin tab so content loads immediately

## Testing
- `luacheck gamemode/modules/f1menu/libraries/client.lua --no-color`

------
https://chatgpt.com/codex/tasks/task_e_6890600c9a608327bb28ef81733473c7