### PR TITLE
Prevent kicking from default factions

### DIFF
--- a/gamemode/modules/administration/netcalls/client.lua
+++ b/gamemode/modules/administration/netcalls/client.lua
@@ -388,6 +388,8 @@ local function OpenRoster(panel, data)
     sheet:DockMargin(10, 10, 10, 10)
     for factionName, members in pairs(data) do
         local membersData = members
+        local factionTable = lia.util.findFaction(LocalPlayer(), factionName)
+        local isDefaultFaction = factionTable and factionTable.isDefault or false
         local page = sheet:Add("DPanel")
         page:Dock(FILL)
         page:DockPadding(10, 10, 10, 10)
@@ -421,7 +423,7 @@ local function OpenRoster(panel, data)
             local parentList = self
             local steamID = line.rowData.steamID
             local function buildMenu(menu, ln, sID)
-                if sID and sID ~= "" and LocalPlayer():hasPrivilege("Can Manage Factions") then
+                if sID and sID ~= "" and LocalPlayer():hasPrivilege("Can Manage Factions") and not isDefaultFaction then
                     menu:AddOption(L("kick"), function()
                         Derma_Query(L("kickConfirm"), L("confirm"), L("yes"), function()
                             net.Start("KickCharacter")

--- a/gamemode/modules/teams/netcalls/client.lua
+++ b/gamemode/modules/teams/netcalls/client.lua
@@ -17,7 +17,9 @@ net.Receive("CharacterInfo", function()
     local characterData = net.ReadTable()
     local character = LocalPlayer():getChar()
     if not character or LocalPlayer():Team() == FACTION_STAFF or not character:hasFlags("V") then return end
+    local factionData = lia.faction.indices[character:getFaction()]
     local canKick = character:hasFlags("K")
+    if factionData and factionData.isDefault then canKick = false end
     if IsValid(lia.gui.rosterSheet) then
         local sheet = lia.gui.rosterSheet
         sheet.search:SetValue("")


### PR DESCRIPTION
## Summary
- avoid showing kick options for default faction members in roster management
- skip kick actions for default faction in faction management roster

## Testing
- `luacheck --no-color gamemode/modules/teams/netcalls/client.lua gamemode/modules/administration/netcalls/client.lua | tail -n 5`


------
https://chatgpt.com/codex/tasks/task_e_689078a45fa883278e9a69ecbd556e05