### PR TITLE
fix: highlight unconfigured doors in ESP

### DIFF
--- a/gamemode/modules/administration/submodules/permissions/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/client.lua
@@ -33,6 +33,13 @@ function MODULE:HUDPaint()
             kind = L("entities")
             label = ent.PrintName or ent:GetClass()
             baseColor = lia.option.get("espEntitiesColor")
+        elseif lia.option.get("espUnconfiguredDoors", false) and ent:isDoor() then
+            local vars = lia.net and lia.net[ent:EntIndex()]
+            if not vars or next(vars) == nil then
+                kind = L("door")
+                label = L("door")
+                baseColor = lia.option.get("espUnconfiguredDoorsColor")
+            end
         end
 
         if not kind then continue end


### PR DESCRIPTION
## Summary
- show unconfigured doors in ESP by checking for missing net vars

## Testing
- `luacheck gamemode/modules/administration/submodules/permissions/libraries/client.lua` *(fails: expected '=' near 'end')*

------
https://chatgpt.com/codex/tasks/task_e_68925b2936ac832785f05de5fdc9e8ef