### PR TITLE
Ensure F1 admin options respect command permissions

### DIFF
--- a/gamemode/modules/administration/libraries/client.lua
+++ b/gamemode/modules/administration/libraries/client.lua
@@ -295,18 +295,20 @@ function MODULE:PopulateAdminTabs(pages)
                             if line.CharID then
                                 local owner = line.SteamID and lia.util.getBySteamID(line.SteamID)
                                 if IsValid(owner) then
-                                    if LocalPlayer():hasPrivilege("Manage Characters") then
-                                        if line.Banned then
+                                    if line.Banned then
+                                        if lia.command.hasAccess(LocalPlayer(), "charunban") then
                                             menu:AddOption(L("unbanCharacter"), function() LocalPlayer():ConCommand('say "/charunban ' .. line.CharID .. '"') end):SetIcon("icon16/accept.png")
-                                        else
+                                        end
+                                    else
+                                        if lia.command.hasAccess(LocalPlayer(), "charban") then
                                             menu:AddOption(L("banCharacter"), function() LocalPlayer():ConCommand('say "/charban ' .. line.CharID .. '"') end):SetIcon("icon16/cancel.png")
                                         end
                                     end
                                 else
-                                    if LocalPlayer():hasPrivilege("Ban Offline") and not line.Banned then
+                                    if not line.Banned and lia.command.hasAccess(LocalPlayer(), "charbanoffline") then
                                         menu:AddOption(L("banCharacterOffline"), function() LocalPlayer():ConCommand('say "/charbanoffline ' .. line.CharID .. '"') end):SetIcon("icon16/cancel.png")
                                     end
-                                    if LocalPlayer():hasPrivilege("Unban Offline") and line.Banned then
+                                    if line.Banned and lia.command.hasAccess(LocalPlayer(), "charunbanoffline") then
                                         menu:AddOption(L("unbanCharacterOffline"), function() LocalPlayer():ConCommand('say "/charunbanoffline ' .. line.CharID .. '"') end):SetIcon("icon16/accept.png")
                                     end
                                 end

--- a/gamemode/modules/administration/netcalls/client.lua
+++ b/gamemode/modules/administration/netcalls/client.lua
@@ -353,13 +353,19 @@ net.Receive("liaAllPKs", function()
         if line.charID then
             local owner = line.steamID and lia.util.getBySteamID(line.steamID)
             if IsValid(owner) then
-                if LocalPlayer():hasPrivilege("Manage Characters") then
+                if lia.command.hasAccess(LocalPlayer(), "charban") then
                     menu:AddOption(L("banCharacter"), function() LocalPlayer():ConCommand('say "/charban ' .. line.charID .. '"') end):SetIcon("icon16/cancel.png")
+                end
+                if lia.command.hasAccess(LocalPlayer(), "charunban") then
                     menu:AddOption(L("unbanCharacter"), function() LocalPlayer():ConCommand('say "/charunban ' .. line.charID .. '"') end):SetIcon("icon16/accept.png")
                 end
             else
-                if LocalPlayer():hasPrivilege("Ban Offline") then menu:AddOption(L("banCharacterOffline"), function() LocalPlayer():ConCommand('say "/charbanoffline ' .. line.charID .. '"') end):SetIcon("icon16/cancel.png") end
-                if LocalPlayer():hasPrivilege("Unban Offline") then menu:AddOption(L("unbanCharacterOffline"), function() LocalPlayer():ConCommand('say "/charunbanoffline ' .. line.charID .. '"') end):SetIcon("icon16/accept.png") end
+                if lia.command.hasAccess(LocalPlayer(), "charbanoffline") then
+                    menu:AddOption(L("banCharacterOffline"), function() LocalPlayer():ConCommand('say "/charbanoffline ' .. line.charID .. '"') end):SetIcon("icon16/cancel.png")
+                end
+                if lia.command.hasAccess(LocalPlayer(), "charunbanoffline") then
+                    menu:AddOption(L("unbanCharacterOffline"), function() LocalPlayer():ConCommand('say "/charunbanoffline ' .. line.charID .. '"') end):SetIcon("icon16/accept.png")
+                end
             end
         end
 
@@ -432,7 +438,9 @@ local function OpenRoster(panel, data)
                         end, L("no"))
                     end):SetIcon("icon16/user_delete.png")
 
-                    menu:AddOption(L("viewCharacterList"), function() LocalPlayer():ConCommand("say /charlist " .. sID) end):SetIcon("icon16/page_copy.png")
+                    if lia.command.hasAccess(LocalPlayer(), "charlist") then
+                        menu:AddOption(L("viewCharacterList"), function() LocalPlayer():ConCommand("say /charlist " .. sID) end):SetIcon("icon16/page_copy.png")
+                    end
                 end
 
                 menu:AddOption(L("copyRow"), function()
@@ -613,9 +621,13 @@ lia.net.readBigTable("liaStaffSummary", function(data)
         local menu = DermaMenu()
         local steamID = line:GetColumnText(2)
         local warningCount = tonumber(line:GetColumnText(4)) or 0
-        if warningCount > 0 then menu:AddOption(L("viewWarningsIssued"), function() LocalPlayer():ConCommand("say /viewwarnsissued " .. steamID) end):SetIcon("icon16/error.png") end
+        if warningCount > 0 and lia.command.hasAccess(LocalPlayer(), "viewwarnsissued") then
+            menu:AddOption(L("viewWarningsIssued"), function() LocalPlayer():ConCommand("say /viewwarnsissued " .. steamID) end):SetIcon("icon16/error.png")
+        end
         local ticketCount = tonumber(line:GetColumnText(5)) or 0
-        if ticketCount > 0 then menu:AddOption(L("viewTicketClaims"), function() LocalPlayer():ConCommand("say /plyviewclaims " .. steamID) end):SetIcon("icon16/page_white_text.png") end
+        if ticketCount > 0 and lia.command.hasAccess(LocalPlayer(), "plyviewclaims") then
+            menu:AddOption(L("viewTicketClaims"), function() LocalPlayer():ConCommand("say /plyviewclaims " .. steamID) end):SetIcon("icon16/page_white_text.png")
+        end
         menu:AddOption(L("copyRow"), function()
             local rowString = ""
             for i, column in ipairs(self.Columns or {}) do
@@ -719,7 +731,9 @@ lia.net.readBigTable("liaAllPlayers", function(players)
         if not IsValid(line) or not line.steamID then return end
         local parentList = self
         requestPlayerCharacters(line.steamID, line, function(menu, ln, steamID)
-            menu:AddOption(L("viewCharacterList"), function() LocalPlayer():ConCommand("say /charlist " .. steamID) end):SetIcon("icon16/page_copy.png")
+            if lia.command.hasAccess(LocalPlayer(), "charlist") then
+                menu:AddOption(L("viewCharacterList"), function() LocalPlayer():ConCommand("say /charlist " .. steamID) end):SetIcon("icon16/page_copy.png")
+            end
             menu:AddOption(L("copyRow"), function()
                 local rowString = ""
                 for i, column in ipairs(parentList.Columns or {}) do
@@ -733,8 +747,12 @@ lia.net.readBigTable("liaAllPlayers", function(players)
 
             menu:AddOption(L("copySteamID"), function() SetClipboardText(steamID) end):SetIcon("icon16/page_copy.png")
             menu:AddOption(L("openSteamProfile"), function() gui.OpenURL("https://steamcommunity.com/profiles/" .. util.SteamIDTo64(steamID)) end):SetIcon("icon16/world.png")
-            menu:AddOption(L("viewWarnings"), function() LocalPlayer():ConCommand("say /viewwarns " .. steamID) end):SetIcon("icon16/error.png")
-            menu:AddOption(L("viewTicketRequests"), function() LocalPlayer():ConCommand("say /viewtickets " .. steamID) end):SetIcon("icon16/help.png")
+            if lia.command.hasAccess(LocalPlayer(), "viewwarns") then
+                menu:AddOption(L("viewWarnings"), function() LocalPlayer():ConCommand("say /viewwarns " .. steamID) end):SetIcon("icon16/error.png")
+            end
+            if lia.command.hasAccess(LocalPlayer(), "viewtickets") then
+                menu:AddOption(L("viewTicketRequests"), function() LocalPlayer():ConCommand("say /viewtickets " .. steamID) end):SetIcon("icon16/help.png")
+            end
         end)
     end
 end)

--- a/gamemode/modules/administration/submodules/permissions/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/client.lua
@@ -165,23 +165,25 @@ net.Receive("DisplayCharList", function()
 
         listView.OnRowRightClick = function(_, _, ln)
             if not (ln and ln.CharID) then return end
-            if not (LocalPlayer():hasPrivilege("Manage Characters") or LocalPlayer():hasPrivilege("Ban Offline") or LocalPlayer():hasPrivilege("Unban Offline")) then return end
+            if not (lia.command.hasAccess(LocalPlayer(), "charban") or lia.command.hasAccess(LocalPlayer(), "charunban") or lia.command.hasAccess(LocalPlayer(), "charbanoffline") or lia.command.hasAccess(LocalPlayer(), "charunbanoffline")) then return end
             local owner = ln.SteamID and lia.util.getBySteamID(ln.SteamID)
             local dMenu = DermaMenu()
             if IsValid(owner) then
-                if LocalPlayer():hasPrivilege("Manage Characters") then
+                if lia.command.hasAccess(LocalPlayer(), "charban") then
                     local opt1 = dMenu:AddOption(L("banCharacter"), function() LocalPlayer():ConCommand('say "/charban ' .. ln.CharID .. '"') end)
                     opt1:SetIcon("icon16/cancel.png")
+                end
+                if lia.command.hasAccess(LocalPlayer(), "charunban") then
                     local opt2 = dMenu:AddOption(L("unbanCharacter"), function() LocalPlayer():ConCommand('say "/charunban ' .. ln.CharID .. '"') end)
                     opt2:SetIcon("icon16/accept.png")
                 end
             else
-                if LocalPlayer():hasPrivilege("Ban Offline") then
+                if lia.command.hasAccess(LocalPlayer(), "charbanoffline") then
                     local opt3 = dMenu:AddOption(L("banCharacterOffline"), function() LocalPlayer():ConCommand('say "/charbanoffline ' .. ln.CharID .. '"') end)
                     opt3:SetIcon("icon16/cancel.png")
                 end
 
-                if LocalPlayer():hasPrivilege("Unban Offline") then
+                if lia.command.hasAccess(LocalPlayer(), "charunbanoffline") then
                     local opt4 = dMenu:AddOption(L("unbanCharacterOffline"), function() LocalPlayer():ConCommand('say "/charunbanoffline ' .. ln.CharID .. '"') end)
                     opt4:SetIcon("icon16/accept.png")
                 end


### PR DESCRIPTION
## Summary
- Gated roster menu's character list option behind the `charlist` command
- Required `viewwarnsissued` and `plyviewclaims` access before showing staff summary links
- Only show character list, warning view, and ticket view entries in the player list when the user has the respective commands

## Testing
- `luacheck gamemode/modules/administration/libraries/client.lua gamemode/modules/administration/netcalls/client.lua gamemode/modules/administration/submodules/permissions/libraries/client.lua` *(fails: many warnings and 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_6890f327adac8327b41ab69a8efecc83