### PR TITLE
fix: show context menu in faction management

### DIFF
--- a/gamemode/modules/administration/netcalls/client.lua
+++ b/gamemode/modules/administration/netcalls/client.lua
@@ -454,14 +454,10 @@ local function OpenRoster(panel, data)
                 end
             end
 
-            if steamID and steamID ~= "" then
-                requestPlayerCharacters(steamID, line, function(menu, ln, sID) buildMenu(menu, ln, sID) end)
-            else
-                local menu = DermaMenu()
-                buildMenu(menu, line, steamID or "")
-                local x, y = gui.MousePos()
-                menu:Open(x, y)
-            end
+            local menu = DermaMenu()
+            buildMenu(menu, line, steamID or "")
+            local x, y = gui.MousePos()
+            menu:Open(x, y)
         end
 
         sheet:AddSheet(factionName, page)


### PR DESCRIPTION
## Summary
- ensure faction management entries open a context menu on right-click

## Testing
- `luac -p gamemode/modules/administration/netcalls/client.lua` *(fails: unexpected symbol near '')*

------
https://chatgpt.com/codex/tasks/task_e_689075c2ed5083278e90167cc9eb7865