### PR TITLE
Localize entity categories

### DIFF
--- a/gamemode/entities/entities/lia_item/shared.lua
+++ b/gamemode/entities/entities/lia_item/shared.lua
@@ -1,7 +1,7 @@
 ﻿ENT.Base = "base_entity"
 ENT.Type = "anim"
 ENT.PrintName = L("item")
-ENT.Category = "Lilia"
+ENT.Category = L("lilia")
 ENT.Spawnable = false
 ENT.RenderGroup = RENDERGROUP_BOTH
 ENT.DrawEntityInfo = true

--- a/gamemode/entities/entities/lia_money/shared.lua
+++ b/gamemode/entities/entities/lia_money/shared.lua
@@ -1,6 +1,6 @@
 ﻿ENT.Type = "anim"
 ENT.PrintName = L("money")
-ENT.Category = "Lilia"
+ENT.Category = L("lilia")
 ENT.Spawnable = false
 ENT.DrawEntityInfo = true
 ENT.isMoney = true

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -16,6 +16,7 @@ LANGUAGE = {
     bodygroups = "Bodygroups",
     flag = "Flag",
     group = "Group",
+    lilia = "Lilia",
     search = "Search...",
     select = "Select",
     storagelockDesc = "Lock or unlock the storage container you’re looking at. Provide a password to set the lock, or run without a password to remove it.",


### PR DESCRIPTION
## Summary
- Use localized token for item and money entity categories
- Add English localization for the new token

## Testing
- `luac -p <(tail -c +4 gamemode/entities/entities/lia_item/shared.lua)`
- `luac -p <(tail -c +4 gamemode/entities/entities/lia_money/shared.lua)`
- `luac -p <(tail -c +4 gamemode/languages/english.lua)`

------
https://chatgpt.com/codex/tasks/task_e_68919a7ec12483278ebcb41e946b1f90