### PR TITLE
Add structured arguments for faction, attribute, and class commands

### DIFF
--- a/gamemode/modules/attributes/commands.lua
+++ b/gamemode/modules/attributes/commands.lua
@@ -1,14 +1,20 @@
-﻿lia.command.add("charsetattrib", {
+lia.command.add("charsetattrib", {
     superAdminOnly = true,
     desc = "setAttributes",
     arguments = {
-
-        { name = "name", type = "player" },
-
-        { name = "attributeName", type = "string" },
-
-        { name = "level", type = "string" },
-
+        {name = "name", type = "player"},
+        {
+            name = "attribute",
+            type = "table",
+            options = function()
+                local options = {}
+                for k, v in pairs(lia.attribs.list) do
+                    options[L(v.name)] = k
+                end
+                return options
+            end
+        },
+        {name = "level", type = "number"}
     },
     privilege = "manageAttributes",
     AdminStick = {
@@ -111,13 +117,19 @@ lia.command.add("charaddattrib", {
     superAdminOnly = true,
     desc = "addAttributes",
     arguments = {
-
-        { name = "name", type = "player" },
-
-        { name = "attributeName", type = "string" },
-
-        { name = "level", type = "string" },
-
+        {name = "name", type = "player"},
+        {
+            name = "attribute",
+            type = "table",
+            options = function()
+                local options = {}
+                for k, v in pairs(lia.attribs.list) do
+                    options[L(v.name)] = k
+                end
+                return options
+            end
+        },
+        {name = "level", type = "number"}
     },
     privilege = "manageAttributes",
     AdminStick = {

--- a/gamemode/modules/doors/commands.lua
+++ b/gamemode/modules/doors/commands.lua
@@ -1,4 +1,4 @@
-﻿local MODULE = MODULE
+local MODULE = MODULE
 lia.command.add("doorsell", {
     desc = "doorsellDesc",
     adminOnly = false,
@@ -425,18 +425,26 @@ lia.command.add("doorinfo", {
 lia.command.add("dooraddfaction", {
     desc = "dooraddfactionDesc",
     arguments = {
-
-        { name = "faction", type = "string" },
-
+        {
+            name = "faction",
+            type = "table",
+            options = function()
+                local options = {}
+                for k, v in pairs(lia.faction.teams) do
+                    options[L(v.name)] = k
+                end
+                return options
+            end
+        }
     },
     adminOnly = true,
     privilege = "manageDoors",
     onRun = function(client, arguments)
         local door = client:getTracedEntity()
         if IsValid(door) and door:isDoor() and not door:getNetVar("disabled", false) then
+            local name = arguments[1]
             local faction
-            if arguments[1] then
-                local name = table.concat(arguments, " ")
+            if name then
                 for k, v in pairs(lia.faction.teams) do
                     if lia.util.stringMatches(k, name) or lia.util.stringMatches(v.name, name) then
                         faction = v
@@ -469,18 +477,26 @@ lia.command.add("dooraddfaction", {
 lia.command.add("doorremovefaction", {
     desc = "doorremovefactionDesc",
     arguments = {
-
-        { name = "faction", type = "string" },
-
+        {
+            name = "faction",
+            type = "table",
+            options = function()
+                local options = {}
+                for k, v in pairs(lia.faction.teams) do
+                    options[L(v.name)] = k
+                end
+                return options
+            end
+        }
     },
     adminOnly = true,
     privilege = "manageDoors",
     onRun = function(client, arguments)
         local door = client:getTracedEntity()
         if IsValid(door) and door:isDoor() and not door:getNetVar("disabled", false) then
+            local name = arguments[1]
             local faction
-            if arguments[1] then
-                local name = table.concat(arguments, " ")
+            if name then
                 for k, v in pairs(lia.faction.teams) do
                     if lia.util.stringMatches(k, name) or lia.util.stringMatches(v.name, name) then
                         faction = v
@@ -513,18 +529,26 @@ lia.command.add("doorremovefaction", {
 lia.command.add("doorsetclass", {
     desc = "doorsetclassDesc",
     arguments = {
-
-        { name = "class", type = "string" },
-
+        {
+            name = "class",
+            type = "table",
+            options = function()
+                local options = {}
+                for _, v in pairs(lia.class.list) do
+                    options[L(v.name)] = v.uniqueID
+                end
+                return options
+            end
+        }
     },
     adminOnly = true,
     privilege = "manageDoors",
     onRun = function(client, arguments)
         local door = client:getTracedEntity()
         if IsValid(door) and door:isDoor() and not door:getNetVar("disabled", false) then
+            local input = arguments[1]
             local class, classData
-            if arguments[1] then
-                local input = table.concat(arguments, " ")
+            if input then
                 local id = tonumber(input) or lia.class.retrieveClass(input)
                 if id then
                     class, classData = id, lia.class.list[id]
@@ -587,3 +611,4 @@ lia.command.add("togglealldoors", {
         MODULE:SaveData()
     end
 })
+

--- a/gamemode/modules/teams/commands.lua
+++ b/gamemode/modules/teams/commands.lua
@@ -1,8 +1,22 @@
-﻿lia.command.add("plytransfer", {
+lia.command.add("plytransfer", {
     adminOnly = true,
     privilege = "manageTransfers",
     desc = "plyTransferDesc",
     alias = {"charsetfaction"},
+    arguments = {
+        {name = "name", type = "player"},
+        {
+            name = "faction",
+            type = "table",
+            options = function()
+                local options = {}
+                for k, v in pairs(lia.faction.teams) do
+                    options[L(v.name)] = k
+                end
+                return options
+            end
+        }
+    },
     onRun = function(client, arguments)
         local targetPlayer = lia.util.findPlayer(client, arguments[1])
         if not targetPlayer or not IsValid(targetPlayer) then
@@ -10,7 +24,7 @@
             return
         end
 
-        local factionName = table.concat(arguments, " ", 2)
+        local factionName = arguments[2]
         local faction = lia.faction.teams[factionName] or lia.util.findFaction(client, factionName)
         if not faction then
             client:notifyLocalized("invalidFaction")
@@ -30,7 +44,13 @@
         if faction.OnTransferred then faction:OnTransferred(targetPlayer, oldFaction) end
         hook.Run("PlayerLoadout", targetPlayer)
         client:notifyLocalized("transferSuccess", targetPlayer:Name(), L(faction.name, client))
-        if client ~= targetPlayer then targetPlayer:notifyLocalized("transferNotification", L(faction.name, targetPlayer), client:Name()) end
+        if client ~= targetPlayer then
+            targetPlayer:notifyLocalized(
+                "transferNotification",
+                L(faction.name, targetPlayer),
+                client:Name()
+            )
+        end
         lia.log.add(client, "plyTransfer", targetPlayer:Name(), oldFactionName, faction.name)
     end
 })
@@ -40,6 +60,20 @@ lia.command.add("plywhitelist", {
     privilege = "manageWhitelists",
     desc = "plyWhitelistDesc",
     alias = {"factionwhitelist"},
+    arguments = {
+        {name = "name", type = "player"},
+        {
+            name = "faction",
+            type = "table",
+            options = function()
+                local options = {}
+                for k, v in pairs(lia.faction.teams) do
+                    options[L(v.name)] = k
+                end
+                return options
+            end
+        }
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -47,7 +81,7 @@ lia.command.add("plywhitelist", {
             return
         end
 
-        local faction = lia.util.findFaction(client, table.concat(arguments, " ", 2))
+        local faction = lia.util.findFaction(client, arguments[2])
         if faction and target:setWhitelisted(faction.index, true) then
             for _, v in player.Iterator() do
                 v:notifyLocalized("whitelist", client:Name(), target:Name(), L(faction.name, v))
@@ -63,6 +97,20 @@ lia.command.add("plyunwhitelist", {
     privilege = "manageWhitelists",
     desc = "plyUnwhitelistDesc",
     alias = {"factionunwhitelist"},
+    arguments = {
+        {name = "name", type = "player"},
+        {
+            name = "faction",
+            type = "table",
+            options = function()
+                local options = {}
+                for k, v in pairs(lia.faction.teams) do
+                    options[L(v.name)] = k
+                end
+                return options
+            end
+        }
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -70,7 +118,7 @@ lia.command.add("plyunwhitelist", {
             return
         end
 
-        local faction = lia.util.findFaction(client, table.concat(arguments, " ", 2))
+        local faction = lia.util.findFaction(client, arguments[2])
         if faction and not faction.isDefault and target:setWhitelisted(faction.index, false) then
             for _, v in player.Iterator() do
                 v:notifyLocalized("unwhitelist", client:Name(), target:Name(), L(faction.name, v))
@@ -86,8 +134,21 @@ lia.command.add("plyunwhitelist", {
 lia.command.add("beclass", {
     adminOnly = false,
     desc = "beClassDesc",
+    arguments = {
+        {
+            name = "class",
+            type = "table",
+            options = function()
+                local options = {}
+                for _, v in pairs(lia.class.list) do
+                    options[L(v.name)] = v.uniqueID
+                end
+                return options
+            end
+        }
+    },
     onRun = function(client, arguments)
-        local className = table.concat(arguments, " ")
+        local className = arguments[1]
         local character = client:getChar()
         if not IsValid(client) or not character then
             client:notifyLocalized("illegalAccess")
@@ -113,6 +174,20 @@ lia.command.add("setclass", {
     adminOnly = true,
     privilege = "manageClasses",
     desc = "setClassDesc",
+    arguments = {
+        {name = "name", type = "player"},
+        {
+            name = "class",
+            type = "table",
+            options = function()
+                local options = {}
+                for _, v in pairs(lia.class.list) do
+                    options[L(v.name)] = v.uniqueID
+                end
+                return options
+            end
+        }
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -120,7 +195,7 @@ lia.command.add("setclass", {
             return
         end
 
-        local className = table.concat(arguments, " ", 2)
+        local className = arguments[2]
         local classID = lia.class.retrieveClass(className)
         local classData = lia.class.list[classID]
         if classData then
@@ -143,9 +218,23 @@ lia.command.add("classwhitelist", {
     adminOnly = true,
     privilege = "manageWhitelists",
     desc = "classWhitelistDesc",
+    arguments = {
+        {name = "name", type = "player"},
+        {
+            name = "class",
+            type = "table",
+            options = function()
+                local options = {}
+                for _, v in pairs(lia.class.list) do
+                    options[L(v.name)] = v.uniqueID
+                end
+                return options
+            end
+        }
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
-        local classID = lia.class.retrieveClass(table.concat(arguments, " ", 2))
+        local classID = lia.class.retrieveClass(arguments[2])
         if not target or not IsValid(target) then
             client:notifyLocalized("targetNotFound")
             return
@@ -173,15 +262,22 @@ lia.command.add("classunwhitelist", {
     privilege = "manageClasses",
     desc = "classUnwhitelistDesc",
     arguments = {
-
-        { name = "name", type = "player" },
-
-        { name = "class", type = "string" },
-
+        {name = "name", type = "player"},
+        {
+            name = "class",
+            type = "table",
+            options = function()
+                local options = {}
+                for _, v in pairs(lia.class.list) do
+                    options[L(v.name)] = v.uniqueID
+                end
+                return options
+            end
+        }
     },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
-        local classID = lia.class.retrieveClass(table.concat(arguments, " ", 2))
+        local classID = lia.class.retrieveClass(arguments[2])
         if not target or not IsValid(target) then
             client:notifyLocalized("targetNotFound")
             return


### PR DESCRIPTION
## Summary
- require structured arguments for faction transfer and whitelist commands
- expose attribute and class names as table options for commands
- support faction/class tables in spawn and door management commands

## Testing
- `luacheck gamemode/modules/attributes/commands.lua gamemode/modules/teams/commands.lua gamemode/modules/spawns/commands.lua gamemode/modules/doors/commands.lua`

------
https://chatgpt.com/codex/tasks/task_e_68941e39ada88327b846c791646cc7ff