### PR TITLE
Add panel for viewing class rosters

### DIFF
--- a/gamemode/core/derma/panels/roster.lua
+++ b/gamemode/core/derma/panels/roster.lua
@@ -1,0 +1,74 @@
+local PANEL = {}
+
+function PANEL:Init()
+    self.sheet = self:Add("liaSheet")
+    self.sheet:Dock(FILL)
+    self.sheet:SetPlaceholderText(L("search"))
+end
+
+function PANEL:SetRosterType(t)
+    self.rosterType = t
+end
+
+function PANEL:Populate(data, canKick)
+    if not IsValid(self.sheet) then return end
+    self.sheet.search:SetValue("")
+    self.sheet:Clear()
+    local rows = {}
+    local originals = {}
+    for _, v in ipairs(data) do
+        rows[#rows + 1] = {v.name, v.steamID, v.class or L("none"), v.playTime, v.lastOnline}
+        originals[#originals + 1] = v
+    end
+    local row = self.sheet:AddListViewRow({
+        columns = {L("name"), L("steamID"), L("class"), L("playtime"), L("lastOnline")},
+        data = rows,
+        getLineText = function(line)
+            local s = ""
+            for i = 1, 5 do
+                local v = line:GetValue(i)
+                if v then s = s .. " " .. tostring(v) end
+            end
+            return s
+        end
+    })
+    if row and row.widget then
+        for i, line in ipairs(row.widget:GetLines() or {}) do
+            line.rowData = originals[i]
+        end
+        row.widget.OnRowRightClick = function(_, _, line)
+            if not IsValid(line) or not line.rowData then return end
+            local rowData = line.rowData
+            local menu = DermaMenu()
+            if canKick and rowData.steamID ~= LocalPlayer():SteamID() then
+                menu:AddOption(L("kick"), function()
+                    Derma_Query(L("kickConfirm"), L("confirm"), L("yes"), function()
+                        net.Start("KickCharacter")
+                        net.WriteInt(tonumber(rowData.id), 32)
+                        net.SendToServer()
+                    end, L("no"))
+                end)
+            end
+            menu:AddOption(L("view") .. " " .. L("characterList"), function()
+                LocalPlayer():ConCommand("say /charlist " .. rowData.steamID)
+            end)
+            menu:AddOption(L("copySteamID"), function()
+                SetClipboardText(rowData.steamID or "")
+            end)
+            menu:AddOption(L("copyRow"), function()
+                local rowString = ""
+                for key, value in pairs(rowData) do
+                    value = tostring(value or L("na"))
+                    rowString = rowString .. key:gsub("^%l", string.upper) .. ": " .. value .. " | "
+                end
+                rowString = rowString:sub(1, -4)
+                SetClipboardText(rowString)
+            end)
+            menu:Open()
+        end
+    end
+    self.sheet:Refresh()
+end
+
+vgui.Register("liaRoster", PANEL, "EditablePanel")
+

--- a/gamemode/modules/teams/libraries/client.lua
+++ b/gamemode/modules/teams/libraries/client.lua
@@ -31,13 +31,14 @@ function MODULE:CreateInformationButtons(pages)
         table.insert(pages, {
             name = L("factionRoster"),
             drawFunc = function(parent)
-                local sheet = vgui.Create("liaSheet", parent)
-                sheet:SetPlaceholderText(L("search"))
-                lia.gui.rosterSheet = sheet
+                local roster = vgui.Create("liaRoster", parent)
+                roster:SetRosterType("faction")
+                lia.gui.roster = roster
                 lia.gui.currentRosterType = "faction"
             end,
             onSelect = function()
-                if IsValid(lia.gui.rosterSheet) then
+                if IsValid(lia.gui.roster) then
+                    lia.gui.roster:SetRosterType("faction")
                     lia.gui.currentRosterType = "faction"
                     net.Start("RequestFactionRoster")
                     net.SendToServer()
@@ -49,13 +50,14 @@ function MODULE:CreateInformationButtons(pages)
         table.insert(pages, {
             name = L("classRoster"),
             drawFunc = function(parent)
-                local sheet = vgui.Create("liaSheet", parent)
-                sheet:SetPlaceholderText(L("search"))
-                lia.gui.rosterSheet = sheet
+                local roster = vgui.Create("liaRoster", parent)
+                roster:SetRosterType("class")
+                lia.gui.roster = roster
                 lia.gui.currentRosterType = "class"
             end,
             onSelect = function()
-                if IsValid(lia.gui.rosterSheet) then
+                if IsValid(lia.gui.roster) then
+                    lia.gui.roster:SetRosterType("class")
                     lia.gui.currentRosterType = "class"
                     net.Start("RequestClassRoster")
                     net.SendToServer()
@@ -65,7 +67,7 @@ function MODULE:CreateInformationButtons(pages)
     end
 end
 
-hook.Add("F1MenuClosed", "liaRosterSheetCleanup", function()
-    lia.gui.rosterSheet = nil
+hook.Add("F1MenuClosed", "liaRosterCleanup", function()
+    lia.gui.roster = nil
     lia.gui.currentRosterType = nil
 end)

--- a/gamemode/modules/teams/netcalls/client.lua
+++ b/gamemode/modules/teams/netcalls/client.lua
@@ -23,69 +23,8 @@ net.Receive("CharacterInfo", function()
         canKick = character:hasFlags("K")
         if factionData and factionData.isDefault then canKick = false end
     end
-    if IsValid(lia.gui.rosterSheet) then
-        local sheet = lia.gui.rosterSheet
-        sheet.search:SetValue("")
-        sheet:Clear()
-        local rows = {}
-        local originals = {}
-        for _, data in ipairs(characterData) do
-            rows[#rows + 1] = {data.name, data.steamID, data.class or L("none"), data.playTime, data.lastOnline}
-            originals[#originals + 1] = data
-        end
-
-        local row = sheet:AddListViewRow({
-            columns = {L("name"), L("steamID"), L("class"), L("playtime"), L("lastOnline")},
-            data = rows,
-            getLineText = function(line)
-                local s = ""
-                for i = 1, 5 do
-                    local v = line:GetValue(i)
-                    if v then s = s .. " " .. tostring(v) end
-                end
-                return s
-            end
-        })
-
-        if row and row.widget then
-            for i, line in ipairs(row.widget:GetLines() or {}) do
-                line.rowData = originals[i]
-            end
-
-            row.widget.OnRowRightClick = function(_, _, line)
-                if not IsValid(line) or not line.rowData then return end
-                local rowData = line.rowData
-                local menu = DermaMenu()
-                if canKick and rowData.steamID ~= LocalPlayer():SteamID() then
-                    menu:AddOption(L("kick"), function()
-                        Derma_Query(L("kickConfirm"), L("confirm"), L("yes"), function()
-                            net.Start("KickCharacter")
-                            net.WriteInt(tonumber(rowData.id), 32)
-                            net.SendToServer()
-                        end, L("no"))
-                    end)
-                end
-
-                menu:AddOption(L("view") .. " " .. L("characterList"), function() LocalPlayer():ConCommand("say /charlist " .. rowData.steamID) end)
-                menu:AddOption(L("copySteamID"), function()
-                    SetClipboardText(rowData.steamID or "")
-                end)
-                menu:AddOption(L("copyRow"), function()
-                    local rowString = ""
-                    for key, value in pairs(rowData) do
-                        value = tostring(value or L("na"))
-                        rowString = rowString .. key:gsub("^%l", string.upper) .. ": " .. value .. " | "
-                    end
-
-                    rowString = rowString:sub(1, -4)
-                    SetClipboardText(rowString)
-                end)
-
-                menu:Open()
-            end
-        end
-
-        sheet:Refresh()
+    if IsValid(lia.gui.roster) then
+        lia.gui.roster:Populate(characterData, canKick)
         return
     end
 


### PR DESCRIPTION
## Summary
- Add `liaRoster` panel to display faction or class rosters with context menu actions
- Hook F1 menu to spawn roster panel for faction or class listings
- Populate roster panel from server via net message
- Move roster panel into core derma panels directory

## Testing
- `luacheck gamemode/core/derma/panels/roster.lua gamemode/modules/teams/libraries/client.lua gamemode/modules/teams/netcalls/client.lua` (132 warnings, 0 errors)


------
https://chatgpt.com/codex/tasks/task_e_68914b705d408327ba12fa33ee861dfd