### PR TITLE
Localize online status in admin char list

### DIFF
--- a/gamemode/modules/administration/netcalls/server.lua
+++ b/gamemode/modules/administration/netcalls/server.lua
@@ -157,7 +157,7 @@ LEFT JOIN lia_chardata AS d ON d.charID = c.id AND d.key = 'charBanInfo']], func
                 Desc = row.desc,
                 Faction = row.faction,
                 SteamID = steamID,
-                LastUsed = stored and "Online" or row.lastJoinTime,
+                LastUsed = stored and L("onlineNow") or row.lastJoinTime,
                 Banned = isBanned,
                 PlayTime = playTime,
                 Money = tonumber(row.money) or 0


### PR DESCRIPTION
## Summary
- Localize the "Online" status in admin character list to use translation keys

## Testing
- `luacheck gamemode/modules/administration/netcalls/server.lua` *(warnings: accessing undefined variables, lines too long)*

------
https://chatgpt.com/codex/tasks/task_e_68927f559ae48327ab538474001a56bc