### PR TITLE
feat: localize recognition command privilege

### DIFF
--- a/gamemode/modules/recognition/commands.lua
+++ b/gamemode/modules/recognition/commands.lua
@@ -6,7 +6,7 @@ local function runCommand(client, args, range)
 end
 
 lia.command.add("recogwhisper", {
-    privilege = "Manage Recognition",
+    privilege = L("Manage Recognition"),
     adminOnly = true,
     syntax = "[player Name]",
     desc = "recogWhisperDesc",
@@ -20,7 +20,7 @@ lia.command.add("recogwhisper", {
 })
 
 lia.command.add("recognormal", {
-    privilege = "Manage Recognition",
+    privilege = L("Manage Recognition"),
     adminOnly = true,
     syntax = "[player Name]",
     desc = "recogNormalDesc",
@@ -34,7 +34,7 @@ lia.command.add("recognormal", {
 })
 
 lia.command.add("recogyell", {
-    privilege = "Manage Recognition",
+    privilege = L("Manage Recognition"),
     adminOnly = true,
     syntax = "[player Name]",
     desc = "recogYellDesc",
@@ -48,7 +48,7 @@ lia.command.add("recogyell", {
 })
 
 lia.command.add("recogbots", {
-    privilege = "Manage Recognition",
+    privilege = L("Manage Recognition"),
     superAdminOnly = true,
     syntax = "[string Range optional] [string Name optional]",
     desc = "recogBotsDesc",


### PR DESCRIPTION
## Summary
- localize recognition command privilege strings

## Testing
- `luacheck gamemode/modules/recognition/commands.lua gamemode/modules/recognition/module.lua gamemode/modules/recognition/libraries/*.lua | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6891a648e43083279bc4df900333be55