### PR TITLE
Localize server logs and command privileges

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -1084,7 +1084,7 @@ end
 gameevent.Listen("server_addban")
 gameevent.Listen("server_removeban")
 hook.Add("server_addban", "LiliaLogServerBan", function(data)
-    lia.admin(string.format("[BAN] %s (%s) was banned for %d minute(s): %s", data.name, data.networkid, data.ban_length, data.ban_reason))
+    lia.admin(L("banLogFormat", data.name, data.networkid, data.ban_length, data.ban_reason))
     lia.db.insertTable({
         player = data.name or "",
         playerSteamID = data.networkid,
@@ -1097,6 +1097,6 @@ hook.Add("server_addban", "LiliaLogServerBan", function(data)
 end)
 
 hook.Add("server_removeban", "LiliaLogServerUnban", function(data)
-    lia.admin("[UNBAN] " .. data.networkid .. " was unbanned.")
+    lia.admin(L("unbanLogFormat", data.networkid))
     lia.db.query("DELETE FROM lia_bans WHERE playerSteamID = " .. lia.db.convertDataType(data.networkid))
 end)

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -1854,4 +1854,6 @@ Reload: Drop]],
     vendorDefaultMoney = "Default Vendor Money",
     vendorDefaultMoneyDesc = "Sets the default amount of money vendors start with.",
     vendor = "Vendor",
+    banLogFormat = "[BAN] %s (%s) was banned for %d minute(s): %s",
+    unbanLogFormat = "[UNBAN] %s was unbanned.",
 }

--- a/gamemode/modules/inventory/commands.lua
+++ b/gamemode/modules/inventory/commands.lua
@@ -1,6 +1,6 @@
 ﻿lia.command.add("updateinvsize", {
     adminOnly = true,
-    privilege = "Set Inventory Size",
+    privilege = L("Set Inventory Size"),
     desc = "updateInventorySizeDesc",
     syntax = "[player Name]",
     onRun = function(client, arguments)
@@ -40,7 +40,7 @@
 
 lia.command.add("setinventorysize", {
     adminOnly = true,
-    privilege = "Set Inventory Size",
+    privilege = L("Set Inventory Size"),
     desc = "setInventorySizeDesc",
     syntax = "[player Name] [number Width] [number Height]",
     onRun = function(client, args)

--- a/gamemode/modules/inventory/submodules/storage/commands.lua
+++ b/gamemode/modules/inventory/submodules/storage/commands.lua
@@ -1,6 +1,6 @@
 local MODULE = MODULE
 lia.command.add("storagelock", {
-    privilege = "Lock Storage",
+    privilege = L("Lock Storage"),
     adminOnly = true,
     desc = "storagelockDesc",
     syntax = "[string Password optional]",

--- a/gamemode/modules/inventory/submodules/vendor/commands.lua
+++ b/gamemode/modules/inventory/submodules/vendor/commands.lua
@@ -1,5 +1,5 @@
 ﻿lia.command.add("restockvendor", {
-    privilege = "Manage Vendors",
+    privilege = L("Manage Vendors"),
     superAdminOnly = true,
     desc = "restockVendorDesc",
     AdminStick = {
@@ -27,7 +27,7 @@
 })
 
 lia.command.add("restockallvendors", {
-    privilege = "Manage Vendors",
+    privilege = L("Manage Vendors"),
     superAdminOnly = true,
     desc = "restockAllVendorsDesc",
     onRun = function(client)
@@ -47,7 +47,7 @@ lia.command.add("restockallvendors", {
 })
 
 lia.command.add("resetallvendormoney", {
-    privilege = "Manage Vendors",
+    privilege = L("Manage Vendors"),
     superAdminOnly = true,
     desc = "resetAllVendorMoneyDesc",
     syntax = "[number Amount]",
@@ -73,7 +73,7 @@ lia.command.add("resetallvendormoney", {
 })
 
 lia.command.add("restockvendormoney", {
-    privilege = "Manage Vendors",
+    privilege = L("Manage Vendors"),
     superAdminOnly = true,
     desc = "restockVendorMoneyDesc",
     syntax = "[number Amount]",


### PR DESCRIPTION
## Summary
- use language keys for server ban and unban log messages
- wrap inventory, storage, and vendor command privileges with localization

## Testing
- `luacheck gamemode/core/hooks/server.lua gamemode/languages/english.lua gamemode/modules/inventory/commands.lua gamemode/modules/inventory/submodules/storage/commands.lua gamemode/modules/inventory/submodules/vendor/commands.lua`

------
https://chatgpt.com/codex/tasks/task_e_689161983a888327876e054c9b56da67