### PR TITLE
Localize admin stick ban option

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -1057,6 +1057,7 @@ LANGUAGE = {
     cheater = "Cheater",
     ["Staff"] = "Staff",
     ["VIP"] = "VIP",
+    ["Ban"] = "Ban",
     ["Bring"] = "Bring",
     ["Goto"] = "Goto",
     ["Respawn"] = "Respawn",

--- a/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
@@ -151,7 +151,7 @@ local function OpenReasonUI(tgt, cmd)
 end
 
 local function HandleModerationOption(opt, tgt)
-    if opt.name == "Ban" then
+    if opt.name == L("Ban") then
         OpenReasonUI(tgt, "banid")
     elseif opt.name == L("kick") then
         OpenReasonUI(tgt, "kick")


### PR DESCRIPTION
## Summary
- localize the Ban option in admin stick handler
- add English translation key for Ban

## Testing
- `luac -p gamemode/languages/english.lua`
- `tail -c +4 gamemode/modules/administration/submodules/adminstick/libraries/client.lua | luac -p -`


------
https://chatgpt.com/codex/tasks/task_e_68927bbaaa6c8327b56659ccb15ef6b7