### PR TITLE
Log missing privilege checks

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -176,7 +176,11 @@ function lia.administrator.hasAccess(ply, privilege)
     if getGroupLevel(grp) >= (lia.administrator.DefaultGroups.superadmin or 3) then return true end
     local g = lia.administrator.groups and lia.administrator.groups[grp] or nil
     if g and g[name] == true then return true end
-    local min = lia.administrator.privileges and lia.administrator.privileges[name] or "user"
+    local min = lia.administrator.privileges and lia.administrator.privileges[name]
+    if not min then
+        lia.information(L("privilegeNoExist", name))
+        min = "user"
+    end
     return shouldGrant(grp, min)
 end
 

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -217,6 +217,7 @@ LANGUAGE = {
     lookToUseAt = "You need to be looking at someone to use '@'",
     itemNoExist = "Sorry, the item that you requested does not exist.",
     cmdNoExist = "Sorry, that command does not exist.",
+    privilegeNoExist = "The privilege '%s' does not exist.",
     plyNoExist = "Sorry, a matching player could not be found.",
     itemCreated = "Item successfully created.",
     inv = "Inventory",


### PR DESCRIPTION
## Summary
- log information when code checks access for a non-existent privilege
- add English localization for missing privilege message

## Testing
- `luacheck gamemode/core/libraries/admin.lua gamemode/languages/english.lua` *(fails: line is too long warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6895794beab48327be28b075c4ec12fb