### PR TITLE
Localize admin stick ban option

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -1070,6 +1070,7 @@ LANGUAGE = {
     ["Ignite"] = "Ignite",
     ["Jail"] = "Jail",
     ["Slay"] = "Slay",
+    ["Ban"] = "Ban",
     waypointButton = "Waypoint",
     ["Ban OOC"] = "Ban OOC",
     ["Ban Offline"] = "Ban Offline",

--- a/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
@@ -151,7 +151,7 @@ local function OpenReasonUI(tgt, cmd)
 end
 
 local function HandleModerationOption(opt, tgt)
-    if opt.name == "Ban" then
+    if opt.name == L("Ban") then
         OpenReasonUI(tgt, "banid")
     elseif opt.name == L("kick") then
         OpenReasonUI(tgt, "kick")


### PR DESCRIPTION
## Summary
- use localization for Admin Stick's Ban option
- add English translation string for `Ban`

## Testing
- `luacheck gamemode/modules/administration/submodules/adminstick/libraries/client.lua gamemode/languages/english.lua`

------
https://chatgpt.com/codex/tasks/task_e_68927bce57bc8327b6012e29bae83d11