### PR TITLE
Localize flag descriptions automatically

### DIFF
--- a/gamemode/core/libraries/compatibility/pac.lua
+++ b/gamemode/core/libraries/compatibility/pac.lua
@@ -244,4 +244,4 @@ lia.administrator.registerPrivilege({
     Category = L("categoryPAC3")
 })
 
-lia.flag.add("P", L("flagPac3"))
+lia.flag.add("P", "flagPac3")

--- a/gamemode/core/libraries/flags.lua
+++ b/gamemode/core/libraries/flags.lua
@@ -3,7 +3,7 @@ lia.flag.list = lia.flag.list or {}
 function lia.flag.add(flag, desc, callback)
     if lia.flag.list[flag] then return end
     lia.flag.list[flag] = {
-        desc = desc,
+        desc = desc and L(desc) or desc,
         callback = callback
     }
 end
@@ -23,16 +23,16 @@ if SERVER then
     end
 end
 
-lia.flag.add("C", L("flagSpawnVehicles"))
-lia.flag.add("z", L("flagSpawnSweps"))
-lia.flag.add("E", L("flagSpawnSents"))
-lia.flag.add("L", L("flagSpawnEffects"))
-lia.flag.add("r", L("flagSpawnRagdolls"))
-lia.flag.add("e", L("flagSpawnProps"))
-lia.flag.add("n", L("flagSpawnNpcs"))
-lia.flag.add("Z", L("flagInviteToYourFaction"))
-lia.flag.add("X", L("flagInviteToYourClass"))
-lia.flag.add("p", L("flagPhysgun"), function(client, isGiven)
+lia.flag.add("C", "flagSpawnVehicles")
+lia.flag.add("z", "flagSpawnSweps")
+lia.flag.add("E", "flagSpawnSents")
+lia.flag.add("L", "flagSpawnEffects")
+lia.flag.add("r", "flagSpawnRagdolls")
+lia.flag.add("e", "flagSpawnProps")
+lia.flag.add("n", "flagSpawnNpcs")
+lia.flag.add("Z", "flagInviteToYourFaction")
+lia.flag.add("X", "flagInviteToYourClass")
+lia.flag.add("p", "flagPhysgun", function(client, isGiven)
     if isGiven then
         client:Give("weapon_physgun")
         client:SelectWeapon("weapon_physgun")
@@ -41,7 +41,7 @@ lia.flag.add("p", L("flagPhysgun"), function(client, isGiven)
     end
 end)
 
-lia.flag.add("t", L("flagToolgun"), function(client, isGiven)
+lia.flag.add("t", "flagToolgun", function(client, isGiven)
     if isGiven then
         client:Give("gmod_tool")
         client:SelectWeapon("gmod_tool")

--- a/gamemode/modules/administration/submodules/permissions/libraries/shared.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/shared.lua
@@ -28,7 +28,7 @@ function MODULE:InitializedModules()
     end
 end
 
-lia.flag.add("p", L("flagPhysgun"), function(client, isGiven)
+lia.flag.add("p", "flagPhysgun", function(client, isGiven)
     if isGiven then
         client:Give("weapon_physgun")
         client:SelectWeapon("weapon_physgun")
@@ -37,7 +37,7 @@ lia.flag.add("p", L("flagPhysgun"), function(client, isGiven)
     end
 end)
 
-lia.flag.add("t", L("flagToolgun"), function(client, isGiven)
+lia.flag.add("t", "flagToolgun", function(client, isGiven)
     if isGiven then
         client:Give("gmod_tool")
         client:SelectWeapon("gmod_tool")
@@ -46,13 +46,13 @@ lia.flag.add("t", L("flagToolgun"), function(client, isGiven)
     end
 end)
 
-lia.flag.add("C", L("flagSpawnVehicles"))
-lia.flag.add("z", L("flagSpawnSweps"))
-lia.flag.add("E", L("flagSpawnSents"))
-lia.flag.add("L", L("flagSpawnEffects"))
-lia.flag.add("r", L("flagSpawnRagdolls"))
-lia.flag.add("e", L("flagSpawnProps"))
-lia.flag.add("n", L("flagSpawnNpcs"))
-lia.flag.add("V", L("flagFactionRoster"))
-lia.flag.add("K", L("flagFactionKick"))
-lia.flag.add("W", L("flagClassRoster"))
+lia.flag.add("C", "flagSpawnVehicles")
+lia.flag.add("z", "flagSpawnSweps")
+lia.flag.add("E", "flagSpawnSents")
+lia.flag.add("L", "flagSpawnEffects")
+lia.flag.add("r", "flagSpawnRagdolls")
+lia.flag.add("e", "flagSpawnProps")
+lia.flag.add("n", "flagSpawnNpcs")
+lia.flag.add("V", "flagFactionRoster")
+lia.flag.add("K", "flagFactionKick")
+lia.flag.add("W", "flagClassRoster")


### PR DESCRIPTION
## Summary
- localize flag descriptions inside `lia.flag.add`
- simplify flag registration by passing localization keys directly

## Testing
- `luac -p gamemode/core/libraries/flags.lua` *(fails: syntax error near 'end')*
- `luac -p gamemode/core/libraries/compatibility/pac.lua`
- `luac -p gamemode/modules/administration/submodules/permissions/libraries/shared.lua`


------
https://chatgpt.com/codex/tasks/task_e_6892be83010483278eb58b1e58438a79