### PR TITLE
Align faction roster row height with addon listings

### DIFF
--- a/gamemode/core/derma/panels/roster.lua
+++ b/gamemode/core/derma/panels/roster.lua
@@ -57,6 +57,7 @@ function PANEL:Populate(data, canKick)
             row = self.sheet:AddRow(function(p, row)
                 local logoSize = 64
                 local margin = 8
+                local rowHeight = logoSize + self.sheet.padding * 2
                 -- Create logo image
                 local logo = vgui.Create("DImage", p)
                 logo:SetSize(logoSize, logoSize)
@@ -93,9 +94,8 @@ function PANEL:Populate(data, canKick)
                         r:SetPos(p:GetWide() - r:GetWide() - pad, math.max(pad, y))
                     end
 
-                    local baseMin = 300
-                    local h = d and pad + t:GetTall() + spacing + d:GetTall() + pad or math.max(baseMin, pad + t:GetTall() + pad)
-                    p:SetTall(h)
+                    local textH = pad + t:GetTall() + spacing + d:GetTall() + pad
+                    p:SetTall(math.max(rowHeight, textH))
                 end
 
                 row.filterText = (title .. " " .. desc .. " " .. right):lower()
@@ -105,7 +105,8 @@ function PANEL:Populate(data, canKick)
             row = self.sheet:AddTextRow({
                 title = title,
                 desc = desc,
-                right = right
+                right = right,
+                minHeight = self.sheet.padding * 2 + 64
             })
         end
 

--- a/gamemode/core/derma/panels/sheet.lua
+++ b/gamemode/core/derma/panels/sheet.lua
@@ -73,6 +73,7 @@ function PANEL:AddTextRow(data)
     local desc = data.desc or ""
     local right = data.right or ""
     local compact = data.compact
+    local minHeight = data.minHeight or (compact and 30 or 40)
     local row = self:AddRow(function(p, row)
         local titleFont = compact and "liaSmallFont" or "liaMediumFont"
         local descFont = compact and "liaMiniFont" or "liaSmallFont"
@@ -113,9 +114,8 @@ function PANEL:AddTextRow(data)
                 r:SetPos(p:GetWide() - r:GetWide() - pad, math.max(pad, y))
             end
 
-            local baseMin = compact and 30 or 40
-            local h = d and pad + t:GetTall() + spacing + d:GetTall() + pad or math.max(baseMin, pad + t:GetTall() + pad)
-            p:SetTall(h)
+            local textH = pad + t:GetTall() + (d and spacing + d:GetTall() or 0) + pad
+            p:SetTall(math.max(minHeight, textH))
         end
 
         row.filterText = (title .. " " .. desc .. " " .. right):lower()

--- a/gamemode/modules/administration/netcalls/client.lua
+++ b/gamemode/modules/administration/netcalls/client.lua
@@ -416,7 +416,8 @@ local function OpenRoster(panel, data)
                     row = rosterSheet:AddRow(function(p, row)
                         local logoSize = 64
                         local margin = 8
-                        
+                        local rowHeight = logoSize + rosterSheet.padding * 2
+
                         -- Create logo image
                         local logo = vgui.Create("DImage", p)
                         logo:SetSize(logoSize, logoSize)
@@ -447,21 +448,20 @@ local function OpenRoster(panel, data)
                         p.PerformLayout = function()
                             local pad = rosterSheet.padding
                             local spacing = 5
-                            
+
                             logo:SetPos(pad, pad)
                             t:SetPos(pad + logoSize + pad, pad)
                             d:SetPos(pad + logoSize + pad, pad + t:GetTall() + spacing)
                             d:SetWide(p:GetWide() - (pad + logoSize + pad) - pad - (r:GetWide() + 10))
                             d:SizeToContentsY()
-                            
+
                             if r then
                                 local y = d and pad + t:GetTall() + spacing + d:GetTall() - r:GetTall() or p:GetTall() * 0.5 - r:GetTall() * 0.5
                                 r:SetPos(p:GetWide() - r:GetWide() - pad, math.max(pad, y))
                             end
-                            
-                            local baseMin = 300
-                            local h = d and pad + t:GetTall() + spacing + d:GetTall() + pad or math.max(baseMin, pad + t:GetTall() + pad)
-                            p:SetTall(h)
+
+                            local textH = pad + t:GetTall() + spacing + d:GetTall() + pad
+                            p:SetTall(math.max(rowHeight, textH))
                         end
                         
                         row.filterText = (title .. " " .. desc .. " " .. right):lower()
@@ -471,7 +471,8 @@ local function OpenRoster(panel, data)
                     row = rosterSheet:AddTextRow({
                         title = title,
                         desc = desc,
-                        right = right
+                        right = right,
+                        minHeight = rosterSheet.padding * 2 + 64
                     })
                 end
                 


### PR DESCRIPTION
## Summary
- Add `minHeight` option to `liaSheet` text rows
- Ensure faction roster entries match addon row height
- Apply same height logic to admin faction roster

## Testing
- `luacheck .` *(fails: 14458 warnings / 17 errors)*
- `luacheck gamemode/core/derma/panels/sheet.lua gamemode/core/derma/panels/roster.lua gamemode/modules/administration/netcalls/client.lua`


------
https://chatgpt.com/codex/tasks/task_e_6895155a6be08327843cf08995bbf342