### PR TITLE
Show translated weapon names clientside

### DIFF
--- a/gamemode/items/base/weapons.lua
+++ b/gamemode/items/base/weapons.lua
@@ -133,6 +133,14 @@ function ITEM:OnSave()
 end
 
 if CLIENT then
+    function ITEM:getName()
+        local weapon = weapons.GetStored(self.class)
+        if weapon and weapon.GetPrintName then
+            return language.GetPhrase(weapon:GetPrintName()):utf8upper()
+        end
+        return L(self.name)
+    end
+
     function ITEM:paintOver(item, w, h)
         if item:getData("equip") then
             surface.SetDrawColor(110, 255, 110, 100)


### PR DESCRIPTION
## Summary
- Make weapon item names use `language.GetPhrase` and `utf8upper` on the client
- Keep existing visual equip marker

## Testing
- `luacheck gamemode/items/base/weapons.lua` *(44 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68914681236c832797ffb87676b9d94e