### PR TITLE
Fix character list ban status

### DIFF
--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -331,12 +331,15 @@ lia.command.add("charlist", {
                     end
                 end
 
+                local bannedVal = stored and stored:getBanned() or tonumber(row.banned) or 0
+                local isBanned = bannedVal ~= 0 and (bannedVal == -1 or bannedVal > os.time())
+
                 local entry = {
                     ID = charID,
                     Name = stored and stored:getName() or row.name,
                     Desc = row.desc,
                     Faction = row.faction,
-                    Banned = (info.banned or tonumber(row.banned) == 1) and L("yes") or L("no"),
+                    Banned = isBanned and L("yes") or L("no"),
                     BanningAdminName = banInfo and banInfo.name or "",
                     BanningAdminSteamID = banInfo and banInfo.steamID or "",
                     BanningAdminRank = banInfo and banInfo.rank or "",

--- a/gamemode/modules/administration/libraries/client.lua
+++ b/gamemode/modules/administration/libraries/client.lua
@@ -270,6 +270,7 @@ function MODULE:PopulateAdminTabs(pages)
                                     local line = list:AddLine(unpack(values))
                                     line.CharID = row.ID
                                     line.SteamID = row.SteamID
+                                    line.Banned = row.Banned
                                 end
                             end
                         end
@@ -295,12 +296,19 @@ function MODULE:PopulateAdminTabs(pages)
                                 local owner = line.SteamID and lia.util.getBySteamID(line.SteamID)
                                 if IsValid(owner) then
                                     if LocalPlayer():hasPrivilege("Manage Characters") then
-                                        menu:AddOption(L("banCharacter"), function() LocalPlayer():ConCommand([[say "/charban ]] .. line.CharID .. [["]]) end):SetIcon("icon16/cancel.png")
-                                        menu:AddOption(L("unbanCharacter"), function() LocalPlayer():ConCommand([[say "/charunban ]] .. line.CharID .. [["]]) end):SetIcon("icon16/accept.png")
+                                        if line.Banned then
+                                            menu:AddOption(L("unbanCharacter"), function() LocalPlayer():ConCommand([[say "/charunban ]] .. line.CharID .. [["]]) end):SetIcon("icon16/accept.png")
+                                        else
+                                            menu:AddOption(L("banCharacter"), function() LocalPlayer():ConCommand([[say "/charban ]] .. line.CharID .. [["]]) end):SetIcon("icon16/cancel.png")
+                                        end
                                     end
                                 else
-                                    if LocalPlayer():hasPrivilege("Ban Offline") then menu:AddOption(L("banCharacterOffline"), function() LocalPlayer():ConCommand([[say "/charbanoffline ]] .. line.CharID .. [["]]) end):SetIcon("icon16/cancel.png") end
-                                    if LocalPlayer():hasPrivilege("Unban Offline") then menu:AddOption(L("unbanCharacterOffline"), function() LocalPlayer():ConCommand([[say "/charunbanoffline ]] .. line.CharID .. [["]]) end):SetIcon("icon16/accept.png") end
+                                    if LocalPlayer():hasPrivilege("Ban Offline") and not line.Banned then
+                                        menu:AddOption(L("banCharacterOffline"), function() LocalPlayer():ConCommand([[say "/charbanoffline ]] .. line.CharID .. [["]]) end):SetIcon("icon16/cancel.png")
+                                    end
+                                    if LocalPlayer():hasPrivilege("Unban Offline") and line.Banned then
+                                        menu:AddOption(L("unbanCharacterOffline"), function() LocalPlayer():ConCommand([[say "/charunbanoffline ]] .. line.CharID .. [["]]) end):SetIcon("icon16/accept.png")
+                                    end
                                 end
                             end
 

--- a/gamemode/modules/administration/netcalls/server.lua
+++ b/gamemode/modules/administration/netcalls/server.lua
@@ -142,7 +142,8 @@ LEFT JOIN lia_chardata AS d ON d.charID = c.id AND d.key = 'charBanInfo']], func
 
         for _, row in ipairs(data or {}) do
             local stored = lia.char.loaded[row.id]
-            local isBanned = tonumber(row.banned) == 1
+            local bannedVal = tonumber(row.banned) or 0
+            local isBanned = bannedVal ~= 0 and (bannedVal == -1 or bannedVal > os.time())
             local steamID = tostring(row.steamID)
             local playTime = tonumber(row.playtime) or 0
             if stored then


### PR DESCRIPTION
## Summary
- Ensure character list correctly detects banned characters
- Only show ban or unban options based on character's ban state
- Use accurate ban status in char list command output

## Testing
- `luacheck gamemode/modules/administration/commands.lua gamemode/modules/administration/libraries/client.lua gamemode/modules/administration/netcalls/server.lua | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6890700d36308327b92a197e8ca9697a