### PR TITLE
Localize command syntax defaults

### DIFF
--- a/gamemode/core/derma/panels/chatbox.lua
+++ b/gamemode/core/derma/panels/chatbox.lua
@@ -122,7 +122,7 @@ function PANEL:setActive(state)
                     end
 
                     btn.DoClick = function()
-                        local syntax = cmdInfo.syntax or ""
+                        local syntax = cmdInfo.syntax or L("")
                         self.text:SetText("/" .. cmdName .. " " .. syntax)
                         self.text:RequestFocus()
                         self.commandList:Remove()

--- a/gamemode/core/libraries/chatbox.lua
+++ b/gamemode/core/libraries/chatbox.lua
@@ -5,7 +5,7 @@ function lia.chat.timestamp(ooc)
 end
 
 function lia.chat.register(chatType, data)
-    data.syntax = data.syntax or ""
+    data.syntax = L(data.syntax or "")
     data.desc = data.desc or ""
     if data.prefix then
         local prefixes = istable(data.prefix) and data.prefix or {data.prefix}

--- a/gamemode/core/libraries/commands.lua
+++ b/gamemode/core/libraries/commands.lua
@@ -1,7 +1,7 @@
 ﻿lia.command = lia.command or {}
 lia.command.list = lia.command.list or {}
 function lia.command.add(command, data)
-    data.syntax = data.syntax or ""
+    data.syntax = L(data.syntax or "")
     data.desc = data.desc or ""
     data.privilege = data.privilege or nil
     local superAdminOnly = data.superAdminOnly
@@ -584,7 +584,7 @@ hook.Add("CreateInformationButtons", "liaInformationCommandsUnified", function(p
                                 right = right
                             })
 
-                            row.filterText = (cmdName .. " " .. (cmdData.syntax or "") .. " " .. desc .. " " .. right):lower()
+                            row.filterText = (cmdName .. " " .. (cmdData.syntax or L("")) .. " " .. desc .. " " .. right):lower()
                         end
                     end
                 end


### PR DESCRIPTION
## Summary
- Ensure command registration localizes `syntax` strings by default
- Localize chat and panel `syntax` fallbacks with `L("")`

## Testing
- `npm test` *(fails: package.json missing)*
- `python -m pytest`
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689294cb7720832784245b3713209dd9