### PR TITLE
feat: add admin tab icons

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -1008,6 +1008,7 @@ else
         if not IsValid(LocalPlayer()) or not LocalPlayer():hasPrivilege(L("manageUsergroups")) then return end
         pages[#pages + 1] = {
             name = L("userGroups"),
+            icon = "icon16/group.png",
             drawFunc = function(parent)
                 lia.gui.usergroups = parent
                 parent:Clear()

--- a/gamemode/modules/administration/libraries/client.lua
+++ b/gamemode/modules/administration/libraries/client.lua
@@ -117,6 +117,7 @@ function MODULE:PopulateAdminTabs(pages)
     if client:hasPrivilege(L("viewStaffManagement")) then
         table.insert(pages, {
             name = L("moduleStaffManagementName"),
+            icon = "icon16/shield.png",
             drawFunc = function(panel)
                 panelRef = panel
                 net.Start("liaRequestStaffSummary")
@@ -128,6 +129,7 @@ function MODULE:PopulateAdminTabs(pages)
     if client:hasPrivilege(L("canAccessPlayerList")) then
         table.insert(pages, {
             name = L("players"),
+            icon = "icon16/user.png",
             drawFunc = function(panel)
                 panelRef = panel
                 net.Start("liaRequestPlayers")
@@ -139,6 +141,7 @@ function MODULE:PopulateAdminTabs(pages)
     if client:hasPrivilege(L("listCharacters")) then
         table.insert(pages, {
             name = L("characterList"),
+            icon = "icon16/book.png",
             drawFunc = function(panel)
                 panelRef = panel
                 panel:Clear()
@@ -344,6 +347,7 @@ function MODULE:PopulateAdminTabs(pages)
     if client:hasPrivilege(L("viewDBTables")) then
         table.insert(pages, {
             name = L("databaseView"),
+            icon = "icon16/database.png",
             drawFunc = function(panel)
                 panelRef = panel
                 panel:Clear()
@@ -414,6 +418,7 @@ function MODULE:PopulateAdminTabs(pages)
     if client:hasPrivilege(L("canAccessFlagManagement")) then
         table.insert(pages, {
             name = L("flagsManagement"),
+            icon = "icon16/flag_red.png",
             drawFunc = function(panel)
                 flagsPanel = panel
                 if flagsData then
@@ -430,6 +435,7 @@ function MODULE:PopulateAdminTabs(pages)
     if client:hasPrivilege(L("canManageFactions")) then
         table.insert(pages, {
             name = L("factionManagement"),
+            icon = "icon16/chart_organisation.png",
             drawFunc = function(panel)
                 rosterPanel = panel
                 net.Start("liaRequestFactionRoster")
@@ -441,6 +447,7 @@ function MODULE:PopulateAdminTabs(pages)
     if client:hasPrivilege(L("manageCharacters")) then
         table.insert(pages, {
             name = L("pkManager"),
+            icon = "icon16/lightning.png",
             drawFunc = function(panel)
                 panelRef = panel
                 net.Start("liaRequestAllPKs")

--- a/gamemode/modules/administration/submodules/logging/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/logging/libraries/client.lua
@@ -69,6 +69,7 @@ function MODULE:PopulateAdminTabs(pages)
     if IsValid(LocalPlayer()) and LocalPlayer():hasPrivilege(L("canSeeLogs")) then
         table.insert(pages, {
             name = L("logs"),
+            icon = "icon16/book_open.png",
             drawFunc = function(panel)
                 receivedPanel = panel
                 net.Start("send_logs_request")

--- a/gamemode/modules/administration/submodules/tickets/module.lua
+++ b/gamemode/modules/administration/submodules/tickets/module.lua
@@ -97,6 +97,7 @@ if CLIENT then
         if not IsValid(LocalPlayer()) or not (LocalPlayer():hasPrivilege(L("alwaysSeeTickets")) or LocalPlayer():isStaffOnDuty()) then return end
         table.insert(pages, {
             name = L("tickets"),
+            icon = "icon16/report.png",
             drawFunc = function(panel)
                 ticketPanel = panel
                 net.Start("liaRequestActiveTickets")

--- a/gamemode/modules/administration/submodules/warns/module.lua
+++ b/gamemode/modules/administration/submodules/warns/module.lua
@@ -80,6 +80,7 @@ if CLIENT then
         if not IsValid(LocalPlayer()) or not LocalPlayer():hasPrivilege(L("viewPlayerWarnings")) then return end
         table.insert(pages, {
             name = L("warnings"),
+            icon = "icon16/error.png",
             drawFunc = function(panel)
                 panelRef = panel
                 net.Start("liaRequestAllWarnings")

--- a/gamemode/modules/f1menu/libraries/client.lua
+++ b/gamemode/modules/f1menu/libraries/client.lua
@@ -153,7 +153,7 @@ function MODULE:CreateMenuButtons(tabs)
                 local panel = sheet:Add("DPanel")
                 panel:Dock(FILL)
                 panel.Paint = function() end
-                local sheetData = sheet:AddSheet(page.name, panel)
+                local sheetData = sheet:AddSheet(page.name, panel, page.icon)
 
                 if page.drawFunc then
                     sheetData.Tab.liaPagePanel = panel

--- a/gamemode/modules/protection/libraries/client.lua
+++ b/gamemode/modules/protection/libraries/client.lua
@@ -1686,6 +1686,7 @@ function MODULE:PopulateAdminTabs(pages)
     if not table.IsEmpty(entitiesByCreator) then
         pages[#pages + 1] = {
             name = L("entities"),
+            icon = "icon16/bricks.png",
             drawFunc = function(entPanel)
                 local sheetContainer = vgui.Create("DPropertySheet", entPanel)
                 sheetContainer:Dock(FILL)


### PR DESCRIPTION
## Summary
- add icon support to admin tab sheets
- assign icons to built-in admin pages

## Testing
- `luacheck gamemode/modules/f1menu/libraries/client.lua gamemode/core/libraries/admin.lua gamemode/modules/administration/submodules/tickets/module.lua gamemode/modules/administration/submodules/warns/module.lua gamemode/modules/administration/submodules/logging/libraries/client.lua gamemode/modules/administration/libraries/client.lua gamemode/modules/protection/libraries/client.lua` *(895 warnings)*


------
https://chatgpt.com/codex/tasks/task_e_6892b884c2b08327a50c0c4d0c313163