### PR TITLE
feat: localize vendor item quantity

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -96,6 +96,7 @@ LANGUAGE = {
     vendorNoItems = "No Items",
     vendorOneItem = "1 Item",
     vendorItems = "%s Items",
+    vendorItemQuantity = "%sx ",
     vendorDefaultName = "Jane Doe",
     vendorEditorButton = "Edit Vendor",
     vendorShowAll = "Show All",

--- a/gamemode/modules/inventory/submodules/vendor/derma/client.lua
+++ b/gamemode/modules/inventory/submodules/vendor/derma/client.lua
@@ -1,4 +1,4 @@
-﻿local sw, sh = ScrW(), ScrH()
+local sw, sh = ScrW(), ScrH()
 local COLS_MODE = 2
 local COLS_PRICE = 3
 local COLS_STOCK = 4
@@ -548,7 +548,7 @@ function PANEL:setQuantity(quantity)
             return
         end
 
-        self.suffix = tostring(quantity) .. "x "
+        self.suffix = L("vendorItemQuantity", quantity)
     else
         self.suffix = ""
     end


### PR DESCRIPTION
## Summary
- localize vendor item quantity prefix

## Testing
- `luacheck gamemode/modules/inventory/submodules/vendor/derma/client.lua gamemode/languages/english.lua` *(fails: '=' expected near 'end')*
- `luacheck gamemode/languages/english.lua`

------
https://chatgpt.com/codex/tasks/task_e_6891a9ffd47c8327a6a0e9c58f41651a