### PR TITLE
refactor: localize cheater action logs

### DIFF
--- a/gamemode/modules/protection/libraries/server.lua
+++ b/gamemode/modules/protection/libraries/server.lua
@@ -329,14 +329,14 @@ end
 
 function MODULE:PlayerUse(client)
     if IsCheater(client) then
-        LogCheaterAction(client, "use entity")
+        LogCheaterAction(client, L("use") .. " " .. L("entity"))
         return false
     end
 end
 
 function MODULE:CanPlayerInteractItem(client, action)
     if IsCheater(client) then
-        LogCheaterAction(client, action .. " item")
+        LogCheaterAction(client, action .. " " .. L("item"))
         return false
     end
 end


### PR DESCRIPTION
## Summary
- avoid plain English in cheater action logging

## Testing
- `luacheck gamemode/modules/protection/commands.lua gamemode/modules/protection/module.lua gamemode/modules/protection/libraries/client.lua gamemode/modules/protection/libraries/server.lua gamemode/modules/protection/netcalls/server.lua` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6891a7c82a6c8327b369186a7f670ba6