### PR TITLE
fix: render flags panel immediately

### DIFF
--- a/gamemode/modules/administration/libraries/client.lua
+++ b/gamemode/modules/administration/libraries/client.lua
@@ -416,8 +416,13 @@ function MODULE:PopulateAdminTabs(pages)
             name = L("flagsManagement"),
             drawFunc = function(panel)
                 flagsPanel = panel
-                net.Start("liaRequestAllFlags")
-                net.SendToServer()
+                if flagsData then
+                    OpenFlagsPanel(panel, flagsData)
+                    flagsData = nil
+                else
+                    net.Start("liaRequestAllFlags")
+                    net.SendToServer()
+                end
             end
         })
     end

--- a/gamemode/modules/administration/netcalls/client.lua
+++ b/gamemode/modules/administration/netcalls/client.lua
@@ -475,14 +475,13 @@ local function OpenRoster(panel, data)
     end
 end
 
-lia.net.readBigTable("liaAllFlags", function(data)
-    if not IsValid(flagsPanel) then return end
-    flagsPanel:Clear()
-    local search = flagsPanel:Add("DTextEntry")
+function OpenFlagsPanel(panel, data)
+    panel:Clear()
+    local search = panel:Add("DTextEntry")
     search:Dock(TOP)
     search:SetPlaceholderText(L("search"))
     search:SetTextColor(Color(255, 255, 255))
-    local list = flagsPanel:Add("DListView")
+    local list = panel:Add("DListView")
     list:Dock(FILL)
     local function addSizedColumn(text)
         local col = list:AddColumn(text)
@@ -554,6 +553,14 @@ lia.net.readBigTable("liaAllFlags", function(data)
         end):SetIcon("icon16/flag_green.png")
 
         menu:Open()
+    end
+end
+
+lia.net.readBigTable("liaAllFlags", function(data)
+    flagsData = data or {}
+    if IsValid(flagsPanel) then
+        OpenFlagsPanel(flagsPanel, flagsData)
+        flagsData = nil
     end
 end)
 


### PR DESCRIPTION
## Summary
- fix flags tab requiring re-entry by caching flag data and rendering panel when available

## Testing
- `luacheck gamemode/modules/administration/netcalls/client.lua gamemode/modules/administration/libraries/client.lua`

------
https://chatgpt.com/codex/tasks/task_e_6891477ffbf0832785f98529918f1c02