### PR TITLE
Toggle offline character bans based on player status

### DIFF
--- a/gamemode/modules/administration/libraries/client.lua
+++ b/gamemode/modules/administration/libraries/client.lua
@@ -269,6 +269,7 @@ function MODULE:PopulateAdminTabs(pages)
                                 if match then
                                     local line = list:AddLine(unpack(values))
                                     line.CharID = row.ID
+                                    line.SteamID = row.SteamID
                                 end
                             end
                         end
@@ -291,13 +292,16 @@ function MODULE:PopulateAdminTabs(pages)
                             end):SetIcon("icon16/page_copy.png")
 
                             if line.CharID then
-                                if LocalPlayer():hasPrivilege("Manage Characters") then
-                                    menu:AddOption(L("banCharacter"), function() LocalPlayer():ConCommand([[say "/charban ]] .. line.CharID .. [["]]) end):SetIcon("icon16/cancel.png")
-                                    menu:AddOption(L("unbanCharacter"), function() LocalPlayer():ConCommand([[say "/charunban ]] .. line.CharID .. [["]]) end):SetIcon("icon16/accept.png")
+                                local owner = line.SteamID and lia.util.getBySteamID(line.SteamID)
+                                if IsValid(owner) then
+                                    if LocalPlayer():hasPrivilege("Manage Characters") then
+                                        menu:AddOption(L("banCharacter"), function() LocalPlayer():ConCommand([[say "/charban ]] .. line.CharID .. [["]]) end):SetIcon("icon16/cancel.png")
+                                        menu:AddOption(L("unbanCharacter"), function() LocalPlayer():ConCommand([[say "/charunban ]] .. line.CharID .. [["]]) end):SetIcon("icon16/accept.png")
+                                    end
+                                else
+                                    if LocalPlayer():hasPrivilege("Ban Offline") then menu:AddOption(L("banCharacterOffline"), function() LocalPlayer():ConCommand([[say "/charbanoffline ]] .. line.CharID .. [["]]) end):SetIcon("icon16/cancel.png") end
+                                    if LocalPlayer():hasPrivilege("Unban Offline") then menu:AddOption(L("unbanCharacterOffline"), function() LocalPlayer():ConCommand([[say "/charunbanoffline ]] .. line.CharID .. [["]]) end):SetIcon("icon16/accept.png") end
                                 end
-
-                                if LocalPlayer():hasPrivilege("Ban Offline") then menu:AddOption(L("banCharacterOffline"), function() LocalPlayer():ConCommand([[say "/charbanoffline ]] .. line.CharID .. [["]]) end):SetIcon("icon16/cancel.png") end
-                                if LocalPlayer():hasPrivilege("Unban Offline") then menu:AddOption(L("unbanCharacterOffline"), function() LocalPlayer():ConCommand([[say "/charunbanoffline ]] .. line.CharID .. [["]]) end):SetIcon("icon16/accept.png") end
                             end
 
                             menu:Open()

--- a/gamemode/modules/administration/netcalls/client.lua
+++ b/gamemode/modules/administration/netcalls/client.lua
@@ -350,10 +350,18 @@ net.Receive("liaAllPKs", function()
         menu:AddOption(L("copyEvidence"), function() SetClipboardText(line.evidence) end):SetIcon("icon16/page_copy.png")
         menu:AddOption(L("copySteamID"), function() SetClipboardText(line.steamID) end):SetIcon("icon16/page_copy.png")
         if line.evidence and line.evidence:match("^https?://") then menu:AddOption(L("viewEvidence"), function() gui.OpenURL(line.evidence) end):SetIcon("icon16/world.png") end
-        menu:AddOption(L("banCharacter"), function() LocalPlayer():ConCommand([[say "/charban ]] .. line.charID .. [["]]) end):SetIcon("icon16/cancel.png")
-        menu:AddOption(L("unbanCharacter"), function() LocalPlayer():ConCommand([[say "/charunban ]] .. line.charID .. [["]]) end):SetIcon("icon16/accept.png")
-        menu:AddOption(L("banCharacterOffline"), function() LocalPlayer():ConCommand([[say "/charbanoffline ]] .. line.charID .. [["]]) end):SetIcon("icon16/cancel.png")
-        menu:AddOption(L("unbanCharacterOffline"), function() LocalPlayer():ConCommand([[say "/charunbanoffline ]] .. line.charID .. [["]]) end):SetIcon("icon16/accept.png")
+        if line.charID then
+            local owner = line.steamID and lia.util.getBySteamID(line.steamID)
+            if IsValid(owner) then
+                if LocalPlayer():hasPrivilege("Manage Characters") then
+                    menu:AddOption(L("banCharacter"), function() LocalPlayer():ConCommand([[say "/charban ]] .. line.charID .. [["]]) end):SetIcon("icon16/cancel.png")
+                    menu:AddOption(L("unbanCharacter"), function() LocalPlayer():ConCommand([[say "/charunban ]] .. line.charID .. [["]]) end):SetIcon("icon16/accept.png")
+                end
+            else
+                if LocalPlayer():hasPrivilege("Ban Offline") then menu:AddOption(L("banCharacterOffline"), function() LocalPlayer():ConCommand([[say "/charbanoffline ]] .. line.charID .. [["]]) end):SetIcon("icon16/cancel.png") end
+                if LocalPlayer():hasPrivilege("Unban Offline") then menu:AddOption(L("unbanCharacterOffline"), function() LocalPlayer():ConCommand([[say "/charunbanoffline ]] .. line.charID .. [["]]) end):SetIcon("icon16/accept.png") end
+            end
+        end
         menu:Open()
     end
 end)

--- a/gamemode/modules/administration/submodules/permissions/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/client.lua
@@ -151,6 +151,7 @@ net.Receive("DisplayCharList", function()
             end
 
             line.CharID = rowData and rowData.ID
+            line.SteamID = targetSteamIDsafe
             if rowData and rowData.extraDetails then
                 local colIndex = 10
                 for _, name in ipairs(extraOrder) do
@@ -163,22 +164,25 @@ net.Receive("DisplayCharList", function()
         listView.OnRowRightClick = function(_, _, ln)
             if not (ln and ln.CharID) then return end
             if not (LocalPlayer():hasPrivilege("Manage Characters") or LocalPlayer():hasPrivilege("Ban Offline") or LocalPlayer():hasPrivilege("Unban Offline")) then return end
+            local owner = ln.SteamID and lia.util.getBySteamID(ln.SteamID)
             local dMenu = DermaMenu()
-            if LocalPlayer():hasPrivilege("Manage Characters") then
-                local opt1 = dMenu:AddOption(L("banCharacter"), function() LocalPlayer():ConCommand([[say "/charban ]] .. ln.CharID .. [["]]) end)
-                opt1:SetIcon("icon16/cancel.png")
-                local opt2 = dMenu:AddOption(L("unbanCharacter"), function() LocalPlayer():ConCommand([[say "/charunban ]] .. ln.CharID .. [["]]) end)
-                opt2:SetIcon("icon16/accept.png")
-            end
+            if IsValid(owner) then
+                if LocalPlayer():hasPrivilege("Manage Characters") then
+                    local opt1 = dMenu:AddOption(L("banCharacter"), function() LocalPlayer():ConCommand([[say "/charban ]] .. ln.CharID .. [["]]) end)
+                    opt1:SetIcon("icon16/cancel.png")
+                    local opt2 = dMenu:AddOption(L("unbanCharacter"), function() LocalPlayer():ConCommand([[say "/charunban ]] .. ln.CharID .. [["]]) end)
+                    opt2:SetIcon("icon16/accept.png")
+                end
+            else
+                if LocalPlayer():hasPrivilege("Ban Offline") then
+                    local opt3 = dMenu:AddOption(L("banCharacterOffline"), function() LocalPlayer():ConCommand([[say "/charbanoffline ]] .. ln.CharID .. [["]]) end)
+                    opt3:SetIcon("icon16/cancel.png")
+                end
 
-            if LocalPlayer():hasPrivilege("Ban Offline") then
-                local opt3 = dMenu:AddOption(L("banCharacterOffline"), function() LocalPlayer():ConCommand([[say "/charbanoffline ]] .. ln.CharID .. [["]]) end)
-                opt3:SetIcon("icon16/cancel.png")
-            end
-
-            if LocalPlayer():hasPrivilege("Unban Offline") then
-                local opt4 = dMenu:AddOption(L("unbanCharacterOffline"), function() LocalPlayer():ConCommand([[say "/charunbanoffline ]] .. ln.CharID .. [["]]) end)
-                opt4:SetIcon("icon16/accept.png")
+                if LocalPlayer():hasPrivilege("Unban Offline") then
+                    local opt4 = dMenu:AddOption(L("unbanCharacterOffline"), function() LocalPlayer():ConCommand([[say "/charunbanoffline ]] .. ln.CharID .. [["]]) end)
+                    opt4:SetIcon("icon16/accept.png")
+                end
             end
 
             dMenu:Open()


### PR DESCRIPTION
## Summary
- Show normal character ban options only when the character's owner is online
- Reveal offline ban actions only when the character's owner is offline

## Testing
- `luacheck gamemode/modules/administration/libraries/client.lua gamemode/modules/administration/netcalls/client.lua gamemode/modules/administration/submodules/permissions/libraries/client.lua` *(fails: expected '=' near 'end')*

------
https://chatgpt.com/codex/tasks/task_e_68906b33b9dc83279c9cfda4a7d666de