### PR TITLE
Localize ticket module string checks

### DIFF
--- a/gamemode/modules/administration/submodules/tickets/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/tickets/libraries/client.lua
@@ -94,7 +94,7 @@ function MODULE:TicketFrame(requester, message, claimed)
     local claimButton
     claimButton = createButton("claimCase", mat_case, 100, function()
         if not shouldClose then
-            if frm.lblTitle:GetText():lower():find("claimed") then
+            if frm.lblTitle:GetText():lower():find(L("claimedBy"):lower()) then
                 chat.AddText(Color(255, 150, 0), "[" .. L("error") .. "] " .. L("caseAlreadyClaimed"))
                 surface.PlaySound("common/wpn_denyselect.wav")
             else


### PR DESCRIPTION
## Summary
- localize ticket claim logic using translation key

## Testing
- `for f in $(find gamemode/modules/administration/submodules/tickets -name '*.lua'); do luajit -b "$f" /tmp/bytecode.out; done`

------
https://chatgpt.com/codex/tasks/task_e_68927bd5e35483278dc3dd1d35e08f35