### PR TITLE
Ensure command metadata is properly localized

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -869,6 +869,7 @@ LANGUAGE = {
     kickedForInfraction = "Kicked for",
     bannedForInfraction = "Banned for",
     togglePermakillDesc = "Toggles a character’s permanent kill flag (marks or unmarks them for permanent death).",
+    charkillDesc = "Opens the PK case menu to permanently kill a character.",
     toggleCheaterDesc = "Toggle a player's cheater status.",
     cheaterMarked = "Marked %s as a cheater.",
     cheaterUnmarked = "Removed cheater status from %s.",

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -194,6 +194,7 @@ lia.command.add("returnsitroom", {
 lia.command.add("charkill", {
     superAdminOnly = true,
     privilege = "Manage Characters",
+    desc = "charkillDesc",
     onRun = function(client)
         local choices = {}
         for _, ply in player.Iterator() do

--- a/gamemode/modules/attributes/commands.lua
+++ b/gamemode/modules/attributes/commands.lua
@@ -2,7 +2,7 @@
     superAdminOnly = true,
     desc = "setAttributes",
     syntax = "[player Name] [string Attribute Name] [number Level]",
-    privilege = L("Manage Attributes"),
+    privilege = "Manage Attributes",
     AdminStick = {
         Name = "setAttributes",
         Category = "characterManagement",
@@ -37,7 +37,7 @@ lia.command.add("checkattributes", {
     adminOnly = true,
     desc = "checkAttributes",
     syntax = "[player Name]",
-    privilege = L("Manage Attributes"),
+    privilege = "Manage Attributes",
     AdminStick = {
         Name = "checkAttributes",
         Category = "characterManagement",
@@ -99,7 +99,7 @@ lia.command.add("charaddattrib", {
     superAdminOnly = true,
     desc = "addAttributes",
     syntax = "[player Name] [string Attribute Name] [number Level]",
-    privilege = L("Manage Attributes"),
+    privilege = "Manage Attributes",
     AdminStick = {
         Name = "addAttributes",
         Category = "characterManagement",

--- a/gamemode/modules/inventory/commands.lua
+++ b/gamemode/modules/inventory/commands.lua
@@ -1,6 +1,6 @@
 ﻿lia.command.add("updateinvsize", {
     adminOnly = true,
-    privilege = L("Set Inventory Size"),
+    privilege = "Set Inventory Size",
     desc = "updateInventorySizeDesc",
     syntax = "[player Name]",
     onRun = function(client, arguments)
@@ -40,7 +40,7 @@
 
 lia.command.add("setinventorysize", {
     adminOnly = true,
-    privilege = L("Set Inventory Size"),
+    privilege = "Set Inventory Size",
     desc = "setInventorySizeDesc",
     syntax = "[player Name] [number Width] [number Height]",
     onRun = function(client, args)

--- a/gamemode/modules/inventory/submodules/storage/commands.lua
+++ b/gamemode/modules/inventory/submodules/storage/commands.lua
@@ -1,6 +1,6 @@
 local MODULE = MODULE
 lia.command.add("storagelock", {
-    privilege = L("Lock Storage"),
+    privilege = "Lock Storage",
     adminOnly = true,
     desc = "storagelockDesc",
     syntax = "[string Password optional]",

--- a/gamemode/modules/inventory/submodules/vendor/commands.lua
+++ b/gamemode/modules/inventory/submodules/vendor/commands.lua
@@ -1,5 +1,5 @@
 ﻿lia.command.add("restockvendor", {
-    privilege = L("Manage Vendors"),
+    privilege = "Manage Vendors",
     superAdminOnly = true,
     desc = "restockVendorDesc",
     AdminStick = {
@@ -27,7 +27,7 @@
 })
 
 lia.command.add("restockallvendors", {
-    privilege = L("Manage Vendors"),
+    privilege = "Manage Vendors",
     superAdminOnly = true,
     desc = "restockAllVendorsDesc",
     onRun = function(client)
@@ -47,7 +47,7 @@ lia.command.add("restockallvendors", {
 })
 
 lia.command.add("resetallvendormoney", {
-    privilege = L("Manage Vendors"),
+    privilege = "Manage Vendors",
     superAdminOnly = true,
     desc = "resetAllVendorMoneyDesc",
     syntax = "[number Amount]",
@@ -73,7 +73,7 @@ lia.command.add("resetallvendormoney", {
 })
 
 lia.command.add("restockvendormoney", {
-    privilege = L("Manage Vendors"),
+    privilege = "Manage Vendors",
     superAdminOnly = true,
     desc = "restockVendorMoneyDesc",
     syntax = "[number Amount]",

--- a/gamemode/modules/recognition/commands.lua
+++ b/gamemode/modules/recognition/commands.lua
@@ -6,7 +6,7 @@ local function runCommand(client, args, range)
 end
 
 lia.command.add("recogwhisper", {
-    privilege = L("Manage Recognition"),
+    privilege = "Manage Recognition",
     adminOnly = true,
     syntax = "[player Name]",
     desc = "recogWhisperDesc",
@@ -20,7 +20,7 @@ lia.command.add("recogwhisper", {
 })
 
 lia.command.add("recognormal", {
-    privilege = L("Manage Recognition"),
+    privilege = "Manage Recognition",
     adminOnly = true,
     syntax = "[player Name]",
     desc = "recogNormalDesc",
@@ -34,7 +34,7 @@ lia.command.add("recognormal", {
 })
 
 lia.command.add("recogyell", {
-    privilege = L("Manage Recognition"),
+    privilege = "Manage Recognition",
     adminOnly = true,
     syntax = "[player Name]",
     desc = "recogYellDesc",
@@ -48,7 +48,7 @@ lia.command.add("recogyell", {
 })
 
 lia.command.add("recogbots", {
-    privilege = L("Manage Recognition"),
+    privilege = "Manage Recognition",
     superAdminOnly = true,
     syntax = "[string Range optional] [string Name optional]",
     desc = "recogBotsDesc",


### PR DESCRIPTION
## Summary
- Remove direct `L()` calls from `privilege` fields so commands rely on translation keys
- Add missing description for `charkill` and provide English translation

## Testing
- `luacheck gamemode/modules/recognition/commands.lua gamemode/modules/attributes/commands.lua gamemode/modules/inventory/commands.lua gamemode/modules/inventory/submodules/vendor/commands.lua gamemode/modules/inventory/submodules/storage/commands.lua gamemode/modules/administration/commands.lua gamemode/languages/english.lua`

------
https://chatgpt.com/codex/tasks/task_e_6891cafe3ac48327a686de1bd39e8bf3