### PR TITLE
fix: handle localized Set Faction icon

### DIFF
--- a/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
@@ -41,8 +41,8 @@ local function GetSubMenuIcon(name)
     if subMenuIcons[L(name)] then return subMenuIcons[L(name)] end
     local setFactionLocalized = L("setFactionTitle"):match("^([^%(]+)") or L("setFactionTitle")
     setFactionLocalized = setFactionLocalized:gsub("^%s*(.-)%s*$", "%1") -- Trim whitespace
-    if name:match("^" .. setFactionLocalized) then return subMenuIcons["setFactionTitle"] end
-    if name:match("Set Faction") then return subMenuIcons["setFactionTitle"] end
+    if name:find(setFactionLocalized, 1, true) == 1 then return subMenuIcons["setFactionTitle"] end
+    if name:find("Set Faction", 1, true) == 1 then return subMenuIcons["setFactionTitle"] end
     return nil
 end
 


### PR DESCRIPTION
## Summary
- ensure GetSubMenuIcon handles localized "Set Faction" labels using plain search

## Testing
- `luacheck gamemode/modules/administration/submodules/adminstick/libraries/client.lua`

------
https://chatgpt.com/codex/tasks/task_e_68955aac5db08327b297de7cf377ffab