### PR TITLE
Allow whitelisting for all classes

### DIFF
--- a/gamemode/core/meta/character.lua
+++ b/gamemode/core/meta/character.lua
@@ -650,7 +650,7 @@ if SERVER then
     ]]
     function characterMeta:WhitelistAllClasses()
         for class, _ in pairs(lia.class.list) do
-            if not lia.class.hasWhitelist(class) then self:classWhitelist(class) end
+            self:classWhitelist(class)
         end
     end
 

--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -1306,7 +1306,7 @@ if SERVER then
 ]]
     function playerMeta:WhitelistAllClasses()
         for class, _ in pairs(lia.class.list) do
-            if lia.class.hasWhitelist(class) then self:classWhitelist(class) end
+            self:classWhitelist(class)
         end
     end
 

--- a/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
@@ -401,18 +401,16 @@ local function IncludeCharacterManagement(tgt, menu, stores)
                 if classes and #classes > 0 then
                     local cw, cu = {}, {}
                     for _, c in ipairs(classes) do
-                        if lia.class.hasWhitelist(c.index) then
-                            if not tgt:hasClassWhitelist(c.index) then
-                                table.insert(cw, {
-                                    name = c.name,
-                                    cmd = 'say /classwhitelist ' .. QuoteArgs(GetIdentifier(tgt), c.uniqueID)
-                                })
-                            else
-                                table.insert(cu, {
-                                    name = c.name,
-                                    cmd = 'say /classunwhitelist ' .. QuoteArgs(GetIdentifier(tgt), c.uniqueID)
-                                })
-                            end
+                        if not tgt:hasClassWhitelist(c.index) then
+                            table.insert(cw, {
+                                name = c.name,
+                                cmd = 'say /classwhitelist ' .. QuoteArgs(GetIdentifier(tgt), c.uniqueID)
+                            })
+                        else
+                            table.insert(cu, {
+                                name = c.name,
+                                cmd = 'say /classunwhitelist ' .. QuoteArgs(GetIdentifier(tgt), c.uniqueID)
+                            })
                         end
                     end
 

--- a/gamemode/modules/teams/commands.lua
+++ b/gamemode/modules/teams/commands.lua
@@ -247,7 +247,7 @@ lia.command.add("classwhitelist", {
         if not target or not IsValid(target) then
             client:notifyLocalized("targetNotFound")
             return
-        elseif not classID or not lia.class.hasWhitelist(classID) then
+        elseif not classID then
             client:notifyLocalized("invalidClass")
             return
         end
@@ -293,7 +293,7 @@ lia.command.add("classunwhitelist", {
         if not target or not IsValid(target) then
             client:notifyLocalized("targetNotFound")
             return
-        elseif not classID or not lia.class.hasWhitelist(classID) then
+        elseif not classID then
             client:notifyLocalized("invalidClass")
             return
         end


### PR DESCRIPTION
## Summary
- Remove hardcoded whitelist check from class whitelist commands
- Update whitelist helpers to include every class
- Show all classes in admin stick whitelist menus

## Testing
- `luacheck --version` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68956056ea388327a79cc0bdcc6402db