### PR TITLE
Suppress usergroup errors during initial database setup

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -351,6 +351,7 @@ end
 if SERVER then
     function lia.administrator.addPermission(groupName, permission, silent)
         if not lia.administrator.groups[groupName] then
+            if lia.administrator._loading then return end
             lia.error(L("usergroupDoesntExist"))
             return
         end
@@ -363,6 +364,7 @@ if SERVER then
 
     function lia.administrator.removePermission(groupName, permission, silent)
         if not lia.administrator.groups[groupName] then
+            if lia.administrator._loading then return end
             lia.error(L("usergroupDoesntExist"))
             return
         end


### PR DESCRIPTION
## Summary
- Skip usergroup existence errors in add/remove permission when admin groups are loading

## Testing
- `luacheck gamemode/core/libraries/admin.lua`

------
https://chatgpt.com/codex/tasks/task_e_6892a2093af08327a82dd16eca34b1fa