### PR TITLE
Warn when undefined privilege is checked

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -173,10 +173,16 @@ function lia.administrator.hasAccess(ply, privilege)
     end
 
     local name = lia.administrator.privIDs and lia.administrator.privIDs[privilege] or privilege
+    if not (lia.administrator.privileges and lia.administrator.privileges[name]) then
+        lia.information(L("privilegeNotExist", name))
+        if IsValid(ply) and ply.notifyLocalized then ply:notifyLocalized("privilegeNotExist", name) end
+        return getGroupLevel(grp) >= (lia.administrator.DefaultGroups.superadmin or 3)
+    end
+
     if getGroupLevel(grp) >= (lia.administrator.DefaultGroups.superadmin or 3) then return true end
     local g = lia.administrator.groups and lia.administrator.groups[grp] or nil
     if g and g[name] == true then return true end
-    local min = lia.administrator.privileges and lia.administrator.privileges[name] or "user"
+    local min = lia.administrator.privileges[name]
     return shouldGrant(grp, min)
 end
 

--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -584,6 +584,7 @@ LANGUAGE = {
     categoryServer = "Server",
     mustSuperAdminStopSound = "You need the '%s' privilege to run stopsound globally.",
     commandConsoleOnly = "This command can only be run from the server console.",
+    privilegeNotExist = "The privilege '%s' does not exist and has been restricted to super administrators. Please notify an administrator.",
     resetInv = "You have cleared %s's inventory!",
     searchingChar = "Searching for character...",
     noAvailableFlags = "No available flags to give.",


### PR DESCRIPTION
## Summary
- Log missing privilege checks and restrict them to super admins
- Add user-facing message when a privilege is undefined

## Testing
- `luacheck gamemode/core/libraries/admin.lua gamemode/languages/english.lua`

------
https://chatgpt.com/codex/tasks/task_e_689580eff8a883279b92d4b46ee386d7