### PR TITLE
feat: localize command syntax

### DIFF
--- a/gamemode/core/derma/panels/chatbox.lua
+++ b/gamemode/core/derma/panels/chatbox.lua
@@ -122,7 +122,7 @@ function PANEL:setActive(state)
                     end
 
                     btn.DoClick = function()
-                        local syntax = cmdInfo.syntax or L("")
+                        local syntax = L(cmdInfo.syntax or "")
                         self.text:SetText("/" .. cmdName .. " " .. syntax)
                         self.text:RequestFocus()
                         self.commandList:Remove()

--- a/gamemode/core/libraries/commands.lua
+++ b/gamemode/core/libraries/commands.lua
@@ -556,7 +556,7 @@ hook.Add("CreateInformationButtons", "liaInformationCommandsUnified", function(p
                         local hasAccess = lia.command.hasAccess(client, cmdName, cmdData)
                         if hasAccess then
                             local text = "/" .. cmdName
-                            if cmdData.syntax and cmdData.syntax ~= "" then text = text .. " " .. cmdData.syntax end
+                            if cmdData.syntax and cmdData.syntax ~= "" then text = text .. " " .. L(cmdData.syntax) end
                             local desc = cmdData.desc ~= "" and L(cmdData.desc) or ""
                             local priv = cmdData.privilege and L(cmdData.privilege) or ""
                             data[#data + 1] = {text, desc, priv}
@@ -575,7 +575,7 @@ hook.Add("CreateInformationButtons", "liaInformationCommandsUnified", function(p
                         local hasAccess, privilege = lia.command.hasAccess(client, cmdName, cmdData)
                         if hasAccess then
                             local text = "/" .. cmdName
-                            if cmdData.syntax and cmdData.syntax ~= "" then text = text .. " " .. cmdData.syntax end
+                            if cmdData.syntax and cmdData.syntax ~= "" then text = text .. " " .. L(cmdData.syntax) end
                             local desc = cmdData.desc ~= "" and L(cmdData.desc) or ""
                             local right = privilege and privilege ~= L("globalAccess") and privilege or ""
                             local row = sheet:AddTextRow({
@@ -584,7 +584,7 @@ hook.Add("CreateInformationButtons", "liaInformationCommandsUnified", function(p
                                 right = right
                             })
 
-                            row.filterText = (cmdName .. " " .. (cmdData.syntax or L("")) .. " " .. desc .. " " .. right):lower()
+                            row.filterText = (cmdName .. " " .. L(cmdData.syntax or "") .. " " .. desc .. " " .. right):lower()
                         end
                     end
                 end


### PR DESCRIPTION
## Summary
- ensure command suggestions use localized syntax strings
- localize command syntax in command list and filter

## Testing
- `luacheck gamemode/core/derma/panels/chatbox.lua gamemode/core/libraries/commands.lua` *(fails: expected '=' near 'end')*
- `luacheck gamemode/core/libraries/commands.lua` *(warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_6892d36f64788327989c1276a97d5123