### PR TITLE
Localize config and option fields by default

### DIFF
--- a/documentation/docs/libraries/lia.config.md
+++ b/documentation/docs/libraries/lia.config.md
@@ -20,13 +20,13 @@ Registers a new config option with the given key, display name, default value, a
 
 * `key` (*string*): Unique identifier for the option.
 
-* `name` (*string*): Display name shown in menus.
+* `name` (*string*): Display name shown in menus. Localized automatically with `L`.
 
 * `value` (*any*): Default stored value.
 
 * `callback` (*function*): Function run when the value changes. *Optional*.
 
-* `data` (*table*): Table describing the option. Common fields include `desc`, `category`, `type`, `min`, `max`, `decimals`, `options`, and `noNetworking`.
+* `data` (*table*): Table describing the option. Common fields include `desc`, `category`, `type`, `min`, `max`, `decimals`, `options`, and `noNetworking`. Any string values for `desc`, `category`, or within `options` are localized automatically.
 
 **Realm**
 
@@ -42,7 +42,7 @@ Registers a new config option with the given key, display name, default value, a
 -- Register a walk-speed option with limits and a callback
 lia.config.add(
     "walkSpeed",
-    "Walk Speed",
+    "walkSpeed",
     130,
     function(_, newValue)
         for _, ply in player.Iterator() do
@@ -50,8 +50,8 @@ lia.config.add(
         end
     end,
     {
-        desc = "Base walking speed for all players.",
-        category = "Movement",
+        desc = "walkSpeedDesc",
+        category = "movement",
         type = "Int",
         min = 50,
         max = 300

--- a/documentation/docs/libraries/lia.option.md
+++ b/documentation/docs/libraries/lia.option.md
@@ -44,15 +44,15 @@ Registers a configurable option that can be networked.
 
 * `key` (*string*): Unique option key.
 
-* `name` (*string*): Display name.
+* `name` (*string*): Display name. Localized automatically with `L`.
 
-* `desc` (*string*): Brief description.
+* `desc` (*string*): Brief description. Localized automatically with `L`.
 
 * `default` (*any*): Default value.
 
 * `callback` (*function | nil*): Runs on change. Optional.
 
-* `data` (*table*): Extra option data. Set `isQuick = true` to also list this option in the quick settings panel.
+* `data` (*table*): Extra option data. Set `isQuick = true` to also list this option in the quick settings panel. String values like `category` or entries within an `options` table are localized automatically.
 
 **Realm**
 
@@ -67,13 +67,13 @@ Registers a configurable option that can be networked.
 ```lua
 lia.option.add(
     "thirdPersonEnabled",
-    "Third Person Enabled",
-    "Toggle third-person view.",
+    "thirdPersonEnabled",
+    "thirdPersonEnabledDesc",
     false,
     function(_, newValue)
         hook.Run("thirdPersonToggled", newValue)
     end,
-    { category = "Third Person" }
+    { category = "thirdPerson" }
 )
 ```
 

--- a/gamemode/core/libraries/config.lua
+++ b/gamemode/core/libraries/config.lua
@@ -39,10 +39,11 @@ lia.config.stored = lia.config.stored or {}
 
     Parameters:
         key (string)        - The unique key for the config variable.
-        name (string)       - The display name for the config variable.
+        name (string)       - The display name for the config variable (localized automatically).
         value (any)         - The default value for the config variable.
         callback (function) - (Optional) Function to call when the config value changes.
-        data (table)        - Table containing additional config properties (type, desc, category, etc).
+        data (table)        - Table containing additional config properties (type, desc, category, etc). String values such as
+                              `desc`, `category`, and entries in an `options` table are localized automatically.
 
     Returns:
         None.
@@ -70,15 +71,25 @@ function lia.config.add(key, name, value, callback, data)
     data.type = data.type or configType
     local oldConfig = lia.config.stored[key]
     local savedValue = oldConfig and oldConfig.value or value
-    local category = data.category
-    local desc = data.desc
+
+    if istable(data.options) then
+        for k, v in pairs(data.options) do
+            if isstring(v) then
+                data.options[k] = L(v)
+            end
+        end
+    end
+
+    data.desc = isstring(data.desc) and L(data.desc) or data.desc
+    data.category = isstring(data.category) and L(data.category) or data.category
+
     lia.config.stored[key] = {
-        name = name or key,
+        name = isstring(name) and L(name) or name or key,
         data = data,
         value = savedValue,
         default = value,
-        desc = desc,
-        category = category or L("character"),
+        desc = data.desc,
+        category = data.category or L("character"),
         noNetworking = data.noNetworking or false,
         callback = callback
     }

--- a/gamemode/core/libraries/option.lua
+++ b/gamemode/core/libraries/option.lua
@@ -21,11 +21,12 @@ lia.option.stored = lia.option.stored or {}
 
     Parameters:
         key (string)         - Unique identifier for the option.
-        name (string)        - Display name for the option (should be localized).
-        desc (string)        - Description for the option (should be localized).
+        name (string)        - Display name for the option (localized automatically).
+        desc (string)        - Description for the option (localized automatically).
         default (any)        - Default value for the option.
         callback (function)  - (Optional) Function to call when the option value changes. Receives (oldValue, newValue).
-        data (table)         - Table containing additional option data (category, min, max, decimals, type, visible, etc).
+        data (table)         - Table containing additional option data (category, min, max, decimals, type, visible, etc). String
+                              fields such as `category` and entries in an `options` table are localized automatically.
 
     Returns:
         None.
@@ -35,10 +36,10 @@ lia.option.stored = lia.option.stored or {}
 
     Example Usage:
         -- Add a boolean option for enabling a HUD element
-        lia.option.add("showHUD", L("showHUD"), L("showHUDDesc"), true, function(old, new)
+        lia.option.add("showHUD", "showHUD", "showHUDDesc", true, function(old, new)
             print("HUD option changed from", old, "to", new)
         end, {
-            category = L("categoryHUD"),
+            category = "categoryHUD",
             isQuick = true,
             shouldNetwork = true
         })
@@ -57,9 +58,20 @@ function lia.option.add(key, name, desc, default, callback, data)
     if data.type then optionType = data.type end
     local old = lia.option.stored[key]
     local value = old and old.value or default
+
+    if istable(data.options) then
+        for k, v in pairs(data.options) do
+            if isstring(v) then
+                data.options[k] = L(v)
+            end
+        end
+    end
+
+    data.category = isstring(data.category) and L(data.category) or data.category
+
     lia.option.stored[key] = {
-        name = name,
-        desc = desc,
+        name = isstring(name) and L(name) or name,
+        desc = isstring(desc) and L(desc) or desc,
         data = data,
         value = value,
         default = default,


### PR DESCRIPTION
## Summary
- Auto-localize names, descriptions, categories and options within `lia.config.add` and `lia.option.add`
- Refresh configuration and option docs to explain automatic localization and show key-based examples

## Testing
- `luacheck gamemode/core/libraries/config.lua gamemode/core/libraries/option.lua | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_689557685f2c83279f32492c73f676b7