### PR TITLE
refactor: drop syntax field for command arguments

### DIFF
--- a/documentation/docs/definitions/command.md
+++ b/documentation/docs/definitions/command.md
@@ -30,7 +30,7 @@ The command name itself is the first argument to `lia.command.add` and is stored
 | `adminOnly` | `boolean` | `false` | Restrict to admins (registers a CAMI privilege). |
 | `superAdminOnly` | `boolean` | `false` | Restrict to superadmins (registers a CAMI privilege). |
 | `privilege` | `string` | `nil` | Custom CAMI privilege name (defaults to command name). |
-| `syntax` | `string` | `""` | Human-readable argument format shown in help. |
+| `arguments` | `table` | `{}` | Ordered argument definitions used to build help text. |
 | `desc` | `string` | `""` | Short description shown in command lists and menus. |
 | `AdminStick` | `table` | `nil` | Defines how the command appears in admin utilities. |
 | `onRun(client, args)` | `function(client, table)` | **required** | Function executed when the command is invoked. |
@@ -119,32 +119,34 @@ privilege = "Manage Doors"
 
 ---
 
-### Syntax & Description
+### Arguments & Description
 
-#### `syntax`
+#### `arguments`
 
 **Type:**
 
-`string`
+`table`
 
 **Description:**
 
-Human-readable syntax string shown in help menus. Does not affect argument parsing.
+Ordered list defining each command argument. Every entry may contain:
 
-You can use spaces in argument names for better readability.
+* `name` – Argument name shown to the user.
+* `type` – One of `player`, `bool`, `table`, or `string`.
+* `optional` – Set to `true` if the argument is optional.
+* `description` – Optional human-readable help text.
+* `options` – Table or function returning options for `table` type.
+* `filter` – Function to filter players for `player` type.
 
-The in-game prompt only appears when every argument follows the `[type Name]` format.
+The displayed syntax string is generated automatically from these definitions.
 
 **Example Usage:**
 
 ```lua
-syntax = "[string Target Name] [number Amount]"
-```
-
-Include the word `optional` inside the brackets to make an argument optional:
-
-```lua
-syntax = "[string Target Name] [number Amount optional]"
+arguments = {
+    {name = "target", type = "player"},
+    {name = "reason", type = "string", optional = true}
+}
 ```
 
 ---
@@ -239,7 +241,7 @@ lia.command.add("restockvendor", {
     superAdminOnly = true,                -- restrict to super administrators
     privilege = "Manage Vendors",        -- custom privilege checked before run
     desc = "Restock the vendor you are looking at.", -- shown in command lists
-    syntax = "[player Target]",          -- help text describing the argument
+    arguments = {{name = "target", type = "player"}}, -- argument definition
     alias = {"vendorrestock"},           -- other names that trigger the command
     AdminStick = {
         Name        = "Restock Vendor",  -- text on the Admin Stick button
@@ -271,7 +273,7 @@ lia.command.add("restockvendor", {
 ```lua
 lia.command.add("goto", {
     adminOnly = true,                    -- only admins may run this command
-    syntax = "[player Target]",         -- how the argument appears in help menus
+    arguments = {{name = "target", type = "player"}}, -- argument definition
     desc = "Teleport to the specified player.", -- short description
     onRun = function(client, args)
         -- look up the target player from the first argument

--- a/documentation/docs/libraries/lia.chatbox.md
+++ b/documentation/docs/libraries/lia.chatbox.md
@@ -67,7 +67,7 @@ Registers a new chat class and sets up its command aliases.
 
 * `data` (*table*): Table of chat class properties.
 
-  * `syntax` (string) – Argument usage description shown in command help.
+  * `arguments` (table) – Ordered argument definitions for the associated command.
 
   * `desc` (string) – Description of the command shown in menus.
 
@@ -109,7 +109,7 @@ Registers a new chat class and sets up its command aliases.
 -- Register a waving emote command
 lia.chat.register("wave", {
     desc = "Wave at those nearby",
-    syntax = "",
+    arguments = {{name = "text", type = "string", optional = true}},
     format = "* %s waves",
     prefix = {"/wave", "/greet"},
     font = "liaChatFontItalics",

--- a/documentation/docs/libraries/lia.commands.md
+++ b/documentation/docs/libraries/lia.commands.md
@@ -36,7 +36,10 @@ Registers a new command with its associated data. See [Command Fields](../defini
 -- Register a simple warn command for administrators
 lia.command.add("warn", {
     adminOnly = true,
-    syntax = "[player Target] [string Reason]",
+    arguments = {
+        {name = "target", type = "player"},
+        {name = "reason", type = "string"}
+    },
     desc = "Send a warning message to the target player.",
     onRun = function(client, args)
         local target = lia.util.findPlayer(client, args[1])
@@ -120,39 +123,6 @@ local args = lia.command.extractArgs('/mycommand "quoted arg" anotherArg')
 
 local args2 = lia.command.extractArgs("/mycommand 'other arg' another")
 -- args2 = { "other arg", "another" }
-```
-
----
-
-### lia.command.parseSyntaxFields
-
-**Purpose**
-
-Parses a command syntax string into an ordered list of field tables. Each field contains a `name`, a `type`, and an `optional` flag derived from the syntax.
-
-**Parameters**
-
-* `syntax` (*string*): Syntax string, e.g. `[string Name] [number Time]`.
-
-  Include the word `optional` inside a bracket to mark that argument as optional.
-
-**Realm**
-
-`Shared`
-
-**Returns**
-
-* *table*: Ordered list of field tables.
-
-* *boolean*: Whether the syntax strictly used the `[type Name]` format.
-
-**Example Usage**
-
-```lua
-local fields, valid = lia.command.parseSyntaxFields("[string Name] [number Time]")
-
--- mark optional arguments with the word "optional"
-local fieldsOpt = lia.command.parseSyntaxFields("[string Name] [number Time optional]")
 ```
 
 ---
@@ -258,15 +228,15 @@ lia.command.send("mycommand", "arg1", "arg2")
 
 **Purpose**
 
-Opens a window asking the player to fill in arguments for the given command. Missing fields defined as `optional` may be left blank; all others must be filled before **Submit** is enabled.
+Opens a window asking the player to fill in missing arguments for the given command. Arguments marked `optional` may be left blank; all others must be filled before **Submit** is enabled.
 
 **Parameters**
 
 * `cmdKey` (*string*): Command name.
 
-* `fields` (*table | string*): Existing arguments or the server-supplied list of missing fields.
+* `missing` (*table*): Array of argument names that still need values.
 
-* `prefix` (*table*): Legacy prefix table (optional).
+* `prefix` (*table*): Arguments already supplied (optional).
 
 **Realm**
 
@@ -279,7 +249,7 @@ Opens a window asking the player to fill in arguments for the given command. Mis
 **Example Usage**
 
 ```lua
-lia.command.openArgumentPrompt("plywhitelist")
+lia.command.openArgumentPrompt("ban", {"target", "duration"})
 ```
 
 ---

--- a/gamemode/core/libraries/chatbox.lua
+++ b/gamemode/core/libraries/chatbox.lua
@@ -62,14 +62,15 @@ end
             format = "chatMeFormat",
             radius = 150,
             desc = "Performs an action.",
-            syntax = "/me <action>",
+            arguments = {{name = "action", type = "string"}},
             onChatAdd = function(speaker, text)
                 chat.AddText(lia.chat.timestamp(false), Color(200, 150, 255), speaker:Name() .. " " .. text)
             end
         })
 ]]
 function lia.chat.register(chatType, data)
-    data.syntax = L(data.syntax or "")
+    data.arguments = data.arguments or {}
+    data.syntax = L(lia.command.buildSyntaxFromArguments(data.arguments))
     data.desc = data.desc or ""
     if data.prefix then
         local prefixes = istable(data.prefix) and data.prefix or {data.prefix}
@@ -128,7 +129,7 @@ function lia.chat.register(chatType, data)
 
         if #aliases > 0 then
             lia.command.add(chatType, {
-                syntax = data.syntax,
+                arguments = data.arguments,
                 desc = data.desc,
                 alias = aliases,
                 onRun = function(_, args) lia.chat.parse(LocalPlayer(), table.concat(args, " ")) end

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -19,7 +19,11 @@
 lia.command.add("plygetplaytime", {
     adminOnly = true,
     privilege = "viewPlaytime",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     AdminStick = {
         Name = "adminStickGetPlayTimeName",
         Category = "moderationTools",
@@ -120,7 +124,11 @@ lia.command.add("sendtositroom", {
     adminOnly = true,
     privilege = "manageSitRooms",
     desc = "sendToSitRoomDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     AdminStick = {
         Name = "sendToSitRoom",
         Category = "moderationTools",
@@ -164,7 +172,11 @@ lia.command.add("returnsitroom", {
     adminOnly = true,
     privilege = "manageSitRooms",
     desc = "returnFromSitroomDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     AdminStick = {
         Name = "returnFromSitroom",
         Category = "moderationTools",
@@ -265,7 +277,11 @@ lia.command.add("charlist", {
     adminOnly = true,
     privilege = "listCharacters",
     desc = "charListDesc",
-    syntax = L("[string Player Or Steam ID]"),
+    arguments = {
+
+        { name = "playerOrSteamId", type = "string" },
+
+    },
     AdminStick = {
         Name = "adminStickOpenCharListName",
         Category = L("player") .. " " .. L("information"),
@@ -367,7 +383,15 @@ lia.command.add("plyban", {
     adminOnly = true,
     privilege = "banPlayer",
     desc = "plyBanDesc",
-    syntax = L("[player Name] [number Duration optional] [string Reason]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "duration", type = "string", optional = true },
+
+        { name = "reason", type = "string" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -382,7 +406,13 @@ lia.command.add("plykick", {
     adminOnly = true,
     privilege = "kickPlayer",
     desc = "plyKickDesc",
-    syntax = L("[player Name] [string Reason optional]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "reason", type = "string", optional = true },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -406,7 +436,11 @@ lia.command.add("plykill", {
     adminOnly = true,
     privilege = "killPlayer",
     desc = "plyKillDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -430,7 +464,11 @@ lia.command.add("plyunban", {
     adminOnly = true,
     privilege = "unbanPlayer",
     desc = "plyUnbanDesc",
-    syntax = L("[string SteamID]"),
+    arguments = {
+
+        { name = "steamid", type = "string" },
+
+    },
     onRun = function(client, arguments)
         local steamid = arguments[1]
         if steamid and steamid ~= "" then
@@ -445,7 +483,13 @@ lia.command.add("plyfreeze", {
     adminOnly = true,
     privilege = "freezePlayer",
     desc = "plyFreezeDesc",
-    syntax = L("[player Name] [number Duration optional]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "duration", type = "string", optional = true },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -461,7 +505,11 @@ lia.command.add("plyunfreeze", {
     adminOnly = true,
     privilege = "unfreezePlayer",
     desc = "plyUnfreezeDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -475,7 +523,11 @@ lia.command.add("plyslay", {
     adminOnly = true,
     privilege = "slayPlayer",
     desc = "plySlayDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -489,7 +541,11 @@ lia.command.add("plyrespawn", {
     adminOnly = true,
     privilege = "respawnPlayer",
     desc = "plyRespawnDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -512,7 +568,13 @@ lia.command.add("plyblind", {
     adminOnly = true,
     privilege = "blindPlayer",
     desc = "plyBlindDesc",
-    syntax = L("[player Name] [number Time optional]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "time", type = "string", optional = true },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -548,7 +610,11 @@ lia.command.add("plyunblind", {
     adminOnly = true,
     privilege = "unblindPlayer",
     desc = "plyUnblindDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -564,7 +630,19 @@ lia.command.add("plyblindfade", {
     adminOnly = true,
     privilege = "blindFadePlayer",
     desc = "plyBlindFadeDesc",
-    syntax = L("[player Name] [number Time optional] [string Color optional] [number FadeIn optional] [number FadeOut optional]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "time", type = "string", optional = true },
+
+        { name = "color", type = "string", optional = true },
+
+        { name = "fadein", type = "string", optional = true },
+
+        { name = "fadeout", type = "string", optional = true },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -589,7 +667,17 @@ lia.command.add("blindfadeall", {
     adminOnly = true,
     privilege = "blindFadeAll",
     desc = "blindFadeAllDesc",
-    syntax = L("[number Time optional] [string Color optional] [number FadeIn optional] [number FadeOut optional]"),
+    arguments = {
+
+        { name = "time", type = "string", optional = true },
+
+        { name = "color", type = "string", optional = true },
+
+        { name = "fadein", type = "string", optional = true },
+
+        { name = "fadeout", type = "string", optional = true },
+
+    },
     onRun = function(_, arguments)
         local duration = tonumber(arguments[1]) or 0
         local colorName = (arguments[2] or "black"):lower()
@@ -613,7 +701,11 @@ lia.command.add("plygag", {
     adminOnly = true,
     privilege = "gagPlayer",
     desc = "plyGagDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -628,7 +720,11 @@ lia.command.add("plyungag", {
     adminOnly = true,
     privilege = "ungagPlayer",
     desc = "plyUngagDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -643,7 +739,11 @@ lia.command.add("plymute", {
     adminOnly = true,
     privilege = "mutePlayer",
     desc = "plyMuteDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) and target:getChar() then
@@ -668,7 +768,11 @@ lia.command.add("plyunmute", {
     adminOnly = true,
     privilege = "unmutePlayer",
     desc = "plyUnmuteDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) and target:getChar() then
@@ -684,7 +788,11 @@ lia.command.add("plybring", {
     adminOnly = true,
     privilege = "bringPlayer",
     desc = "plyBringDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -699,7 +807,11 @@ lia.command.add("plygoto", {
     adminOnly = true,
     privilege = "gotoPlayer",
     desc = "plyGotoDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -714,7 +826,11 @@ lia.command.add("plyreturn", {
     adminOnly = true,
     privilege = "returnPlayer",
     desc = "plyReturnDesc",
-    syntax = L("[player Name optional]"),
+    arguments = {
+
+        { name = "name", type = "player", optional = true },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         target = IsValid(target) and target or client
@@ -731,7 +847,11 @@ lia.command.add("plyjail", {
     adminOnly = true,
     privilege = "jailPlayer",
     desc = "plyJailDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -755,7 +875,11 @@ lia.command.add("plyunjail", {
     adminOnly = true,
     privilege = "unjailPlayer",
     desc = "plyUnjailDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -770,7 +894,11 @@ lia.command.add("plycloak", {
     adminOnly = true,
     privilege = "cloakPlayer",
     desc = "plyCloakDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -784,7 +912,11 @@ lia.command.add("plyuncloak", {
     adminOnly = true,
     privilege = "uncloakPlayer",
     desc = "plyUncloakDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -798,7 +930,11 @@ lia.command.add("plygod", {
     adminOnly = true,
     privilege = "godPlayer",
     desc = "plyGodDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -812,7 +948,11 @@ lia.command.add("plyungod", {
     adminOnly = true,
     privilege = "ungodPlayer",
     desc = "plyUngodDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -826,7 +966,13 @@ lia.command.add("plyignite", {
     adminOnly = true,
     privilege = "ignitePlayer",
     desc = "plyIgniteDesc",
-    syntax = L("[player Name] [number Duration optional]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "duration", type = "string", optional = true },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -841,7 +987,11 @@ lia.command.add("plyextinguish", {
     adminOnly = true,
     privilege = "extinguishPlayer",
     desc = "plyExtinguishDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -855,7 +1005,11 @@ lia.command.add("plystrip", {
     adminOnly = true,
     privilege = "stripPlayer",
     desc = "plyStripDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.command.findPlayer(client, arguments[1])
         if IsValid(target) then
@@ -878,7 +1032,11 @@ lia.command.add("pktoggle", {
     adminOnly = true,
     privilege = "togglePermakill",
     desc = "togglePermakillDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     AdminStick = {
         Name = "adminStickTogglePermakillName",
         Category = "characterManagement",
@@ -913,7 +1071,11 @@ lia.command.add("charunbanoffline", {
     superAdminOnly = true,
     privilege = "unbanOffline",
     desc = "charUnbanOfflineDesc",
-    syntax = L("[number Char ID]"),
+    arguments = {
+
+        { name = "charId", type = "string" },
+
+    },
     onRun = function(client, arguments)
         local charID = tonumber(arguments[1])
         if not charID then return client:notifyLocalized("invalidCharID") end
@@ -930,7 +1092,11 @@ lia.command.add("charbanoffline", {
     superAdminOnly = true,
     privilege = "banOffline",
     desc = "charBanOfflineDesc",
-    syntax = L("[number Char ID]"),
+    arguments = {
+
+        { name = "charId", type = "string" },
+
+    },
     onRun = function(client, arguments)
         local charID = tonumber(arguments[1])
         if not charID then return client:notifyLocalized("invalidCharID") end
@@ -959,7 +1125,11 @@ lia.command.add("playglobalsound", {
     superAdminOnly = true,
     privilege = "playSounds",
     desc = "playGlobalSoundDesc",
-    syntax = L("[string Sound]"),
+    arguments = {
+
+        { name = "sound", type = "string" },
+
+    },
     onRun = function(client, arguments)
         local sound = arguments[1]
         if not sound or sound == "" then
@@ -977,7 +1147,13 @@ lia.command.add("playsound", {
     superAdminOnly = true,
     privilege = "playSounds",
     desc = "playSoundDesc",
-    syntax = L("[player Name] [string Sound]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "sound", type = "string" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local sound = arguments[2]
@@ -1028,7 +1204,13 @@ lia.command.add("forcefallover", {
     adminOnly = true,
     privilege = "forceFallover",
     desc = "forceFalloverDesc",
-    syntax = L("[player Name] [number Time optional]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "time", type = "string", optional = true },
+
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1072,7 +1254,11 @@ lia.command.add("forcegetup", {
     adminOnly = true,
     privilege = "forceGetUp",
     desc = "forceGetUpDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1101,7 +1287,11 @@ lia.command.add("forcegetup", {
 lia.command.add("chardesc", {
     adminOnly = false,
     desc = "changeCharDesc",
-    syntax = L("[string Desc optional]"),
+    arguments = {
+
+        { name = "desc", type = "string", optional = true },
+
+    },
     onRun = function(client, arguments)
         local desc = table.concat(arguments, " ")
         if not desc:find("%S") then return client:requestString(L("chgName"), L("chgNameDesc"), function(text) lia.command.run(client, "chardesc", {text}) end, client:getChar() and client:getChar():getDesc() or "") end
@@ -1137,7 +1327,11 @@ lia.command.add("chargetup", {
 lia.command.add("fallover", {
     adminOnly = false,
     desc = "fallOverDesc",
-    syntax = L("[number Time optional]"),
+    arguments = {
+
+        { name = "time", type = "string", optional = true },
+
+    },
     onRun = function(client, arguments)
         if client:getNetVar("FallOverCooldown", false) then
             client:notifyLocalized("cmdCooldown")
@@ -1198,7 +1392,11 @@ lia.command.add("checkinventory", {
     adminOnly = true,
     privilege = "checkInventories",
     desc = "checkInventoryDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     AdminStick = {
         Name = "adminStickCheckInventoryName",
         Category = "characterManagement",
@@ -1232,7 +1430,13 @@ lia.command.add("flaggive", {
     adminOnly = true,
     privilege = "manageFlags",
     desc = "flagGiveDesc",
-    syntax = L("[player Name] [string Flags]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "flags", type = "string" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1266,7 +1470,11 @@ lia.command.add("flaggiveall", {
     adminOnly = true,
     privilege = "manageFlags",
     desc = "giveAllFlagsDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     AdminStick = {
         Name = "adminStickGiveAllFlagsName",
         Category = "characterManagement",
@@ -1293,7 +1501,11 @@ lia.command.add("flagtakeall", {
     adminOnly = true,
     privilege = "manageFlags",
     desc = "takeAllFlagsDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     AdminStick = {
         Name = "adminStickTakeAllFlagsName",
         Category = "characterManagement",
@@ -1325,7 +1537,13 @@ lia.command.add("flagtake", {
     adminOnly = true,
     privilege = "manageFlags",
     desc = "flagTakeDesc",
-    syntax = L("[player Name] [string Flags]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "flags", type = "string" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1350,7 +1568,13 @@ lia.command.add("pflaggive", {
     adminOnly = true,
     privilege = "manageFlags",
     desc = "playerFlagGiveDesc",
-    syntax = L("[player Name] [string Flags]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "flags", type = "string" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1384,7 +1608,11 @@ lia.command.add("pflaggiveall", {
     adminOnly = true,
     privilege = "manageFlags",
     desc = "giveAllFlagsDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1405,7 +1633,11 @@ lia.command.add("pflagtakeall", {
     adminOnly = true,
     privilege = "manageFlags",
     desc = "takeAllFlagsDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1426,7 +1658,13 @@ lia.command.add("pflagtake", {
     adminOnly = true,
     privilege = "manageFlags",
     desc = "playerFlagTakeDesc",
-    syntax = L("[player Name] [string Flags]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "flags", type = "string" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1462,7 +1700,11 @@ lia.command.add("charvoicetoggle", {
     adminOnly = true,
     privilege = "toggleVoiceBanCharacter",
     desc = "charVoiceToggleDesc",
-    syntax = L("[string Name]"),
+    arguments = {
+
+        { name = "name", type = "string" },
+
+    },
     AdminStick = {
         Name = "toggleVoice",
         Category = "moderationTools",
@@ -1552,7 +1794,11 @@ lia.command.add("charunban", {
     superAdminOnly = true,
     privilege = "manageCharacters",
     desc = "charUnbanDesc",
-    syntax = L("[string Name or Number ID]"),
+    arguments = {
+
+        { name = "nameOrNumberId", type = "string" },
+
+    },
     onRun = function(client, arguments)
         if (client.liaNextSearch or 0) >= CurTime() then return L("searchingChar") end
         local queryArg = table.concat(arguments, " ")
@@ -1612,7 +1858,11 @@ lia.command.add("clearinv", {
     superAdminOnly = true,
     privilege = "manageCharacters",
     desc = "clearInvDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     AdminStick = {
         Name = "adminStickClearInventoryName",
         Category = "characterManagement",
@@ -1635,7 +1885,11 @@ lia.command.add("charkick", {
     adminOnly = true,
     privilege = "kickCharacters",
     desc = "kickCharDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     AdminStick = {
         Name = "adminStickKickCharacterName",
         Category = "characterManagement",
@@ -1667,7 +1921,11 @@ lia.command.add("freezeallprops", {
     superAdminOnly = true,
     privilege = "manageCharacters",
     desc = "freezeAllPropsDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1695,7 +1953,11 @@ lia.command.add("charban", {
     superAdminOnly = true,
     privilege = "manageCharacters",
     desc = "banCharDesc",
-    syntax = L("[string Name or Number ID]"),
+    arguments = {
+
+        { name = "nameOrNumberId", type = "string" },
+
+    },
     AdminStick = {
         Name = "banCharacter",
         Category = "characterManagement",
@@ -1745,7 +2007,11 @@ lia.command.add("checkmoney", {
     adminOnly = true,
     privilege = "getCharacterInfo",
     desc = "checkMoneyDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     AdminStick = {
         Name = "adminStickCheckMoneyName",
         Category = "characterManagement",
@@ -1768,7 +2034,11 @@ lia.command.add("listbodygroups", {
     adminOnly = true,
     privilege = "getCharacterInfo",
     desc = "listBodygroupsDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1812,7 +2082,13 @@ lia.command.add("charsetspeed", {
     adminOnly = true,
     privilege = "manageCharacterStats",
     desc = "setSpeedDesc",
-    syntax = L("[player Name] [number Speed optional]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "speed", type = "string", optional = true },
+
+    },
     AdminStick = {
         Name = "adminStickSetCharSpeedName",
         Category = "characterManagement",
@@ -1835,7 +2111,13 @@ lia.command.add("charsetmodel", {
     adminOnly = true,
     privilege = "manageCharacterInformation",
     desc = "setModelDesc",
-    syntax = L("[player Name] [string Model optional]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "model", type = "string", optional = true },
+
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1855,7 +2137,13 @@ lia.command.add("chargiveitem", {
     superAdminOnly = true,
     privilege = "manageItems",
     desc = "giveItemDesc",
-    syntax = L("[player Name] [item Item Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "itemName", type = "string" },
+
+    },
     AdminStick = {
         Name = "adminStickGiveItemName",
         Category = "characterManagement",
@@ -1904,7 +2192,13 @@ lia.command.add("charsetdesc", {
     adminOnly = true,
     privilege = "manageCharacterInformation",
     desc = "setDescDesc",
-    syntax = L("[player Name] [string Description optional]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "description", type = "string", optional = true },
+
+    },
     AdminStick = {
         Name = "adminStickSetCharDescName",
         Category = "characterManagement",
@@ -1934,7 +2228,13 @@ lia.command.add("charsetname", {
     adminOnly = true,
     privilege = "manageCharacterInformation",
     desc = "setNameDesc",
-    syntax = L("[player Name] [string New Name optional]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "newName", type = "string", optional = true },
+
+    },
     AdminStick = {
         Name = "adminStickSetCharNameName",
         Category = "characterManagement",
@@ -1959,7 +2259,13 @@ lia.command.add("charsetscale", {
     adminOnly = true,
     privilege = "manageCharacterStats",
     desc = "setScaleDesc",
-    syntax = L("[player Name] [number Scale optional]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "scale", type = "string", optional = true },
+
+    },
     AdminStick = {
         Name = "adminStickSetCharScaleName",
         Category = "characterManagement",
@@ -1983,7 +2289,13 @@ lia.command.add("charsetjump", {
     adminOnly = true,
     privilege = "manageCharacterStats",
     desc = "setJumpDesc",
-    syntax = L("[player Name] [number Power optional]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "power", type = "string", optional = true },
+
+    },
     AdminStick = {
         Name = "adminStickSetCharJumpName",
         Category = "characterManagement",
@@ -2007,7 +2319,15 @@ lia.command.add("charsetbodygroup", {
     adminOnly = true,
     privilege = "manageBodygroups",
     desc = "setBodygroupDesc",
-    syntax = L("[player Name] [string BodyGroup Name] [number Value]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "bodygroupName", type = "string" },
+
+        { name = "value", type = "string" },
+
+    },
     onRun = function(client, arguments)
         local name = arguments[1]
         local bodyGroup = arguments[2]
@@ -2036,7 +2356,13 @@ lia.command.add("charsetskin", {
     adminOnly = true,
     privilege = "manageCharacterStats",
     desc = "setSkinDesc",
-    syntax = L("[player Name] [number Skin]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "skin", type = "string" },
+
+    },
     AdminStick = {
         Name = "adminStickSetCharSkinName",
         Category = "characterManagement",
@@ -2062,7 +2388,13 @@ lia.command.add("charsetmoney", {
     superAdminOnly = true,
     privilege = "manageCharacters",
     desc = "setMoneyDesc",
-    syntax = L("[player Name] [number Amount]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "amount", type = "string" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local amount = tonumber(arguments[2])
@@ -2086,7 +2418,13 @@ lia.command.add("charaddmoney", {
     superAdminOnly = true,
     privilege = "manageCharacters",
     desc = "addMoneyDesc",
-    syntax = L("[player Name] [number Amount]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "amount", type = "string" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local amount = tonumber(arguments[2])
@@ -2113,7 +2451,11 @@ lia.command.add("globalbotsay", {
     superAdminOnly = true,
     privilege = "botSay",
     desc = "globalBotSayDesc",
-    syntax = L("[string Message]"),
+    arguments = {
+
+        { name = "message", type = "string" },
+
+    },
     onRun = function(client, arguments)
         local message = table.concat(arguments, " ")
         if message == "" then
@@ -2131,7 +2473,13 @@ lia.command.add("botsay", {
     superAdminOnly = true,
     privilege = "botSay",
     desc = "botSayDesc",
-    syntax = L("[string Bot Name] [string Message]"),
+    arguments = {
+
+        { name = "botName", type = "string" },
+
+        { name = "message", type = "string" },
+
+    },
     onRun = function(client, arguments)
         if #arguments < 2 then
             client:notifyLocalized("needBotAndMessage")
@@ -2161,7 +2509,13 @@ lia.command.add("forcesay", {
     superAdminOnly = true,
     privilege = "forceSay",
     desc = "forceSayDesc",
-    syntax = L("[player Name] [string Message]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "message", type = "string" },
+
+    },
     AdminStick = {
         Name = "adminStickForceSayName",
         Category = "moderationTools",
@@ -2202,7 +2556,13 @@ lia.command.add("getmodel", {
 
 lia.command.add("pm", {
     desc = "pmDesc",
-    syntax = L("[player Name] [string Message]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "message", type = "string" },
+
+    },
     onRun = function(client, arguments)
         if not lia.config.get("AllowPMs") then
             client:notifyLocalized("pmsDisabled")
@@ -2230,7 +2590,11 @@ lia.command.add("chargetmodel", {
     adminOnly = true,
     privilege = "getCharacterInfo",
     desc = "getCharModelDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     AdminStick = {
         Name = "adminStickGetCharModelName",
         Category = "characterManagement",
@@ -2264,7 +2628,11 @@ lia.command.add("checkflags", {
     adminOnly = true,
     privilege = "getCharacterInfo",
     desc = "checkFlagsDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     AdminStick = {
         Name = "adminStickGetCharFlagsName",
         Category = "characterManagement",
@@ -2291,7 +2659,11 @@ lia.command.add("chargetname", {
     adminOnly = true,
     privilege = "getCharacterInfo",
     desc = "getCharNameDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     AdminStick = {
         Name = "adminStickGetCharNameName",
         Category = "characterManagement",
@@ -2313,7 +2685,11 @@ lia.command.add("chargethealth", {
     adminOnly = true,
     privilege = "getCharacterInfo",
     desc = "getHealthDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     AdminStick = {
         Name = "adminStickGetCharHealthName",
         Category = "characterManagement",
@@ -2335,7 +2711,11 @@ lia.command.add("chargetmoney", {
     adminOnly = true,
     privilege = "getCharacterInfo",
     desc = "getMoneyDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     AdminStick = {
         Name = "adminStickGetCharMoneyName",
         Category = "characterManagement",
@@ -2358,7 +2738,11 @@ lia.command.add("chargetinventory", {
     adminOnly = true,
     privilege = "getCharacterInfo",
     desc = "getInventoryDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     AdminStick = {
         Name = "adminStickGetCharInventoryName",
         Category = "characterManagement",
@@ -2392,7 +2776,11 @@ lia.command.add("getallinfos", {
     adminOnly = true,
     privilege = "getCharacterInfo",
     desc = "getAllInfosDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     AdminStick = {
         Name = "adminStickGetAllInfosName",
         Category = "characterManagement",
@@ -2436,7 +2824,11 @@ lia.command.add("dropmoney", {
     adminOnly = true,
     privilege = "manageCharacters",
     desc = "dropMoneyDesc",
-    syntax = L("[number Amount]"),
+    arguments = {
+
+        { name = "amount", type = "string" },
+
+    },
     onRun = function(client, arguments)
         local amount = tonumber(arguments[1])
         if not amount or amount <= 0 then

--- a/gamemode/modules/administration/submodules/tickets/commands.lua
+++ b/gamemode/modules/administration/submodules/tickets/commands.lua
@@ -4,7 +4,11 @@ lia.command.add("viewtickets", {
     adminOnly = true,
     privilege = "viewClaims",
     desc = "viewTicketsDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local targetName = arguments[1]
         if not targetName then
@@ -51,7 +55,11 @@ lia.command.add("plyviewclaims", {
     adminOnly = true,
     privilege = "viewClaims",
     desc = "plyViewClaimsDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     AdminStick = {
         Name = "viewTicketClaims",
         Category = "moderationTools",

--- a/gamemode/modules/administration/submodules/warns/commands.lua
+++ b/gamemode/modules/administration/submodules/warns/commands.lua
@@ -3,7 +3,13 @@ lia.command.add("warn", {
     adminOnly = true,
     privilege = "issueWarnings",
     desc = "warnDesc",
-    syntax = L("[player Target] [string Reason]"),
+    arguments = {
+
+        { name = "target", type = "player" },
+
+        { name = "reason", type = "string" },
+
+    },
     AdminStick = {
         Name = "warnPlayer",
         Category = "moderationTools",
@@ -41,7 +47,11 @@ lia.command.add("viewwarns", {
     adminOnly = true,
     privilege = "viewPlayerWarnings",
     desc = "viewWarnsDesc",
-    syntax = L("[player Target]"),
+    arguments = {
+
+        { name = "target", type = "player" },
+
+    },
     AdminStick = {
         Name = "viewPlayerWarnings",
         Category = "moderationTools",

--- a/gamemode/modules/attributes/commands.lua
+++ b/gamemode/modules/attributes/commands.lua
@@ -1,7 +1,15 @@
 ﻿lia.command.add("charsetattrib", {
     superAdminOnly = true,
     desc = "setAttributes",
-    syntax = L("[player Name] [string Attribute Name] [number Level]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "attributeName", type = "string" },
+
+        { name = "level", type = "string" },
+
+    },
     privilege = "manageAttributes",
     AdminStick = {
         Name = "setAttributes",
@@ -36,7 +44,11 @@
 lia.command.add("checkattributes", {
     adminOnly = true,
     desc = "checkAttributes",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     privilege = "manageAttributes",
     AdminStick = {
         Name = "checkAttributes",
@@ -98,7 +110,15 @@ lia.command.add("checkattributes", {
 lia.command.add("charaddattrib", {
     superAdminOnly = true,
     desc = "addAttributes",
-    syntax = L("[player Name] [string Attribute Name] [number Level]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "attributeName", type = "string" },
+
+        { name = "level", type = "string" },
+
+    },
     privilege = "manageAttributes",
     AdminStick = {
         Name = "addAttributes",

--- a/gamemode/modules/chatbox/commands.lua
+++ b/gamemode/modules/chatbox/commands.lua
@@ -2,7 +2,11 @@
     adminOnly = true,
     privilege = "banOOC",
     desc = "banOOCCommandDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     AdminStick = {
         Name = "banOOCStickName",
         Category = "moderationTools",
@@ -26,7 +30,11 @@ lia.command.add("unbanooc", {
     adminOnly = true,
     privilege = "unbanOOC",
     desc = "unbanOOCCommandDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     AdminStick = {
         Name = "unbanOOCStickName",
         Category = "moderationTools",

--- a/gamemode/modules/chatbox/libraries/shared.lua
+++ b/gamemode/modules/chatbox/libraries/shared.lua
@@ -1,5 +1,9 @@
 ﻿lia.chat.register("meclose", {
-    syntax = L("[string Action]"),
+    arguments = {
+
+        { name = "action", type = "string" },
+
+    },
     desc = "mecloseDesc",
     format = "emoteFormat",
     onCanHear = lia.config.get("ChatRange", 280) * 0.25,
@@ -10,7 +14,11 @@
 })
 
 lia.chat.register("actions", {
-    syntax = L("[string Action]"),
+    arguments = {
+
+        { name = "action", type = "string" },
+
+    },
     desc = "actionsDesc",
     format = "emoteFormat",
     color = Color(255, 150, 0),
@@ -19,7 +27,11 @@ lia.chat.register("actions", {
 })
 
 lia.chat.register("mefar", {
-    syntax = L("[string Action]"),
+    arguments = {
+
+        { name = "action", type = "string" },
+
+    },
     desc = "mefarDesc",
     format = "emoteFormat",
     onCanHear = lia.config.get("ChatRange", 280) * 2,
@@ -30,7 +42,11 @@ lia.chat.register("mefar", {
 })
 
 lia.chat.register("itclose", {
-    syntax = L("[string Text]"),
+    arguments = {
+
+        { name = "text", type = "string" },
+
+    },
     desc = "itcloseDesc",
     onChatAdd = function(_, text) chat.AddText(lia.config.get("ChatColor"), "**" .. text) end,
     onCanHear = lia.config.get("ChatRange", 280) * 0.25,
@@ -41,7 +57,11 @@ lia.chat.register("itclose", {
 })
 
 lia.chat.register("itfar", {
-    syntax = L("[string Text]"),
+    arguments = {
+
+        { name = "text", type = "string" },
+
+    },
     desc = "itfarDesc",
     onChatAdd = function(_, text) chat.AddText(lia.config.get("ChatColor"), "**" .. text) end,
     onCanHear = lia.config.get("ChatRange", 280) * 2,
@@ -63,7 +83,11 @@ lia.chat.register("coinflip", {
 })
 
 lia.chat.register("ic", {
-    syntax = L("[string Text]"),
+    arguments = {
+
+        { name = "text", type = "string" },
+
+    },
     desc = "icDesc",
     format = "icFormat",
     onGetColor = function(speaker)
@@ -79,7 +103,11 @@ lia.chat.register("ic", {
 })
 
 lia.chat.register("me", {
-    syntax = L("[string Action]"),
+    arguments = {
+
+        { name = "action", type = "string" },
+
+    },
     desc = "meDesc",
     format = "emoteFormat",
     onGetColor = lia.chat.classes.ic.onGetColor,
@@ -95,7 +123,11 @@ lia.chat.register("me", {
 })
 
 lia.chat.register("globalme", {
-    syntax = L("[string Action]"),
+    arguments = {
+
+        { name = "action", type = "string" },
+
+    },
     desc = "globalMeDesc",
     format = "emoteFormat",
     onGetColor = lia.chat.classes.ic.onGetColor,
@@ -107,7 +139,11 @@ lia.chat.register("globalme", {
 })
 
 lia.chat.register("it", {
-    syntax = L("[string Text]"),
+    arguments = {
+
+        { name = "text", type = "string" },
+
+    },
     desc = "itDesc",
     onChatAdd = function(_, text) chat.AddText(lia.chat.timestamp(false), lia.config.get("ChatColor"), "**" .. text) end,
     onCanHear = function(speaker, listener)
@@ -122,7 +158,11 @@ lia.chat.register("it", {
 })
 
 lia.chat.register("w", {
-    syntax = L("[string Text]"),
+    arguments = {
+
+        { name = "text", type = "string" },
+
+    },
     desc = "wDesc",
     format = "whisperFormat",
     onGetColor = function(speaker)
@@ -138,7 +178,11 @@ lia.chat.register("w", {
 })
 
 lia.chat.register("y", {
-    syntax = L("[string Text]"),
+    arguments = {
+
+        { name = "text", type = "string" },
+
+    },
     desc = "yDesc",
     format = "yellFormat",
     onGetColor = function(speaker)
@@ -154,7 +198,11 @@ lia.chat.register("y", {
 })
 
 lia.chat.register("looc", {
-    syntax = L("[string Text]"),
+    arguments = {
+
+        { name = "text", type = "string" },
+
+    },
     desc = "loocDesc",
     onCanSay = function(speaker)
         local delay = lia.config.get("LOOCDelay", false)
@@ -180,7 +228,11 @@ lia.chat.register("looc", {
 })
 
 lia.chat.register("adminchat", {
-    syntax = L("[string Text]"),
+    arguments = {
+
+        { name = "text", type = "string" },
+
+    },
     desc = "adminchatDesc",
     onGetColor = function() return Color(0, 196, 255) end,
     onCanHear = function(_, listener) return listener:hasPrivilege(L("adminChat")) end,
@@ -210,7 +262,13 @@ lia.chat.register("roll", {
 })
 
 lia.chat.register("pm", {
-    syntax = L("[player Name] [string Message]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "message", type = "string" },
+
+    },
     desc = "pmDesc",
     format = "pmFormat",
     color = Color(249, 211, 89),
@@ -219,7 +277,11 @@ lia.chat.register("pm", {
 })
 
 lia.chat.register("eventlocal", {
-    syntax = L("[string Text]"),
+    arguments = {
+
+        { name = "text", type = "string" },
+
+    },
     desc = "eventlocalDesc",
     onCanSay = function(speaker) return speaker:hasPrivilege(L("localEventChat")) end,
     onCanHear = function(speaker, listener)
@@ -233,7 +295,11 @@ lia.chat.register("eventlocal", {
 })
 
 lia.chat.register("event", {
-    syntax = L("[string Text]"),
+    arguments = {
+
+        { name = "text", type = "string" },
+
+    },
     desc = "eventDesc",
     onCanSay = function(speaker) return speaker:hasPrivilege(L("eventChat")) end,
     onCanHear = function() return true end,
@@ -243,7 +309,11 @@ lia.chat.register("event", {
 })
 
 lia.chat.register("ooc", {
-    syntax = L("[string Text]"),
+    arguments = {
+
+        { name = "text", type = "string" },
+
+    },
     desc = "oocDesc",
     onCanSay = function(speaker, text)
         if GetGlobalBool("oocblocked", false) then
@@ -281,7 +351,11 @@ lia.chat.register("ooc", {
 })
 
 lia.chat.register("me's", {
-    syntax = L("[string Action]"),
+    arguments = {
+
+        { name = "action", type = "string" },
+
+    },
     desc = "mesDesc",
     format = "mePossessiveFormat",
     onCanHear = lia.config.get("ChatRange", 280),
@@ -305,7 +379,11 @@ lia.chat.register("me's", {
 })
 
 lia.chat.register("mefarfar", {
-    syntax = L("[string Action]"),
+    arguments = {
+
+        { name = "action", type = "string" },
+
+    },
     desc = "mefarfarDesc",
     format = "emoteFormat",
     onChatAdd = function(speaker, text, anonymous)
@@ -329,7 +407,11 @@ lia.chat.register("mefarfar", {
 })
 
 lia.chat.register("help", {
-    syntax = L("[string Text]"),
+    arguments = {
+
+        { name = "text", type = "string" },
+
+    },
     desc = "helpDesc",
     onCanSay = function() return true end,
     onCanHear = function(speaker, listener)

--- a/gamemode/modules/doors/commands.lua
+++ b/gamemode/modules/doors/commands.lua
@@ -254,7 +254,11 @@ lia.command.add("doortogglehidden", {
 
 lia.command.add("doorsetprice", {
     desc = "doorsetpriceDesc",
-    syntax = L("[number Price]"),
+    arguments = {
+
+        { name = "price", type = "string" },
+
+    },
     adminOnly = true,
     privilege = "manageDoors",
     AdminStick = {
@@ -281,7 +285,11 @@ lia.command.add("doorsetprice", {
 
 lia.command.add("doorsettitle", {
     desc = "doorsettitleDesc",
-    syntax = L("[string Title]"),
+    arguments = {
+
+        { name = "title", type = "string" },
+
+    },
     adminOnly = true,
     privilege = "manageDoors",
     AdminStick = {
@@ -416,7 +424,11 @@ lia.command.add("doorinfo", {
 
 lia.command.add("dooraddfaction", {
     desc = "dooraddfactionDesc",
-    syntax = L("[faction Faction]"),
+    arguments = {
+
+        { name = "faction", type = "string" },
+
+    },
     adminOnly = true,
     privilege = "manageDoors",
     onRun = function(client, arguments)
@@ -456,7 +468,11 @@ lia.command.add("dooraddfaction", {
 
 lia.command.add("doorremovefaction", {
     desc = "doorremovefactionDesc",
-    syntax = L("[faction Faction]"),
+    arguments = {
+
+        { name = "faction", type = "string" },
+
+    },
     adminOnly = true,
     privilege = "manageDoors",
     onRun = function(client, arguments)
@@ -496,7 +512,11 @@ lia.command.add("doorremovefaction", {
 
 lia.command.add("doorsetclass", {
     desc = "doorsetclassDesc",
-    syntax = L("[class Class]"),
+    arguments = {
+
+        { name = "class", type = "string" },
+
+    },
     adminOnly = true,
     privilege = "manageDoors",
     onRun = function(client, arguments)

--- a/gamemode/modules/inventory/commands.lua
+++ b/gamemode/modules/inventory/commands.lua
@@ -2,7 +2,11 @@
     adminOnly = true,
     privilege = "setInventorySize",
     desc = "updateInventorySizeDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -42,7 +46,15 @@ lia.command.add("setinventorysize", {
     adminOnly = true,
     privilege = "setInventorySize",
     desc = "setInventorySizeDesc",
-    syntax = L("[player Name] [number Width] [number Height]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "width", type = "string" },
+
+        { name = "height", type = "string" },
+
+    },
     onRun = function(client, args)
         local target = lia.util.findPlayer(client, args[1])
         if not target or not IsValid(target) then

--- a/gamemode/modules/inventory/submodules/storage/commands.lua
+++ b/gamemode/modules/inventory/submodules/storage/commands.lua
@@ -3,7 +3,11 @@ lia.command.add("storagelock", {
     privilege = "lockStorage",
     adminOnly = true,
     desc = "storagelockDesc",
-    syntax = L("[string Password optional]"),
+    arguments = {
+
+        { name = "password", type = "string", optional = true },
+
+    },
     onRun = function(client, arguments)
         local entity = client:getTracedEntity()
         if entity and IsValid(entity) then

--- a/gamemode/modules/inventory/submodules/vendor/commands.lua
+++ b/gamemode/modules/inventory/submodules/vendor/commands.lua
@@ -50,7 +50,11 @@ lia.command.add("resetallvendormoney", {
     privilege = "manageVendors",
     superAdminOnly = true,
     desc = "resetAllVendorMoneyDesc",
-    syntax = L("[number Amount]"),
+    arguments = {
+
+        { name = "amount", type = "string" },
+
+    },
     AdminStick = {
         Name = "resetAllVendorMoneyStickName",
         TargetClass = "lia_vendor"
@@ -76,7 +80,11 @@ lia.command.add("restockvendormoney", {
     privilege = "manageVendors",
     superAdminOnly = true,
     desc = "restockVendorMoneyDesc",
-    syntax = L("[number Amount]"),
+    arguments = {
+
+        { name = "amount", type = "string" },
+
+    },
     AdminStick = {
         Name = "restockVendorMoneyStickName",
         TargetClass = "lia_vendor"

--- a/gamemode/modules/protection/commands.lua
+++ b/gamemode/modules/protection/commands.lua
@@ -2,7 +2,11 @@
     adminOnly = true,
     privilege = "toggleCheaterStatus",
     desc = "toggleCheaterDesc",
-    syntax = L("[player Target]"),
+    arguments = {
+
+        { name = "target", type = "player" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then

--- a/gamemode/modules/recognition/commands.lua
+++ b/gamemode/modules/recognition/commands.lua
@@ -8,7 +8,11 @@ end
 lia.command.add("recogwhisper", {
     privilege = "manageRecognition",
     adminOnly = true,
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     desc = "recogWhisperDesc",
     AdminStick = {
         Name = "recogWhisperStickName",
@@ -22,7 +26,11 @@ lia.command.add("recogwhisper", {
 lia.command.add("recognormal", {
     privilege = "manageRecognition",
     adminOnly = true,
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     desc = "recogNormalDesc",
     AdminStick = {
         Name = "recogNormalStickName",
@@ -36,7 +44,11 @@ lia.command.add("recognormal", {
 lia.command.add("recogyell", {
     privilege = "manageRecognition",
     adminOnly = true,
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     desc = "recogYellDesc",
     AdminStick = {
         Name = "recogYellStickName",
@@ -50,7 +62,13 @@ lia.command.add("recogyell", {
 lia.command.add("recogbots", {
     privilege = "manageRecognition",
     superAdminOnly = true,
-    syntax = L("[string Range optional] [string Name optional]"),
+    arguments = {
+
+        { name = "range", type = "string", optional = true },
+
+        { name = "name", type = "string", optional = true },
+
+    },
     desc = "recogBotsDesc",
     AdminStick = {
         Name = "recogBotsStickName",

--- a/gamemode/modules/spawns/commands.lua
+++ b/gamemode/modules/spawns/commands.lua
@@ -3,7 +3,11 @@ lia.command.add("spawnadd", {
     privilege = "manageSpawns",
     adminOnly = true,
     desc = "spawnAddDesc",
-    syntax = L("[faction Faction]"),
+    arguments = {
+
+        { name = "faction", type = "string" },
+
+    },
     onRun = function(client, arguments)
         local factionName = arguments[1]
         if not factionName then return L("invalidArg") end
@@ -40,7 +44,11 @@ lia.command.add("spawnremoveinradius", {
     privilege = "manageSpawns",
     adminOnly = true,
     desc = "spawnRemoveInRadiusDesc",
-    syntax = L("[number Radius optional]"),
+    arguments = {
+
+        { name = "radius", type = "string", optional = true },
+
+    },
     onRun = function(client, arguments)
         local position = client:GetPos()
         local radius = tonumber(arguments[1]) or 120
@@ -73,7 +81,11 @@ lia.command.add("spawnremovebyname", {
     privilege = "manageSpawns",
     adminOnly = true,
     desc = "spawnRemoveByNameDesc",
-    syntax = L("[faction Faction]"),
+    arguments = {
+
+        { name = "faction", type = "string" },
+
+    },
     onRun = function(client, arguments)
         local factionName = arguments[1]
         local factionInfo = lia.faction.indices[factionName:lower()]
@@ -121,7 +133,11 @@ lia.command.add("returnitems", {
     superAdminOnly = true,
     privilege = "returnItems",
     desc = "returnItemsDesc",
-    syntax = L("[player Name]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+    },
     AdminStick = {
         Name = "returnItems",
         Category = "characterManagement",

--- a/gamemode/modules/teams/commands.lua
+++ b/gamemode/modules/teams/commands.lua
@@ -172,7 +172,13 @@ lia.command.add("classunwhitelist", {
     adminOnly = true,
     privilege = "manageClasses",
     desc = "classUnwhitelistDesc",
-    syntax = L("[player Name] [class Class]"),
+    arguments = {
+
+        { name = "name", type = "player" },
+
+        { name = "class", type = "string" },
+
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local classID = lia.class.retrieveClass(table.concat(arguments, " ", 2))


### PR DESCRIPTION
## Summary
- remove `syntax` field and always register commands via structured `arguments`
- convert chat registration and existing command files to use `arguments`
- update documentation for command and chat APIs

## Testing
- `luacheck .` *(fails: 14346 warnings / 18 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68940832d6a48327a08754c7b13a4b0a