### PR TITLE
feat: localize serverguard privileges

### DIFF
--- a/gamemode/core/libraries/compatibility/serverguard.lua
+++ b/gamemode/core/libraries/compatibility/serverguard.lua
@@ -30,9 +30,9 @@ function serverguard.permission:Add(identifier, priv)
 
                 if lia.administrator and lia.administrator.registerPrivilege then
                     lia.administrator.registerPrivilege({
-                        Name = identifier,
+                        Name = L(identifier),
                         MinAccess = "admin",
-                        Category = "ServerGuard"
+                        Category = L("categoryServerGuard")
                     })
                 end
             end

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -1650,6 +1650,7 @@ Reload: Drop]],
     samEnforceStaff = "Enforce Staff Rank To SAM",
     samEnforceStaffDesc = "Determines whether staff enforcement for SAM commands is enabled",
     categorySAM = "SAM | Admin Mod",
+    categoryServerGuard = "ServerGuard",
     -- Config localization
     categoryFonts = "Fonts",
     categoryData = "Data",


### PR DESCRIPTION
## Summary
- localize ServerGuard privilege names and category
- add translation entry for ServerGuard category

## Testing
- `luacheck gamemode/core/libraries/compatibility/serverguard.lua gamemode/languages/english.lua`


------
https://chatgpt.com/codex/tasks/task_e_689158a0a8c4832780bd98b30edef9b1