### PR TITLE
Centralize privilege localization

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -1002,9 +1002,9 @@ concommand.Add("plysetgroup", function(ply, _, args)
 end)
 
 lia.administrator.registerPrivilege({
-    Name = L("stopSoundForEveryone"),
+    Name = "stopSoundForEveryone",
     MinAccess = "superadmin",
-    Category = L("categoryServer")
+    Category = "categoryServer"
 })
 
 concommand.Add("stopsoundall", function(client)

--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -97,12 +97,12 @@ local function camiBootstrapFromExisting()
         local m = tostring(pr.MinAccess or "user"):lower()
         if lia.administrator.privileges[n] == nil then
             lia.administrator.privileges[n] = m
-            lia.administrator.privMeta[n] = tostring(pr.Category or L("unassigned"))
+            lia.administrator.privMeta[n] = L(pr.Category or "unassigned")
             for g in pairs(lia.administrator.groups or {}) do
                 if shouldGrant(g, m) then lia.administrator.groups[g][n] = true end
             end
         else
-            lia.administrator.privMeta[n] = lia.administrator.privMeta[n] or tostring(pr.Category or L("unassigned"))
+            lia.administrator.privMeta[n] = lia.administrator.privMeta[n] or L(pr.Category or "unassigned")
         end
     end
 
@@ -130,12 +130,13 @@ end
 
 function lia.administrator.registerPrivilege(priv)
     if not priv or not priv.Name then return end
-    local name = tostring(priv.Name)
+    local name = L(priv.Name)
     if name == "" then return end
     if lia.administrator.privileges[name] ~= nil then return end
     local min = tostring(priv.MinAccess or "user"):lower()
     lia.administrator.privileges[name] = min
-    lia.administrator.privMeta[name] = tostring(priv.Category or L("unassigned"))
+    local category = L(priv.Category or "unassigned")
+    lia.administrator.privMeta[name] = category
     for groupName, perms in pairs(lia.administrator.groups) do
         perms = perms or {}
         lia.administrator.groups[groupName] = perms
@@ -146,7 +147,7 @@ function lia.administrator.registerPrivilege(priv)
     hook.Run("OnPrivilegeRegistered", {
         Name = name,
         MinAccess = min,
-        Category = lia.administrator.privMeta[name]
+        Category = category
     })
 
     if SERVER then lia.administrator.save() end

--- a/gamemode/core/libraries/commands.lua
+++ b/gamemode/core/libraries/commands.lua
@@ -16,7 +16,7 @@ function lia.command.add(command, data)
         lia.administrator.registerPrivilege({
             Name = privilegeName,
             MinAccess = superAdminOnly and "superadmin" or "admin",
-            Category = L("commands")
+            Category = "commands"
         })
     end
 

--- a/gamemode/core/libraries/compatibility/cami.lua
+++ b/gamemode/core/libraries/compatibility/cami.lua
@@ -72,7 +72,7 @@ hook.Add("CAMI.OnPrivilegeRegistered", "liaAdminPrivAdded", function(priv)
     if lia.administrator.privileges[name] ~= nil then return end
     local min = tostring(priv.MinAccess or "user"):lower()
     lia.administrator.privileges[name] = min
-    lia.administrator.privMeta[name] = tostring(priv.Category or L("unassigned"))
+    lia.administrator.privMeta[name] = L(priv.Category or "unassigned")
     for groupName in pairs(lia.administrator.groups or {}) do
         if shouldGrant(groupName, min) then lia.administrator.groups[groupName][name] = true end
     end

--- a/gamemode/core/libraries/compatibility/pac.lua
+++ b/gamemode/core/libraries/compatibility/pac.lua
@@ -239,9 +239,9 @@ lia.config.add("BlockPackURLoad", L("blockPackUrlLoad"), true, nil, {
 })
 
 lia.administrator.registerPrivilege({
-    Name = L("canUsePAC3"),
+    Name = "canUsePAC3",
     MinAccess = "admin",
-    Category = L("categoryPAC3")
+    Category = "categoryPAC3"
 })
 
 lia.flag.add("P", L("flagPac3"))

--- a/gamemode/core/libraries/compatibility/sam.lua
+++ b/gamemode/core/libraries/compatibility/sam.lua
@@ -175,15 +175,15 @@ lia.command.add("cleardecals", {
 })
 
 lia.administrator.registerPrivilege({
-    Name = L("canSeeSAMNotificationsOutsideStaff"),
+    Name = "canSeeSAMNotificationsOutsideStaff",
     MinAccess = "superadmin",
-    Category = L("categorySAM")
+    Category = "categorySAM"
 })
 
 lia.administrator.registerPrivilege({
-    Name = L("canBypassSAMFactionWhitelist"),
+    Name = "canBypassSAMFactionWhitelist",
     MinAccess = "superadmin",
-    Category = L("categorySAM")
+    Category = "categorySAM"
 })
 
 lia.config.add("AdminOnlyNotification", L("adminOnlyNotifications"), true, nil, {

--- a/gamemode/core/libraries/compatibility/serverguard.lua
+++ b/gamemode/core/libraries/compatibility/serverguard.lua
@@ -30,9 +30,9 @@ function serverguard.permission:Add(identifier, priv)
 
                 if lia.administrator and lia.administrator.registerPrivilege then
                     lia.administrator.registerPrivilege({
-                        Name = L(identifier),
+                        Name = identifier,
                         MinAccess = "admin",
-                        Category = L("categoryServerGuard")
+                        Category = "categoryServerGuard"
                     })
                 end
             end

--- a/gamemode/core/libraries/compatibility/simfphys.lua
+++ b/gamemode/core/libraries/compatibility/simfphys.lua
@@ -70,9 +70,9 @@ lia.config.add("TimeToEnterVehicle", L("timeToEnterVehicle"), 4, nil, {
 })
 
 lia.administrator.registerPrivilege({
-    Name = L("canEditSimfphysCars"),
+    Name = "canEditSimfphysCars",
     MinAccess = "superadmin",
-    Category = L("simfphysVehicles")
+    Category = "simfphysVehicles"
 })
 
 hook.Add("simfphysPhysicsCollide", "SIMFPHYS_simfphysPhysicsCollide", function() return true end)

--- a/gamemode/core/libraries/modularity.lua
+++ b/gamemode/core/libraries/modularity.lua
@@ -5,8 +5,8 @@ local ModuleFiles = {"pim.lua", "client.lua", "server.lua", "config.lua", "comma
 local function loadPermissions(Privileges)
     if not Privileges or not istable(Privileges) then return end
     for _, privilegeData in ipairs(Privileges) do
-        local privilegeName = L(privilegeData.Name)
-        local privilegeCategory = privilegeData.Category and L(privilegeData.Category) or MODULE.name
+        local privilegeName = privilegeData.Name
+        local privilegeCategory = privilegeData.Category or MODULE.name
         lia.administrator.registerPrivilege({
             Name = privilegeName,
             MinAccess = privilegeData.MinAccess or "admin",

--- a/gamemode/modules/administration/submodules/permissions/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/server.lua
@@ -1,8 +1,8 @@
 ﻿local GM = GM or GAMEMODE
 lia.administrator.registerPrivilege({
-    Name = L("useDisallowedTools"),
+    Name = "useDisallowedTools",
     MinAccess = "superadmin",
-    Category = L("categoryStaffTools")
+    Category = "categoryStaffTools"
 })
 local restrictedProperties = {
     persist = true,

--- a/gamemode/modules/administration/submodules/permissions/libraries/shared.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/shared.lua
@@ -9,7 +9,7 @@ function MODULE:InitializedModules()
                 lia.administrator.registerPrivilege({
                     Name = L("accessPropertyPrivilege", prop.MenuLabel),
                     MinAccess = "admin",
-                    Category = L("categoryStaffManagement")
+                    Category = "categoryStaffManagement"
                 })
             end
         end
@@ -21,7 +21,7 @@ function MODULE:InitializedModules()
                 lia.administrator.registerPrivilege({
                     Name = L("accessToolPrivilege", tool:gsub("^%l", string.upper)),
                     MinAccess = defaultUserTools[string.lower(tool)] and "user" or "admin",
-                    Category = L("categoryStaffTools")
+                    Category = "categoryStaffTools"
                 })
             end
         end

--- a/gamemode/modules/protection/libraries/server.lua
+++ b/gamemode/modules/protection/libraries/server.lua
@@ -1,8 +1,8 @@
 ﻿local MODULE = MODULE
 lia.administrator.registerPrivilege({
-    Name = L("receiveCheaterNotifications"),
+    Name = "receiveCheaterNotifications",
     MinAccess = "admin",
-    Category = L("protection")
+    Category = "protection"
 })
 
 local function IsCheater(client)


### PR DESCRIPTION
## Summary
- Localize privilege name and category within `lia.administrator.registerPrivilege`
- Pass raw identifiers to `registerPrivilege` in modules and compatibility layers
- Localize CAMI privilege categories during synchronization

## Testing
- `luac -p gamemode/core/libraries/admin.lua` (and other touched files, removing BOM where needed)

------
https://chatgpt.com/codex/tasks/task_e_6892bfce1d408327b1ff874c8205b46c