### PR TITLE
Localize classes tab label

### DIFF
--- a/gamemode/modules/teams/libraries/client.lua
+++ b/gamemode/modules/teams/libraries/client.lua
@@ -20,7 +20,7 @@ end
 
 function MODULE:CreateMenuButtons(tabs)
     local joinable = lia.class.retrieveJoinable(LocalPlayer())
-    if #joinable > 1 then tabs["classes"] = function(panel) panel:Add("liaClasses") end end
+    if #joinable > 1 then tabs[L("classes")] = function(panel) panel:Add("liaClasses") end end
 end
 
 function MODULE:CreateInformationButtons(pages)


### PR DESCRIPTION
## Summary
- Use translated label for the classes tab in the team menu

## Testing
- `luacheck gamemode/modules/teams/libraries/client.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689167c6e4f08327a178d3b9b6168413