### PR TITLE
feat: localize default skin name

### DIFF
--- a/gamemode/core/derma/panels/panels.lua
+++ b/gamemode/core/derma/panels/panels.lua
@@ -126,7 +126,7 @@ local QuickPanel = {}
 function QuickPanel:Init()
     if IsValid(lia.gui.quick) then lia.gui.quick:Remove() end
     lia.gui.quick = self
-    self:SetSkin(lia.config.get("DermaSkin", "Lilia Skin"))
+    self:SetSkin(lia.config.get("DermaSkin", L("liliaSkin")))
     self:SetSize(400, 36)
     self:SetPos(ScrW() - 36, -36)
     self:MakePopup()

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -188,6 +188,7 @@ LANGUAGE = {
     alreadyHaveGrenade = "You already have this type of grenade.",
     invalidFaction = "The specified faction is not valid.",
     submit = "Submit",
+    subOption = "Sub Option",
     apply = "Apply",
     cfgSet = "%s has set \"%s\" to %s.",
     invalid = "You have provided an invalid %s",


### PR DESCRIPTION
## Summary
- use translated label for default derma skin name
- add missing translation for sub-option label in item menus

## Testing
- `luacheck gamemode/languages/english.lua gamemode/core/derma/panels/panels.lua` *(warnings: setting non-standard globals, line length, undefined variables; no errors)*

------
https://chatgpt.com/codex/tasks/task_e_68917f2acad48327ae7c841fdc77495e