### PR TITLE
Add SteamID copy option to faction roster

### DIFF
--- a/gamemode/modules/teams/netcalls/client.lua
+++ b/gamemode/modules/teams/netcalls/client.lua
@@ -62,6 +62,9 @@ net.Receive("CharacterInfo", function()
                 end
 
                 menu:AddOption(L("view") .. " " .. L("characterList"), function() LocalPlayer():ConCommand("say /charlist " .. rowData.steamID) end)
+                menu:AddOption(L("copySteamID"), function()
+                    SetClipboardText(rowData.steamID or "")
+                end)
                 menu:AddOption(L("copyRow"), function()
                     local rowString = ""
                     for key, value in pairs(rowData) do
@@ -137,6 +140,7 @@ net.Receive("CharacterInfo", function()
             end
 
             menu:AddOption(L("view") .. " " .. L("characterList"), function() LocalPlayer():ConCommand("say /charlist " .. rowData.steamID) end)
+            menu:AddOption(L("copySteamID"), function() SetClipboardText(rowData.steamID or "") end)
             menu:AddOption(L("copyRow"), function()
                 local rowString = ""
                 for key, value in pairs(rowData) do


### PR DESCRIPTION
## Summary
- allow copying a member's SteamID from faction management roster

## Testing
- `luacheck gamemode/modules/teams/netcalls/client.lua | tail -n 5`

------
https://chatgpt.com/codex/tasks/task_e_68906b4a88e88327b7824cd449c8a1ff