### PR TITLE
Localize item spawner strings

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -383,6 +383,7 @@ LANGUAGE = {
     copy = "Copy",
     giveToCharacter = "Give To Character...",
     giveTo = "Give to",
+    characterSteamIDFormat = "[%s] [%s]",
     spawnItem = "Spawn item",
     spawnItemTitle = "Spawn %s",
     spawnUndoText = "Undone %s",

--- a/gamemode/modules/administration/submodules/itemspawner/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/itemspawner/libraries/client.lua
@@ -36,7 +36,7 @@
                 local ply = character:getPlayer()
                 if IsValid(ply) then
                     local steamID = ply:SteamID() or ""
-                    combo:AddChoice(string.format("[%s] [%s]", character:getName() or L("unknown"), steamID), steamID)
+                    combo:AddChoice(L("characterSteamIDFormat", character:getName() or L("unknown"), steamID), steamID)
                 end
             end
 

--- a/gamemode/modules/administration/submodules/itemspawner/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/itemspawner/libraries/server.lua
@@ -46,7 +46,7 @@ net.Receive("SpawnMenuSpawnItem", function(_, client)
             if char then ent.liaCharID = char:getID() end
             ent:SetCreator(client)
         end
-        undo.Create("item")
+        undo.Create(L("item"))
         undo.SetPlayer(client)
         undo.AddEntity(ent)
         local name = lia.item.list[id] and lia.item.list[id].name or id


### PR DESCRIPTION
## Summary
- Localize undo text for spawning items
- Localize SteamID display for item giving

## Testing
- `luacheck gamemode/modules/administration/submodules/itemspawner gamemode/languages/english.lua`

------
https://chatgpt.com/codex/tasks/task_e_68927bc5dcdc8327894a48f2082239c3