### PR TITLE
Fix flags management tab not populating on first load

### DIFF
--- a/gamemode/modules/administration/libraries/client.lua
+++ b/gamemode/modules/administration/libraries/client.lua
@@ -415,7 +415,7 @@ function MODULE:PopulateAdminTabs(pages)
         table.insert(pages, {
             name = L("flagsManagement"),
             drawFunc = function(panel)
-                panelRef = panel
+                flagsPanel = panel
                 net.Start("liaRequestAllFlags")
                 net.SendToServer()
             end

--- a/gamemode/modules/administration/netcalls/client.lua
+++ b/gamemode/modules/administration/netcalls/client.lua
@@ -476,13 +476,13 @@ local function OpenRoster(panel, data)
 end
 
 lia.net.readBigTable("liaAllFlags", function(data)
-    if not IsValid(panelRef) then return end
-    panelRef:Clear()
-    local search = panelRef:Add("DTextEntry")
+    if not IsValid(flagsPanel) then return end
+    flagsPanel:Clear()
+    local search = flagsPanel:Add("DTextEntry")
     search:Dock(TOP)
     search:SetPlaceholderText(L("search"))
     search:SetTextColor(Color(255, 255, 255))
-    local list = panelRef:Add("DListView")
+    local list = flagsPanel:Add("DListView")
     list:Dock(FILL)
     local function addSizedColumn(text)
         local col = list:AddColumn(text)


### PR DESCRIPTION
## Summary
- ensure flag management uses its own panel reference so data renders when first opened

## Testing
- `luacheck gamemode/modules/administration/netcalls/client.lua gamemode/modules/administration/libraries/client.lua`

------
https://chatgpt.com/codex/tasks/task_e_6891289a69a88327803212be8e775c36