### PR TITLE
Use language.GetPhrase on SWEP PrintName

### DIFF
--- a/gamemode/core/derma/panels/extended_spawnmenu.lua
+++ b/gamemode/core/derma/panels/extended_spawnmenu.lua
@@ -253,7 +253,7 @@ hook.Add("PopulateContent", "liaExtendedSpawnMenuPopulateContent", function(pnlC
         node.PropPanel:Add(header)
         for _, ent in SortedPairsByMemberValue(ents, "PrintName") do
             local t = {
-                nicename = ent.PrintName or ent.ClassName,
+                nicename = ent.PrintName and language.GetPhrase(ent.PrintName) or ent.ClassName,
                 spawnname = ent.ClassName,
                 material = "entities/" .. ent.ClassName .. ".png",
                 admin = ent.AdminOnly
@@ -364,7 +364,7 @@ hook.Add("PopulateContent", "liaExtendedSpawnMenuPopulateContent", function(pnlC
         node.PropPanel:Add(header)
         for _, ent in SortedPairsByMemberValue(vs, "PrintName") do
             local t = {
-                nicename = ent.PrintName or ent.ClassName,
+                nicename = ent.PrintName and language.GetPhrase(ent.PrintName) or ent.ClassName,
                 spawnname = ent.ClassName,
                 material = "entities/" .. ent.ClassName .. ".png",
                 admin = ent.AdminOnly
@@ -401,7 +401,7 @@ hook.Add("PopulateContent", "liaExtendedSpawnMenuPopulateContent", function(pnlC
         node.PropPanel:Add(header)
         for _, ent in SortedPairsByMemberValue(ws, "PrintName") do
             local t = {
-                nicename = ent.PrintName or ent.ClassName,
+                nicename = ent.PrintName and language.GetPhrase(ent.PrintName) or ent.ClassName,
                 spawnname = ent.ClassName,
                 material = "entities/" .. ent.ClassName .. ".png",
                 admin = ent.AdminOnly

--- a/gamemode/core/libraries/thirdparty/sh_extensions.lua
+++ b/gamemode/core/libraries/thirdparty/sh_extensions.lua
@@ -200,7 +200,7 @@ properties.Add("lia_npc_weapon", {
                 if WeaponTable.AdminOnly and not LocalPlayer():hasPrivilege(L("canSpawnSWEPs")) then continue end
                 local icon = vgui.Create("ContentIcon", PropPanel)
                 icon:SetMaterial("entities/" .. WeaponTable.ClassName .. ".png")
-                icon:SetName(WeaponTable.PrintName or "#" .. WeaponTable.ClassName)
+                icon:SetName(WeaponTable.PrintName and language.GetPhrase(WeaponTable.PrintName) or "#" .. WeaponTable.ClassName)
                 icon:SetAdminOnly(WeaponTable.AdminOnly or false)
                 icon.DoClick = function()
                     changeWep(self, ent, WeaponTable.ClassName)

--- a/gamemode/items/base/weapons.lua
+++ b/gamemode/items/base/weapons.lua
@@ -135,8 +135,8 @@ end
 if CLIENT then
     function ITEM:getName()
         local weapon = weapons.GetStored(self.class)
-        if weapon and weapon.GetPrintName then
-            return language.GetPhrase(weapon:GetPrintName())
+        if weapon and weapon.PrintName then
+            return language.GetPhrase(weapon.PrintName)
         end
         return L(self.name)
     end

--- a/gamemode/modules/administration/submodules/permissions/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/client.lua
@@ -70,7 +70,7 @@ function MODULE:HUDPaint()
             local wep = ent:GetActiveWeapon()
             if IsValid(wep) then
                 local ammo, reserve = wep:Clip1(), ent:GetAmmoCount(wep:GetPrimaryAmmoType())
-                local wepName = wep:GetPrintName()
+                local wepName = language.GetPhrase(wep:GetPrintName())
                 if ammo >= 0 and reserve >= 0 then wepName = wepName .. " [" .. ammo .. "/" .. reserve .. "]" end
                 draw.SimpleTextOutlined(wepName, "liaSmallFont", screenPos.x, barY + barH + 5, Color(255, 255, 255, 255), TEXT_ALIGN_CENTER, TEXT_ALIGN_TOP, 1, Color(0, 0, 0, 255))
             end


### PR DESCRIPTION
## Summary
- Remove weapon meta and inline `language.GetPhrase` for SWEP names
- Localize weapon names in the weapon selector and admin ESP directly
- Translate spawn menu weapon entries with `language.GetPhrase`

## Testing
- `luacheck gamemode/core/derma/panels/weaponselector.lua` *(warnings: accessing undefined globals)*
- `luacheck gamemode/modules/administration/submodules/permissions/libraries/client.lua` *(fails: expected '=' near 'end')*
- `luacheck gamemode/core/derma/panels/extended_spawnmenu.lua` *(warnings: accessing undefined globals)*
- `luacheck gamemode/core/libraries/loader.lua` *(warnings: accessing undefined globals)*

------
https://chatgpt.com/codex/tasks/task_e_68914b2543d4832797690ecab21dc91d