### PR TITLE
Localize team roster outputs

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -411,6 +411,7 @@ LANGUAGE = {
     minutesAgo = "%s minutes ago",
     hoursAgo = "%s hours ago",
     daysAgo = "%s days ago",
+    ago = "ago",
     onlineNow = "Online now",
     weekdaySunday = "Sunday",
     weekdayMonday = "Monday",

--- a/gamemode/modules/teams/netcalls/client.lua
+++ b/gamemode/modules/teams/netcalls/client.lua
@@ -89,7 +89,16 @@ net.Receive("CharacterInfo", function()
                 local rowString = ""
                 for key, value in pairs(rowData) do
                     value = tostring(value or L("na"))
-                    rowString = rowString .. key:gsub("^%l", string.upper) .. ": " .. value .. " | "
+                    local columnName
+                    for _, col in ipairs(columns) do
+                        if col.field == key then
+                            columnName = col.name
+                            break
+                        end
+                    end
+
+                    columnName = columnName or key:gsub("^%l", string.upper)
+                    rowString = rowString .. columnName .. ": " .. value .. " | "
                 end
 
                 rowString = rowString:sub(1, -4)

--- a/gamemode/modules/teams/netcalls/server.lua
+++ b/gamemode/modules/teams/netcalls/server.lua
@@ -1,3 +1,10 @@
+local function stripAgo(timeSince)
+    local agoStr = L("ago")
+    local suffix = " " .. agoStr
+    if timeSince:sub(-#suffix) == suffix then return timeSince:sub(1, -#suffix - 1) end
+    return timeSince
+end
+
 net.Receive("RequestFactionRoster", function(_, client)
     local character = client:getChar()
     if not character or not character:hasFlags("V") then return end
@@ -23,7 +30,7 @@ net.Receive("RequestFactionRoster", function(_, client)
                     if not isnumber(last) then last = os.time(lia.time.toNumber(v.lastJoinTime)) end
                     local lastDiff = os.time() - last
                     local timeSince = lia.time.TimeSince(last)
-                    local timeStripped = timeSince:match("^(.-)%sago$") or timeSince
+                    local timeStripped = stripAgo(timeSince)
                     lastOnlineText = L("agoFormat", timeStripped, lia.time.formatDHM(lastDiff))
                 end
 
@@ -83,7 +90,7 @@ net.Receive("RequestClassRoster", function(_, client)
                     if not isnumber(last) then last = os.time(lia.time.toNumber(v.lastJoinTime)) end
                     local lastDiff = os.time() - last
                     local timeSince = lia.time.TimeSince(last)
-                    local timeStripped = timeSince:match("^(.-)%sago$") or timeSince
+                    local timeStripped = stripAgo(timeSince)
                     lastOnlineText = L("agoFormat", timeStripped, lia.time.formatDHM(lastDiff))
                 end
 


### PR DESCRIPTION
## Summary
- use localized "ago" parsing when displaying last online times
- show localized column names when copying team roster rows
- add missing `ago` translation

## Testing
- `luacheck gamemode/modules/teams/netcalls/server.lua gamemode/modules/teams/netcalls/client.lua gamemode/languages/english.lua` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68919eb871a08327b1f4cc07f5745923