### PR TITLE
feat: localize command syntax

### DIFF
--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -19,7 +19,7 @@
 lia.command.add("plygetplaytime", {
     adminOnly = true,
     privilege = L("View Playtime"),
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     AdminStick = {
         Name = "adminStickGetPlayTimeName",
         Category = "moderationTools",
@@ -120,7 +120,7 @@ lia.command.add("sendtositroom", {
     adminOnly = true,
     privilege = L("Manage SitRooms"),
     desc = "sendToSitRoomDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     AdminStick = {
         Name = "sendToSitRoom",
         Category = "moderationTools",
@@ -164,7 +164,7 @@ lia.command.add("returnsitroom", {
     adminOnly = true,
     privilege = L("Manage SitRooms"),
     desc = "returnFromSitroomDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     AdminStick = {
         Name = "returnFromSitroom",
         Category = "moderationTools",
@@ -265,7 +265,7 @@ lia.command.add("charlist", {
     adminOnly = true,
     privilege = L("List Characters"),
     desc = "charListDesc",
-    syntax = "[string Player Or Steam ID]",
+    syntax = L("[string Player Or Steam ID]"),
     AdminStick = {
         Name = "adminStickOpenCharListName",
         Category = L("player") .. " " .. L("information"),
@@ -368,7 +368,7 @@ lia.command.add("plyban", {
     adminOnly = true,
     privilege = L("Ban Player"),
     desc = "plyBanDesc",
-    syntax = "[player Name] [number Duration optional] [string Reason]",
+    syntax = L("[player Name] [number Duration optional] [string Reason]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -383,7 +383,7 @@ lia.command.add("plykick", {
     adminOnly = true,
     privilege = L("Kick Player"),
     desc = "plyKickDesc",
-    syntax = "[player Name] [string Reason optional]",
+    syntax = L("[player Name] [string Reason optional]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -407,7 +407,7 @@ lia.command.add("plykill", {
     adminOnly = true,
     privilege = L("Kill Player"),
     desc = "plyKillDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -431,7 +431,7 @@ lia.command.add("plyunban", {
     adminOnly = true,
     privilege = L("Unban Player"),
     desc = "plyUnbanDesc",
-    syntax = "[string SteamID]",
+    syntax = L("[string SteamID]"),
     onRun = function(client, arguments)
         local steamid = arguments[1]
         if steamid and steamid ~= "" then
@@ -446,7 +446,7 @@ lia.command.add("plyfreeze", {
     adminOnly = true,
     privilege = L("Freeze Player"),
     desc = "plyFreezeDesc",
-    syntax = "[player Name] [number Duration optional]",
+    syntax = L("[player Name] [number Duration optional]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -462,7 +462,7 @@ lia.command.add("plyunfreeze", {
     adminOnly = true,
     privilege = L("Unfreeze Player"),
     desc = "plyUnfreezeDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -476,7 +476,7 @@ lia.command.add("plyslay", {
     adminOnly = true,
     privilege = L("Slay Player"),
     desc = "plySlayDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -490,7 +490,7 @@ lia.command.add("plyrespawn", {
     adminOnly = true,
     privilege = L("Respawn Player"),
     desc = "plyRespawnDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -513,7 +513,7 @@ lia.command.add("plyblind", {
     adminOnly = true,
     privilege = L("Blind Player"),
     desc = "plyBlindDesc",
-    syntax = "[player Name] [number Time optional]",
+    syntax = L("[player Name] [number Time optional]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -549,7 +549,7 @@ lia.command.add("plyunblind", {
     adminOnly = true,
     privilege = L("Unblind Player"),
     desc = "plyUnblindDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -565,7 +565,7 @@ lia.command.add("plyblindfade", {
     adminOnly = true,
     privilege = L("Blind Fade Player"),
     desc = "plyBlindFadeDesc",
-    syntax = "[player Name] [number Time optional] [string Color optional] [number FadeIn optional] [number FadeOut optional]",
+    syntax = L("[player Name] [number Time optional] [string Color optional] [number FadeIn optional] [number FadeOut optional]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -590,7 +590,7 @@ lia.command.add("blindfadeall", {
     adminOnly = true,
     privilege = L("Blind Fade All"),
     desc = "blindFadeAllDesc",
-    syntax = "[number Time optional] [string Color optional] [number FadeIn optional] [number FadeOut optional]",
+    syntax = L("[number Time optional] [string Color optional] [number FadeIn optional] [number FadeOut optional]"),
     onRun = function(_, arguments)
         local duration = tonumber(arguments[1]) or 0
         local colorName = (arguments[2] or "black"):lower()
@@ -614,7 +614,7 @@ lia.command.add("plygag", {
     adminOnly = true,
     privilege = L("Gag Player"),
     desc = "plyGagDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -629,7 +629,7 @@ lia.command.add("plyungag", {
     adminOnly = true,
     privilege = L("Ungag Player"),
     desc = "plyUngagDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -644,7 +644,7 @@ lia.command.add("plymute", {
     adminOnly = true,
     privilege = L("Mute Player"),
     desc = "plyMuteDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) and target:getChar() then
@@ -669,7 +669,7 @@ lia.command.add("plyunmute", {
     adminOnly = true,
     privilege = L("Unmute Player"),
     desc = "plyUnmuteDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) and target:getChar() then
@@ -685,7 +685,7 @@ lia.command.add("plybring", {
     adminOnly = true,
     privilege = L("Bring Player"),
     desc = "plyBringDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -700,7 +700,7 @@ lia.command.add("plygoto", {
     adminOnly = true,
     privilege = L("Goto Player"),
     desc = "plyGotoDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -715,7 +715,7 @@ lia.command.add("plyreturn", {
     adminOnly = true,
     privilege = L("Return Player"),
     desc = "plyReturnDesc",
-    syntax = "[player Name optional]",
+    syntax = L("[player Name optional]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         target = IsValid(target) and target or client
@@ -732,7 +732,7 @@ lia.command.add("plyjail", {
     adminOnly = true,
     privilege = L("Jail Player"),
     desc = "plyJailDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -756,7 +756,7 @@ lia.command.add("plyunjail", {
     adminOnly = true,
     privilege = L("Unjail Player"),
     desc = "plyUnjailDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -771,7 +771,7 @@ lia.command.add("plycloak", {
     adminOnly = true,
     privilege = L("Cloak Player"),
     desc = "plyCloakDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -785,7 +785,7 @@ lia.command.add("plyuncloak", {
     adminOnly = true,
     privilege = L("Uncloak Player"),
     desc = "plyUncloakDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -799,7 +799,7 @@ lia.command.add("plygod", {
     adminOnly = true,
     privilege = L("God Player"),
     desc = "plyGodDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -813,7 +813,7 @@ lia.command.add("plyungod", {
     adminOnly = true,
     privilege = L("Ungod Player"),
     desc = "plyUngodDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -827,7 +827,7 @@ lia.command.add("plyignite", {
     adminOnly = true,
     privilege = L("Ignite Player"),
     desc = "plyIgniteDesc",
-    syntax = "[player Name] [number Duration optional]",
+    syntax = L("[player Name] [number Duration optional]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -842,7 +842,7 @@ lia.command.add("plyextinguish", {
     adminOnly = true,
     privilege = L("Extinguish Player"),
     desc = "plyExtinguishDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -856,7 +856,7 @@ lia.command.add("plystrip", {
     adminOnly = true,
     privilege = L("Strip Player"),
     desc = "plyStripDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -879,7 +879,7 @@ lia.command.add("pktoggle", {
     adminOnly = true,
     privilege = L("Toggle Permakill"),
     desc = "togglePermakillDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     AdminStick = {
         Name = "adminStickTogglePermakillName",
         Category = "characterManagement",
@@ -914,7 +914,7 @@ lia.command.add("charunbanoffline", {
     superAdminOnly = true,
     privilege = L("Unban Offline"),
     desc = "charUnbanOfflineDesc",
-    syntax = "[number Char ID]",
+    syntax = L("[number Char ID]"),
     onRun = function(client, arguments)
         local charID = tonumber(arguments[1])
         if not charID then return client:notifyLocalized("invalidCharID") end
@@ -931,7 +931,7 @@ lia.command.add("charbanoffline", {
     superAdminOnly = true,
     privilege = L("Ban Offline"),
     desc = "charBanOfflineDesc",
-    syntax = "[number Char ID]",
+    syntax = L("[number Char ID]"),
     onRun = function(client, arguments)
         local charID = tonumber(arguments[1])
         if not charID then return client:notifyLocalized("invalidCharID") end
@@ -960,7 +960,7 @@ lia.command.add("playglobalsound", {
     superAdminOnly = true,
     privilege = L("Play Sounds"),
     desc = "playGlobalSoundDesc",
-    syntax = "[string Sound]",
+    syntax = L("[string Sound]"),
     onRun = function(client, arguments)
         local sound = arguments[1]
         if not sound or sound == "" then
@@ -978,7 +978,7 @@ lia.command.add("playsound", {
     superAdminOnly = true,
     privilege = L("Play Sounds"),
     desc = "playSoundDesc",
-    syntax = "[player Name] [string Sound]",
+    syntax = L("[player Name] [string Sound]"),
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local sound = arguments[2]
@@ -1029,7 +1029,7 @@ lia.command.add("forcefallover", {
     adminOnly = true,
     privilege = L("Force Fallover"),
     desc = "forceFalloverDesc",
-    syntax = "[player Name] [number Time optional]",
+    syntax = L("[player Name] [number Time optional]"),
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1073,7 +1073,7 @@ lia.command.add("forcegetup", {
     adminOnly = true,
     privilege = L("Force GetUp"),
     desc = "forceGetUpDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1102,7 +1102,7 @@ lia.command.add("forcegetup", {
 lia.command.add("chardesc", {
     adminOnly = false,
     desc = "changeCharDesc",
-    syntax = "[string Desc optional]",
+    syntax = L("[string Desc optional]"),
     onRun = function(client, arguments)
         local desc = table.concat(arguments, " ")
         if not desc:find("%S") then return client:requestString(L("chgName"), L("chgNameDesc"), function(text) lia.command.run(client, "chardesc", {text}) end, client:getChar() and client:getChar():getDesc() or "") end
@@ -1138,7 +1138,7 @@ lia.command.add("chargetup", {
 lia.command.add("fallover", {
     adminOnly = false,
     desc = "fallOverDesc",
-    syntax = "[number Time optional]",
+    syntax = L("[number Time optional]"),
     onRun = function(client, arguments)
         if client:getNetVar("FallOverCooldown", false) then
             client:notifyLocalized("cmdCooldown")
@@ -1199,7 +1199,7 @@ lia.command.add("checkinventory", {
     adminOnly = true,
     privilege = L("Check Inventories"),
     desc = "checkInventoryDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     AdminStick = {
         Name = "adminStickCheckInventoryName",
         Category = "characterManagement",
@@ -1233,7 +1233,7 @@ lia.command.add("flaggive", {
     adminOnly = true,
     privilege = L("Manage Flags"),
     desc = "flagGiveDesc",
-    syntax = "[player Name] [string Flags]",
+    syntax = L("[player Name] [string Flags]"),
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1267,7 +1267,7 @@ lia.command.add("flaggiveall", {
     adminOnly = true,
     privilege = L("Manage Flags"),
     desc = "giveAllFlagsDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     AdminStick = {
         Name = "adminStickGiveAllFlagsName",
         Category = "characterManagement",
@@ -1294,7 +1294,7 @@ lia.command.add("flagtakeall", {
     adminOnly = true,
     privilege = L("Manage Flags"),
     desc = "takeAllFlagsDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     AdminStick = {
         Name = "adminStickTakeAllFlagsName",
         Category = "characterManagement",
@@ -1326,7 +1326,7 @@ lia.command.add("flagtake", {
     adminOnly = true,
     privilege = L("Manage Flags"),
     desc = "flagTakeDesc",
-    syntax = "[player Name] [string Flags]",
+    syntax = L("[player Name] [string Flags]"),
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1351,7 +1351,7 @@ lia.command.add("pflaggive", {
     adminOnly = true,
     privilege = L("Manage Flags"),
     desc = "playerFlagGiveDesc",
-    syntax = "[player Name] [string Flags]",
+    syntax = L("[player Name] [string Flags]"),
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1387,7 +1387,7 @@ lia.command.add("pflaggiveall", {
     adminOnly = true,
     privilege = L("Manage Flags"),
     desc = "giveAllFlagsDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1408,7 +1408,7 @@ lia.command.add("pflagtakeall", {
     adminOnly = true,
     privilege = L("Manage Flags"),
     desc = "takeAllFlagsDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1429,7 +1429,7 @@ lia.command.add("pflagtake", {
     adminOnly = true,
     privilege = L("Manage Flags"),
     desc = "playerFlagTakeDesc",
-    syntax = "[player Name] [string Flags]",
+    syntax = L("[player Name] [string Flags]"),
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1466,7 +1466,7 @@ lia.command.add("charvoicetoggle", {
     adminOnly = true,
     privilege = L("Toggle Voice Ban Character"),
     desc = "charVoiceToggleDesc",
-    syntax = "[string Name]",
+    syntax = L("[string Name]"),
     AdminStick = {
         Name = "toggleVoice",
         Category = "moderationTools",
@@ -1556,7 +1556,7 @@ lia.command.add("charunban", {
     superAdminOnly = true,
     privilege = L("Manage Characters"),
     desc = "charUnbanDesc",
-    syntax = "[string Name or Number ID]",
+    syntax = L("[string Name or Number ID]"),
     onRun = function(client, arguments)
         if (client.liaNextSearch or 0) >= CurTime() then return L("searchingChar") end
         local queryArg = table.concat(arguments, " ")
@@ -1616,7 +1616,7 @@ lia.command.add("clearinv", {
     superAdminOnly = true,
     privilege = L("Manage Characters"),
     desc = "clearInvDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     AdminStick = {
         Name = "adminStickClearInventoryName",
         Category = "characterManagement",
@@ -1639,7 +1639,7 @@ lia.command.add("charkick", {
     adminOnly = true,
     privilege = L("Kick Characters"),
     desc = "kickCharDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     AdminStick = {
         Name = "adminStickKickCharacterName",
         Category = "characterManagement",
@@ -1671,7 +1671,7 @@ lia.command.add("freezeallprops", {
     superAdminOnly = true,
     privilege = L("Manage Characters"),
     desc = "freezeAllPropsDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1699,7 +1699,7 @@ lia.command.add("charban", {
     superAdminOnly = true,
     privilege = L("Manage Characters"),
     desc = "banCharDesc",
-    syntax = "[string Name or Number ID]",
+    syntax = L("[string Name or Number ID]"),
     AdminStick = {
         Name = "banCharacter",
         Category = "characterManagement",
@@ -1749,7 +1749,7 @@ lia.command.add("checkmoney", {
     adminOnly = true,
     privilege = L("Get Character Info"),
     desc = "checkMoneyDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     AdminStick = {
         Name = "adminStickCheckMoneyName",
         Category = "characterManagement",
@@ -1772,7 +1772,7 @@ lia.command.add("listbodygroups", {
     adminOnly = true,
     privilege = L("Get Character Info"),
     desc = "listBodygroupsDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1816,7 +1816,7 @@ lia.command.add("charsetspeed", {
     adminOnly = true,
     privilege = L("Manage Character Stats"),
     desc = "setSpeedDesc",
-    syntax = "[player Name] [number Speed optional]",
+    syntax = L("[player Name] [number Speed optional]"),
     AdminStick = {
         Name = "adminStickSetCharSpeedName",
         Category = "characterManagement",
@@ -1839,7 +1839,7 @@ lia.command.add("charsetmodel", {
     adminOnly = true,
     privilege = L("Manage Character Information"),
     desc = "setModelDesc",
-    syntax = "[player Name] [string Model optional]",
+    syntax = L("[player Name] [string Model optional]"),
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1859,7 +1859,7 @@ lia.command.add("chargiveitem", {
     superAdminOnly = true,
     privilege = L("Manage Items"),
     desc = "giveItemDesc",
-    syntax = "[player Name] [item Item Name]",
+    syntax = L("[player Name] [item Item Name]"),
     AdminStick = {
         Name = "adminStickGiveItemName",
         Category = "characterManagement",
@@ -1908,7 +1908,7 @@ lia.command.add("charsetdesc", {
     adminOnly = true,
     privilege = L("Manage Character Information"),
     desc = "setDescDesc",
-    syntax = "[player Name] [string Description optional]",
+    syntax = L("[player Name] [string Description optional]"),
     AdminStick = {
         Name = "adminStickSetCharDescName",
         Category = "characterManagement",
@@ -1938,7 +1938,7 @@ lia.command.add("charsetname", {
     adminOnly = true,
     privilege = L("Manage Character Information"),
     desc = "setNameDesc",
-    syntax = "[player Name] [string New Name optional]",
+    syntax = L("[player Name] [string New Name optional]"),
     AdminStick = {
         Name = "adminStickSetCharNameName",
         Category = "characterManagement",
@@ -1963,7 +1963,7 @@ lia.command.add("charsetscale", {
     adminOnly = true,
     privilege = L("Manage Character Stats"),
     desc = "setScaleDesc",
-    syntax = "[player Name] [number Scale optional]",
+    syntax = L("[player Name] [number Scale optional]"),
     AdminStick = {
         Name = "adminStickSetCharScaleName",
         Category = "characterManagement",
@@ -1987,7 +1987,7 @@ lia.command.add("charsetjump", {
     adminOnly = true,
     privilege = L("Manage Character Stats"),
     desc = "setJumpDesc",
-    syntax = "[player Name] [number Power optional]",
+    syntax = L("[player Name] [number Power optional]"),
     AdminStick = {
         Name = "adminStickSetCharJumpName",
         Category = "characterManagement",
@@ -2011,7 +2011,7 @@ lia.command.add("charsetbodygroup", {
     adminOnly = true,
     privilege = L("Manage Bodygroups"),
     desc = "setBodygroupDesc",
-    syntax = "[player Name] [string BodyGroup Name] [number Value]",
+    syntax = L("[player Name] [string BodyGroup Name] [number Value]"),
     onRun = function(client, arguments)
         local name = arguments[1]
         local bodyGroup = arguments[2]
@@ -2040,7 +2040,7 @@ lia.command.add("charsetskin", {
     adminOnly = true,
     privilege = L("Manage Character Stats"),
     desc = "setSkinDesc",
-    syntax = "[player Name] [number Skin]",
+    syntax = L("[player Name] [number Skin]"),
     AdminStick = {
         Name = "adminStickSetCharSkinName",
         Category = "characterManagement",
@@ -2066,7 +2066,7 @@ lia.command.add("charsetmoney", {
     superAdminOnly = true,
     privilege = L("Manage Characters"),
     desc = "setMoneyDesc",
-    syntax = "[player Name] [number Amount]",
+    syntax = L("[player Name] [number Amount]"),
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local amount = tonumber(arguments[2])
@@ -2090,7 +2090,7 @@ lia.command.add("charaddmoney", {
     superAdminOnly = true,
     privilege = L("Manage Characters"),
     desc = "addMoneyDesc",
-    syntax = "[player Name] [number Amount]",
+    syntax = L("[player Name] [number Amount]"),
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local amount = tonumber(arguments[2])
@@ -2117,7 +2117,7 @@ lia.command.add("globalbotsay", {
     superAdminOnly = true,
     privilege = L("Bot Say"),
     desc = "globalBotSayDesc",
-    syntax = "[string Message]",
+    syntax = L("[string Message]"),
     onRun = function(client, arguments)
         local message = table.concat(arguments, " ")
         if message == "" then
@@ -2135,7 +2135,7 @@ lia.command.add("botsay", {
     superAdminOnly = true,
     privilege = L("Bot Say"),
     desc = "botSayDesc",
-    syntax = "[string Bot Name] [string Message]",
+    syntax = L("[string Bot Name] [string Message]"),
     onRun = function(client, arguments)
         if #arguments < 2 then
             client:notifyLocalized("needBotAndMessage")
@@ -2165,7 +2165,7 @@ lia.command.add("forcesay", {
     superAdminOnly = true,
     privilege = L("Force Say"),
     desc = "forceSayDesc",
-    syntax = "[player Name] [string Message]",
+    syntax = L("[player Name] [string Message]"),
     AdminStick = {
         Name = "Force Say",
         Category = "moderationTools",
@@ -2206,7 +2206,7 @@ lia.command.add("getmodel", {
 
 lia.command.add("pm", {
     desc = "pmDesc",
-    syntax = "[player Name] [string Message]",
+    syntax = L("[player Name] [string Message]"),
     onRun = function(client, arguments)
         if not lia.config.get("AllowPMs") then
             client:notifyLocalized("pmsDisabled")
@@ -2234,7 +2234,7 @@ lia.command.add("chargetmodel", {
     adminOnly = true,
     privilege = L("Get Character Info"),
     desc = "getCharModelDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     AdminStick = {
         Name = "adminStickGetCharModelName",
         Category = "characterManagement",
@@ -2268,7 +2268,7 @@ lia.command.add("checkflags", {
     adminOnly = true,
     privilege = L("Get Character Info"),
     desc = "checkFlagsDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     AdminStick = {
         Name = "adminStickGetCharFlagsName",
         Category = "characterManagement",
@@ -2295,7 +2295,7 @@ lia.command.add("chargetname", {
     adminOnly = true,
     privilege = L("Get Character Info"),
     desc = "getCharNameDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     AdminStick = {
         Name = "adminStickGetCharNameName",
         Category = "characterManagement",
@@ -2317,7 +2317,7 @@ lia.command.add("chargethealth", {
     adminOnly = true,
     privilege = L("Get Character Info"),
     desc = "getHealthDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     AdminStick = {
         Name = "adminStickGetCharHealthName",
         Category = "characterManagement",
@@ -2339,7 +2339,7 @@ lia.command.add("chargetmoney", {
     adminOnly = true,
     privilege = L("Get Character Info"),
     desc = "getMoneyDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     AdminStick = {
         Name = "adminStickGetCharMoneyName",
         Category = "characterManagement",
@@ -2362,7 +2362,7 @@ lia.command.add("chargetinventory", {
     adminOnly = true,
     privilege = L("Get Character Info"),
     desc = "getInventoryDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     AdminStick = {
         Name = "adminStickGetCharInventoryName",
         Category = "characterManagement",
@@ -2396,7 +2396,7 @@ lia.command.add("getallinfos", {
     adminOnly = true,
     privilege = L("Get Character Info"),
     desc = "getAllInfosDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     AdminStick = {
         Name = "adminStickGetAllInfosName",
         Category = "characterManagement",

--- a/gamemode/modules/administration/submodules/tickets/commands.lua
+++ b/gamemode/modules/administration/submodules/tickets/commands.lua
@@ -4,7 +4,7 @@ lia.command.add("viewtickets", {
     adminOnly = true,
     privilege = L("View Claims"),
     desc = "viewTicketsDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local targetName = arguments[1]
         if not targetName then
@@ -51,7 +51,7 @@ lia.command.add("plyviewclaims", {
     adminOnly = true,
     privilege = L("View Claims"),
     desc = "plyViewClaimsDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     AdminStick = {
         Name = "viewTicketClaims",
         Category = "moderationTools",

--- a/gamemode/modules/administration/submodules/warns/commands.lua
+++ b/gamemode/modules/administration/submodules/warns/commands.lua
@@ -3,7 +3,7 @@ lia.command.add("warn", {
     adminOnly = true,
     privilege = "issueWarnings",
     desc = "warnDesc",
-    syntax = "[player Target] [string Reason]",
+    syntax = L("[player Target] [string Reason]"),
     AdminStick = {
         Name = "warnPlayer",
         Category = "moderationTools",
@@ -41,7 +41,7 @@ lia.command.add("viewwarns", {
     adminOnly = true,
     privilege = "viewPlayerWarnings",
     desc = "viewWarnsDesc",
-    syntax = "[player Target]",
+    syntax = L("[player Target]"),
     AdminStick = {
         Name = "viewPlayerWarnings",
         Category = "moderationTools",

--- a/gamemode/modules/attributes/commands.lua
+++ b/gamemode/modules/attributes/commands.lua
@@ -1,7 +1,7 @@
 ﻿lia.command.add("charsetattrib", {
     superAdminOnly = true,
     desc = "setAttributes",
-    syntax = "[player Name] [string Attribute Name] [number Level]",
+    syntax = L("[player Name] [string Attribute Name] [number Level]"),
     privilege = L("Manage Attributes"),
     AdminStick = {
         Name = "setAttributes",
@@ -36,7 +36,7 @@
 lia.command.add("checkattributes", {
     adminOnly = true,
     desc = "checkAttributes",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     privilege = L("Manage Attributes"),
     AdminStick = {
         Name = "checkAttributes",
@@ -98,7 +98,7 @@ lia.command.add("checkattributes", {
 lia.command.add("charaddattrib", {
     superAdminOnly = true,
     desc = "addAttributes",
-    syntax = "[player Name] [string Attribute Name] [number Level]",
+    syntax = L("[player Name] [string Attribute Name] [number Level]"),
     privilege = L("Manage Attributes"),
     AdminStick = {
         Name = "addAttributes",

--- a/gamemode/modules/chatbox/commands.lua
+++ b/gamemode/modules/chatbox/commands.lua
@@ -2,7 +2,7 @@
     adminOnly = true,
     privilege = L("Ban OOC"),
     desc = "banOOCCommandDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     AdminStick = {
         Name = "banOOCStickName",
         Category = "moderationTools",
@@ -26,7 +26,7 @@ lia.command.add("unbanooc", {
     adminOnly = true,
     privilege = L("Unban OOC"),
     desc = "unbanOOCCommandDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     AdminStick = {
         Name = "unbanOOCStickName",
         Category = "moderationTools",

--- a/gamemode/modules/chatbox/libraries/shared.lua
+++ b/gamemode/modules/chatbox/libraries/shared.lua
@@ -1,5 +1,5 @@
 ﻿lia.chat.register("meclose", {
-    syntax = "[string Action]",
+    syntax = L("[string Action]"),
     desc = "mecloseDesc",
     format = "emoteFormat",
     onCanHear = lia.config.get("ChatRange", 280) * 0.25,
@@ -10,7 +10,7 @@
 })
 
 lia.chat.register("actions", {
-    syntax = "[string Action]",
+    syntax = L("[string Action]"),
     desc = "actionsDesc",
     format = "emoteFormat",
     color = Color(255, 150, 0),
@@ -19,7 +19,7 @@ lia.chat.register("actions", {
 })
 
 lia.chat.register("mefar", {
-    syntax = "[string Action]",
+    syntax = L("[string Action]"),
     desc = "mefarDesc",
     format = "emoteFormat",
     onCanHear = lia.config.get("ChatRange", 280) * 2,
@@ -30,7 +30,7 @@ lia.chat.register("mefar", {
 })
 
 lia.chat.register("itclose", {
-    syntax = "[string Text]",
+    syntax = L("[string Text]"),
     desc = "itcloseDesc",
     onChatAdd = function(_, text) chat.AddText(lia.config.get("ChatColor"), "**" .. text) end,
     onCanHear = lia.config.get("ChatRange", 280) * 0.25,
@@ -41,7 +41,7 @@ lia.chat.register("itclose", {
 })
 
 lia.chat.register("itfar", {
-    syntax = "[string Text]",
+    syntax = L("[string Text]"),
     desc = "itfarDesc",
     onChatAdd = function(_, text) chat.AddText(lia.config.get("ChatColor"), "**" .. text) end,
     onCanHear = lia.config.get("ChatRange", 280) * 2,
@@ -63,7 +63,7 @@ lia.chat.register("coinflip", {
 })
 
 lia.chat.register("ic", {
-    syntax = "[string Text]",
+    syntax = L("[string Text]"),
     desc = "icDesc",
     format = "icFormat",
     onGetColor = function(speaker)
@@ -79,7 +79,7 @@ lia.chat.register("ic", {
 })
 
 lia.chat.register("me", {
-    syntax = "[string Action]",
+    syntax = L("[string Action]"),
     desc = "meDesc",
     format = "emoteFormat",
     onGetColor = lia.chat.classes.ic.onGetColor,
@@ -95,7 +95,7 @@ lia.chat.register("me", {
 })
 
 lia.chat.register("globalme", {
-    syntax = "[string Action]",
+    syntax = L("[string Action]"),
     desc = "globalMeDesc",
     format = "emoteFormat",
     onGetColor = lia.chat.classes.ic.onGetColor,
@@ -107,7 +107,7 @@ lia.chat.register("globalme", {
 })
 
 lia.chat.register("it", {
-    syntax = "[string Text]",
+    syntax = L("[string Text]"),
     desc = "itDesc",
     onChatAdd = function(_, text) chat.AddText(lia.chat.timestamp(false), lia.config.get("ChatColor"), "**" .. text) end,
     onCanHear = function(speaker, listener)
@@ -122,7 +122,7 @@ lia.chat.register("it", {
 })
 
 lia.chat.register("w", {
-    syntax = "[string Text]",
+    syntax = L("[string Text]"),
     desc = "wDesc",
     format = "whisperFormat",
     onGetColor = function(speaker)
@@ -138,7 +138,7 @@ lia.chat.register("w", {
 })
 
 lia.chat.register("y", {
-    syntax = "[string Text]",
+    syntax = L("[string Text]"),
     desc = "yDesc",
     format = "yellFormat",
     onGetColor = function(speaker)
@@ -154,7 +154,7 @@ lia.chat.register("y", {
 })
 
 lia.chat.register("looc", {
-    syntax = "[string Text]",
+    syntax = L("[string Text]"),
     desc = "loocDesc",
     onCanSay = function(speaker)
         local delay = lia.config.get("LOOCDelay", false)
@@ -180,7 +180,7 @@ lia.chat.register("looc", {
 })
 
 lia.chat.register("adminchat", {
-    syntax = "[string Text]",
+    syntax = L("[string Text]"),
     desc = "adminchatDesc",
     onGetColor = function() return Color(0, 196, 255) end,
     onCanHear = function(_, listener) return listener:hasPrivilege(L("adminChat")) end,
@@ -210,7 +210,7 @@ lia.chat.register("roll", {
 })
 
 lia.chat.register("pm", {
-    syntax = "[player Name] [string Message]",
+    syntax = L("[player Name] [string Message]"),
     desc = "pmDesc",
     format = "pmFormat",
     color = Color(249, 211, 89),
@@ -219,7 +219,7 @@ lia.chat.register("pm", {
 })
 
 lia.chat.register("eventlocal", {
-    syntax = "[string Text]",
+    syntax = L("[string Text]"),
     desc = "eventlocalDesc",
     onCanSay = function(speaker) return speaker:hasPrivilege(L("localEventChat")) end,
     onCanHear = function(speaker, listener)
@@ -233,7 +233,7 @@ lia.chat.register("eventlocal", {
 })
 
 lia.chat.register("event", {
-    syntax = "[string Text]",
+    syntax = L("[string Text]"),
     desc = "eventDesc",
     onCanSay = function(speaker) return speaker:hasPrivilege(L("eventChat")) end,
     onCanHear = function() return true end,
@@ -243,7 +243,7 @@ lia.chat.register("event", {
 })
 
 lia.chat.register("ooc", {
-    syntax = "[string Text]",
+    syntax = L("[string Text]"),
     desc = "oocDesc",
     onCanSay = function(speaker, text)
         if GetGlobalBool("oocblocked", false) then
@@ -281,7 +281,7 @@ lia.chat.register("ooc", {
 })
 
 lia.chat.register("me's", {
-    syntax = "[string Action]",
+    syntax = L("[string Action]"),
     desc = "mesDesc",
     format = "mePossessiveFormat",
     onCanHear = lia.config.get("ChatRange", 280),
@@ -305,7 +305,7 @@ lia.chat.register("me's", {
 })
 
 lia.chat.register("mefarfar", {
-    syntax = "[string Action]",
+    syntax = L("[string Action]"),
     desc = "mefarfarDesc",
     format = "emoteFormat",
     onChatAdd = function(speaker, text, anonymous)
@@ -329,7 +329,7 @@ lia.chat.register("mefarfar", {
 })
 
 lia.chat.register("help", {
-    syntax = "[string Text]",
+    syntax = L("[string Text]"),
     desc = "helpDesc",
     onCanSay = function() return true end,
     onCanHear = function(speaker, listener)

--- a/gamemode/modules/doors/commands.lua
+++ b/gamemode/modules/doors/commands.lua
@@ -254,7 +254,7 @@ lia.command.add("doortogglehidden", {
 
 lia.command.add("doorsetprice", {
     desc = "doorsetpriceDesc",
-    syntax = "[number Price]",
+    syntax = L("[number Price]"),
     adminOnly = true,
     privilege = L("Manage Doors"),
     AdminStick = {
@@ -281,7 +281,7 @@ lia.command.add("doorsetprice", {
 
 lia.command.add("doorsettitle", {
     desc = "doorsettitleDesc",
-    syntax = "[string Title]",
+    syntax = L("[string Title]"),
     adminOnly = true,
     privilege = L("Manage Doors"),
     AdminStick = {
@@ -416,7 +416,7 @@ lia.command.add("doorinfo", {
 
 lia.command.add("dooraddfaction", {
     desc = "dooraddfactionDesc",
-    syntax = "[faction Faction]",
+    syntax = L("[faction Faction]"),
     adminOnly = true,
     privilege = L("Manage Doors"),
     onRun = function(client, arguments)
@@ -456,7 +456,7 @@ lia.command.add("dooraddfaction", {
 
 lia.command.add("doorremovefaction", {
     desc = "doorremovefactionDesc",
-    syntax = "[faction Faction]",
+    syntax = L("[faction Faction]"),
     adminOnly = true,
     privilege = L("Manage Doors"),
     onRun = function(client, arguments)
@@ -496,7 +496,7 @@ lia.command.add("doorremovefaction", {
 
 lia.command.add("doorsetclass", {
     desc = "doorsetclassDesc",
-    syntax = "[class Class]",
+    syntax = L("[class Class]"),
     adminOnly = true,
     privilege = L("Manage Doors"),
     onRun = function(client, arguments)

--- a/gamemode/modules/inventory/commands.lua
+++ b/gamemode/modules/inventory/commands.lua
@@ -2,7 +2,7 @@
     adminOnly = true,
     privilege = L("Set Inventory Size"),
     desc = "updateInventorySizeDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -42,7 +42,7 @@ lia.command.add("setinventorysize", {
     adminOnly = true,
     privilege = L("Set Inventory Size"),
     desc = "setInventorySizeDesc",
-    syntax = "[player Name] [number Width] [number Height]",
+    syntax = L("[player Name] [number Width] [number Height]"),
     onRun = function(client, args)
         local target = lia.util.findPlayer(client, args[1])
         if not target or not IsValid(target) then

--- a/gamemode/modules/inventory/submodules/storage/commands.lua
+++ b/gamemode/modules/inventory/submodules/storage/commands.lua
@@ -3,7 +3,7 @@ lia.command.add("storagelock", {
     privilege = L("Lock Storage"),
     adminOnly = true,
     desc = "storagelockDesc",
-    syntax = "[string Password optional]",
+    syntax = L("[string Password optional]"),
     onRun = function(client, arguments)
         local entity = client:getTracedEntity()
         if entity and IsValid(entity) then

--- a/gamemode/modules/inventory/submodules/vendor/commands.lua
+++ b/gamemode/modules/inventory/submodules/vendor/commands.lua
@@ -50,7 +50,7 @@ lia.command.add("resetallvendormoney", {
     privilege = L("Manage Vendors"),
     superAdminOnly = true,
     desc = "resetAllVendorMoneyDesc",
-    syntax = "[number Amount]",
+    syntax = L("[number Amount]"),
     AdminStick = {
         Name = "resetAllVendorMoneyStickName",
         TargetClass = "lia_vendor"
@@ -76,7 +76,7 @@ lia.command.add("restockvendormoney", {
     privilege = L("Manage Vendors"),
     superAdminOnly = true,
     desc = "restockVendorMoneyDesc",
-    syntax = "[number Amount]",
+    syntax = L("[number Amount]"),
     AdminStick = {
         Name = "restockVendorMoneyStickName",
         TargetClass = "lia_vendor"

--- a/gamemode/modules/protection/commands.lua
+++ b/gamemode/modules/protection/commands.lua
@@ -2,7 +2,7 @@
     adminOnly = true,
     privilege = L("Toggle Cheater Status"),
     desc = "toggleCheaterDesc",
-    syntax = "[player Target]",
+    syntax = L("[player Target]"),
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then

--- a/gamemode/modules/recognition/commands.lua
+++ b/gamemode/modules/recognition/commands.lua
@@ -8,7 +8,7 @@ end
 lia.command.add("recogwhisper", {
     privilege = L("Manage Recognition"),
     adminOnly = true,
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     desc = "recogWhisperDesc",
     AdminStick = {
         Name = "recogWhisperStickName",
@@ -22,7 +22,7 @@ lia.command.add("recogwhisper", {
 lia.command.add("recognormal", {
     privilege = L("Manage Recognition"),
     adminOnly = true,
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     desc = "recogNormalDesc",
     AdminStick = {
         Name = "recogNormalStickName",
@@ -36,7 +36,7 @@ lia.command.add("recognormal", {
 lia.command.add("recogyell", {
     privilege = L("Manage Recognition"),
     adminOnly = true,
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     desc = "recogYellDesc",
     AdminStick = {
         Name = "recogYellStickName",
@@ -50,7 +50,7 @@ lia.command.add("recogyell", {
 lia.command.add("recogbots", {
     privilege = L("Manage Recognition"),
     superAdminOnly = true,
-    syntax = "[string Range optional] [string Name optional]",
+    syntax = L("[string Range optional] [string Name optional]"),
     desc = "recogBotsDesc",
     AdminStick = {
         Name = "recogBotsStickName",

--- a/gamemode/modules/spawns/commands.lua
+++ b/gamemode/modules/spawns/commands.lua
@@ -3,7 +3,7 @@ lia.command.add("spawnadd", {
     privilege = "manageSpawns",
     adminOnly = true,
     desc = "spawnAddDesc",
-    syntax = "[faction Faction]",
+    syntax = L("[faction Faction]"),
     onRun = function(client, arguments)
         local factionName = arguments[1]
         if not factionName then return L("invalidArg") end
@@ -40,7 +40,7 @@ lia.command.add("spawnremoveinradius", {
     privilege = "manageSpawns",
     adminOnly = true,
     desc = "spawnRemoveInRadiusDesc",
-    syntax = "[number Radius optional]",
+    syntax = L("[number Radius optional]"),
     onRun = function(client, arguments)
         local position = client:GetPos()
         local radius = tonumber(arguments[1]) or 120
@@ -73,7 +73,7 @@ lia.command.add("spawnremovebyname", {
     privilege = "manageSpawns",
     adminOnly = true,
     desc = "spawnRemoveByNameDesc",
-    syntax = "[faction Faction]",
+    syntax = L("[faction Faction]"),
     onRun = function(client, arguments)
         local factionName = arguments[1]
         local factionInfo = lia.faction.indices[factionName:lower()]
@@ -121,7 +121,7 @@ lia.command.add("returnitems", {
     superAdminOnly = true,
     privilege = "returnItems",
     desc = "returnItemsDesc",
-    syntax = "[player Name]",
+    syntax = L("[player Name]"),
     AdminStick = {
         Name = "returnItems",
         Category = "characterManagement",

--- a/gamemode/modules/teams/commands.lua
+++ b/gamemode/modules/teams/commands.lua
@@ -2,7 +2,7 @@
     adminOnly = true,
     privilege = L("Manage Transfers"),
     desc = "plyTransferDesc",
-    syntax = "[player Name] [faction Faction]",
+    syntax = L("[player Name] [faction Faction]"),
     alias = {"charsetfaction"},
     onRun = function(client, arguments)
         local targetPlayer = lia.util.findPlayer(client, arguments[1])
@@ -40,7 +40,7 @@ lia.command.add("plywhitelist", {
     adminOnly = true,
     privilege = L("Manage Whitelists"),
     desc = "plyWhitelistDesc",
-    syntax = "[player Name] [faction Faction]",
+    syntax = L("[player Name] [faction Faction]"),
     alias = {"factionwhitelist"},
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
@@ -64,7 +64,7 @@ lia.command.add("plyunwhitelist", {
     adminOnly = true,
     privilege = L("Manage Whitelists"),
     desc = "plyUnwhitelistDesc",
-    syntax = "[player Name] [faction Faction]",
+    syntax = L("[player Name] [faction Faction]"),
     alias = {"factionunwhitelist"},
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
@@ -89,7 +89,7 @@ lia.command.add("plyunwhitelist", {
 lia.command.add("beclass", {
     adminOnly = false,
     desc = "beClassDesc",
-    syntax = "[class Class]",
+    syntax = L("[class Class]"),
     onRun = function(client, arguments)
         local className = table.concat(arguments, " ")
         local character = client:getChar()
@@ -117,7 +117,7 @@ lia.command.add("setclass", {
     adminOnly = true,
     privilege = L("Manage Classes"),
     desc = "setClassDesc",
-    syntax = "[player Name] [class Class]",
+    syntax = L("[player Name] [class Class]"),
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -148,7 +148,7 @@ lia.command.add("classwhitelist", {
     adminOnly = true,
     privilege = L("Manage Whitelists"),
     desc = "classWhitelistDesc",
-    syntax = "[player Name] [class Class]",
+    syntax = L("[player Name] [class Class]"),
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local classID = lia.class.retrieveClass(table.concat(arguments, " ", 2))
@@ -178,7 +178,7 @@ lia.command.add("classunwhitelist", {
     adminOnly = true,
     privilege = L("Manage Classes"),
     desc = "classUnwhitelistDesc",
-    syntax = "[player Name] [class Class]",
+    syntax = L("[player Name] [class Class]"),
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local classID = lia.class.retrieveClass(table.concat(arguments, " ", 2))


### PR DESCRIPTION
## Summary
- Localize command syntax strings across modules

## Testing
- `luac -p gamemode/modules/administration/commands.lua` (fails: unexpected symbol near '')

------
https://chatgpt.com/codex/tasks/task_e_6892927ce0a4832781d2cfce3f984a16