### PR TITLE
feat: localize web image placeholder

### DIFF
--- a/gamemode/core/libraries/webimage.lua
+++ b/gamemode/core/libraries/webimage.lua
@@ -1,4 +1,4 @@
-﻿lia.webimage = lia.webimage or {}
+lia.webimage = lia.webimage or {}
 local ip = string.Replace(string.Replace(game.GetIPAddress() or "unknown", ":", "_"), "%.", "_")
 local gamemode = engine.ActiveGamemode() or "unknown"
 local baseDir = "lilia/" .. ip .. "/" .. gamemode .. "/"
@@ -161,7 +161,8 @@ concommand.Add("test_webimage_menu", function()
     local urlEntry = vgui.Create("DTextEntry", frame)
     urlEntry:SetPos(10, 30)
     urlEntry:SetSize(frame:GetWide() - 20, 25)
-    urlEntry:SetText("https://i.imgur.com/WNdLdwQ.jpeg")
+    urlEntry:SetText("")
+    urlEntry:SetPlaceholderText(L("imageURLPlaceholder"))
     local loadBtn = vgui.Create("DButton", frame)
     loadBtn:SetPos(10, 65)
     loadBtn:SetSize(frame:GetWide() - 20, 30)

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -1034,6 +1034,7 @@ LANGUAGE = {
     blockedOOC = "Blocked OOC!",
     webImagesTitle = "Web Images",
     webImageTesterTitle = "WebImage Tester",
+    imageURLPlaceholder = "Image URL (e.g., https://i.imgur.com/WNdLdwQ.jpeg)",
     loadImage = "Load Image",
     webImagesCleared = "Web image cache cleared.",
     webSoundsTitle = "Web Sounds",


### PR DESCRIPTION
## Summary
- replace hardcoded web image URL with translatable placeholder
- add English translation for the placeholder

## Testing
- `luac -p gamemode/core/libraries/webimage.lua`
- `luac -p gamemode/languages/english.lua`


------
https://chatgpt.com/codex/tasks/task_e_6892a033aef48327913e3c088ac30895