### PR TITLE
refactor: use iterators instead of GetAll

### DIFF
--- a/gamemode/core/derma/mainmenu/character.lua
+++ b/gamemode/core/derma/mainmenu/character.lua
@@ -55,7 +55,7 @@ end
 
 function PANEL:hideExternalEntities()
     self.hiddenEntities = {}
-    for _, ent in ipairs(ents.GetAll()) do
+    for _, ent in ents.Iterator() do
         if ent ~= self.modelEntity and not ent:IsWorld() and not ent:CreatedByMap() then
             self.hiddenEntities[ent] = ent:GetNoDraw()
             ent:SetNoDraw(true)

--- a/gamemode/modules/administration/netcalls/server.lua
+++ b/gamemode/modules/administration/netcalls/server.lua
@@ -192,7 +192,7 @@ end)
 net.Receive("liaRequestAllFlags", function(_, client)
     if not client:hasPrivilege(L("canAccessFlagManagement")) then return end
     local data = {}
-    for _, ply in ipairs(player.GetAll()) do
+    for _, ply in player.Iterator() do
         local char = ply:getChar()
         data[#data + 1] = {
             name = ply:Name(),

--- a/gamemode/modules/administration/submodules/permissions/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/client.lua
@@ -9,7 +9,7 @@ function MODULE:HUDPaint()
     if not client:isNoClipping() then return end
     if not (client:hasPrivilege("No Clip ESP Outside Staff Character") or client:isStaffOnDuty()) then return end
     if not lia.option.get("espEnabled", false) then return end
-    for _, ent in pairs(ents.GetAll()) do
+    for _, ent in ents.Iterator() do
         if not IsValid(ent) or ent == client or ent:IsWeapon() then continue end
         local pos = ent:GetPos()
         if not pos then continue end

--- a/gamemode/modules/doors/libraries/server.lua
+++ b/gamemode/modules/doors/libraries/server.lua
@@ -60,7 +60,7 @@ function MODULE:SaveData()
     local map = game.GetMap()
     local condition = buildCondition(gamemode, map)
     local rows = {}
-    for _, door in ipairs(ents.GetAll()) do
+    for _, door in ents.Iterator() do
         if door:isDoor() then
             rows[#rows + 1] = {
                 gamemode = gamemode,


### PR DESCRIPTION
## Summary
- replace player/ent GetAll loops with built-in iterators

## Testing
- `luacheck gamemode/modules/administration/netcalls/server.lua gamemode/modules/administration/submodules/permissions/libraries/client.lua gamemode/modules/doors/libraries/server.lua gamemode/core/derma/mainmenu/character.lua | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68913247a3948327a1b36de0eb67c537