### PR TITLE
Add helper functions for character retrieval and remove direct loaded table access

### DIFF
--- a/documentation/docs/hooks/gamemode_hooks.md
+++ b/documentation/docs/hooks/gamemode_hooks.md
@@ -7004,7 +7004,8 @@ Determines whether one character recognizes another.
 ```lua
 -- Only recognize characters from the same faction.
 hook.Add("isCharRecognized", "ValidateCharacterRecognition", function(character, id)
-    return character:getFaction() == lia.char.loaded[id]:getFaction()
+    local other = lia.char.getCharacter(id)
+    return other and character:getFaction() == other:getFaction()
 end)
 ```
 

--- a/gamemode/core/derma/mainmenu/character.lua
+++ b/gamemode/core/derma/mainmenu/character.lua
@@ -1,4 +1,4 @@
-﻿local PANEL = {}
+local PANEL = {}
 function PANEL:Init()
     local client = LocalPlayer()
     local clientChar = client.getChar and client:getChar()
@@ -36,7 +36,7 @@ function PANEL:Init()
     self:loadBackground()
     if clientChar and lia.characters and #lia.characters > 0 then
         for i, charID in ipairs(lia.characters) do
-            local charObj = isnumber(charID) and lia.char.loaded[charID] or charID
+            local charObj = isnumber(charID) and lia.char.getCharacter(charID) or charID
             if charObj and charObj.getID and charObj:getID() == clientChar:getID() then
                 self.currentIndex = i
                 break
@@ -151,7 +151,7 @@ function PANEL:createStartButton()
     local hasStaffChar = false
     if lia.characters and #lia.characters > 0 then
         for _, charID in pairs(lia.characters) do
-            local character = lia.char.loaded[charID]
+            local character = lia.char.getCharacter(charID)
             if character and character:getFaction() == FACTION_STAFF then
                 hasStaffChar = true
                 break
@@ -173,7 +173,7 @@ function PANEL:createStartButton()
                 if hasStaffChar then
                     -- Load staff character
                     for _, charID in pairs(lia.characters) do
-                        local character = lia.char.loaded[charID]
+                        local character = lia.char.getCharacter(charID)
                         if character and character:getFaction() == FACTION_STAFF then
                             lia.module.list["mainmenu"]:chooseCharacter(character:getID()):catch(function(err)
                                 if err and err ~= "" then
@@ -456,7 +456,7 @@ function PANEL:updateSelectedCharacter()
     if #chars == 0 then return end
     self.currentIndex = self.currentIndex or 1
     local sel = chars[self.currentIndex] or chars[1]
-    local character = lia.char.loaded[sel]
+    local character = lia.char.getCharacter(sel)
     if IsValid(self.infoFrame) then self.infoFrame:Remove() end
     if IsValid(self.selectBtn) then self.selectBtn:Remove() end
     if IsValid(self.deleteBtn) then self.deleteBtn:Remove() end
@@ -470,7 +470,7 @@ function PANEL:createSelectedCharacterInfoPanel(character)
     local total = #chars
     local index = 1
     for i, cID in ipairs(chars) do
-        local cObj = isnumber(cID) and lia.char.loaded[cID] or cID
+        local cObj = isnumber(cID) and lia.char.getCharacter(cID) or cID
         if cObj and cObj.getID and cObj:getID() == character:getID() then
             index = i
             break

--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -1,4 +1,4 @@
-﻿local GM = GM or GAMEMODE
+local GM = GM or GAMEMODE
 function GM:CharPreSave(character)
     local client = character:getPlayer()
     local loginTime = character:getLoginTime()
@@ -70,8 +70,8 @@ function GM:PlayerShouldPermaKill(client)
 end
 
 function GM:CharLoaded(id)
-    local character = lia.char.loaded[id]
-    if character then
+    lia.char.getCharacter(id, nil, function(character)
+        if not character then return end
         local client = character:getPlayer()
         if IsValid(client) then
             local uniqueID = "liaSaveChar" .. client:SteamID64()
@@ -83,7 +83,7 @@ function GM:CharLoaded(id)
                 end
             end)
         end
-    end
+    end)
 end
 
 function GM:PrePlayerLoadedChar(client)
@@ -103,8 +103,9 @@ end
 
 function GM:CanItemBeTransfered(item, curInv, inventory)
     if item.isBag and curInv ~= inventory and item.getInv and item:getInv() and table.Count(item:getInv():getItems()) > 0 then
-        local character = lia.char.loaded[curInv.client]
-        character:getPlayer():notifyLocalized("forbiddenActionStorage")
+        lia.char.getCharacter(curInv.client, nil, function(character)
+            if character then character:getPlayer():notifyLocalized("forbiddenActionStorage") end
+        end)
         return false
     end
 
@@ -533,7 +534,7 @@ function GM:SetupBotPlayer(client)
     inventory.id = "bot" .. character:getID()
     character.vars.inv[1] = inventory
     lia.inventory.instances[inventory.id] = inventory
-    lia.char.loaded[botID] = character
+    lia.char.addCharacter(botID, character)
     character:setup()
     client:Spawn()
 end
@@ -1104,7 +1105,16 @@ hook.Add("server_removeban", "LiliaLogServerUnban", function(data)
     lia.db.query("DELETE FROM lia_bans WHERE playerSteamID = " .. lia.db.convertDataType(data.networkid))
 end)
 
-local networkStrings = {"AdminModeSwapCharacter", "AnimationStatus", "ArgumentsRequest", "BinaryQuestionRequest", "ButtonRequest", "ChangeAttribute", "CharacterInfo", "CheckHack", "CheckSeed", "CreateTableUI", "CurTime-Sync", "CurTimeSync", "DisplayCharList", "ForceUpdateF1", "KickCharacter", "LIA_BigTable_Ack", "MyBigTableNetString", "NetStreamDS", "OpenInvMenu", "OptionsRequest", "RegenChat", "RequestDropdown", "RequestFactionRoster", "RequestRemoveWarning", "RunLocalOption", "RunOption", "ServerChatAddText", "SpawnMenuGiveItem", "SpawnMenuSpawnItem", "StringRequest", "TicketSystem", "TicketSystemClaim", "TicketSystemClose", "TransferMoneyFromP2P", "VendorAllowClass", "VendorAllowFaction", "VendorEdit", "VendorExit", "VendorFaction", "VendorMaxStock", "VendorMode", "VendorMoney", "VendorOpen", "VendorPrice", "VendorStock", "VendorSync", "VendorTrade", "VerifyCheats", "VerifyCheatsResponse", "ViewClaims", "WorkshopDownloader_Info", "WorkshopDownloader_Request", "WorkshopDownloader_Start", "actBar", "attrib", "blindFade", "blindTarget", "cMsg", "cfgList", "cfgSet", "charInfo", "charKick", "charSet", "charVar", "classUpdate", "cmd", "doorMenu", "doorPerm", "gVar", "invAct", "invData", "invQuantity", "item", "liaActiveTickets", "liaAllFlags", "liaAllPKs", "liaAllPlayers", "liaAllWarnings", "liaCharChoose", "liaCharCreate", "liaCharDelete", "liaCharFetchNames", "liaCharList", "liaCharacterData", "liaCharacterInvList", "liaCmdArgPrompt", "liaDBTableData", "liaDBTables", "liaData", "liaDataSync", "liaDatabaseViewData", "liaFactionRosterData", "liaFullCharList", "liaGroupPermChanged", "liaGroupsAdd", "liaGroupsRemove", "liaGroupsRename", "liaGroupsRequest", "liaGroupsSetPerm", "liaInventoryAdd", "liaInventoryData", "liaInventoryDelete", "liaInventoryInit", "liaInventoryRemove", "liaItemDelete", "liaItemInspect", "liaItemInstance", "liaModifyFlags", "liaNotify", "liaNotifyL", "liaPACPartAdd", "liaPACPartRemove", "liaPACPartReset", "liaPACSync", "liaPKsCount", "liaPlayerCharacters", "liaRequestActiveTickets", "liaRequestAllFlags", "liaRequestAllPKs", "liaRequestAllWarnings", "liaRequestDatabaseView", "liaRequestFactionRoster", "liaRequestFullCharList", "liaRequestPKsCount", "liaRequestPlayerCharacters", "liaRequestPlayers", "liaRequestStaffSummary", "liaRequestTableData", "liaRequestTicketsCount", "liaRequestWarningsCount", "liaStaffSummary", "liaStorageExit", "liaStorageOpen", "liaStorageTransfer", "liaStorageUnlock", "liaTeleportToEntity", "liaTicketsCount", "liaTransferItem", "liaWarningsCount", "lia_managesitrooms_action", "managesitrooms", "msg", "nDel", "nLcl", "nVar", "playerLoadedChar", "postPlayerLoadedChar", "prePlayerLoadedChar", "removeF1", "request_respawn", "rgnDone", "send_logs", "send_logs_request", "seqSet", "setWaypoint", "setWaypointWithLogo", "trunkInitStorage", "updateAdminGroups", "updateAdminPrivilegeIDs", "updateAdminPrivilegeMeta", "updateAdminPrivileges"}
+local networkStrings = {"AdminModeSwapCharacter", "AnimationStatus", "ArgumentsRequest", "BinaryQuestionRequest", "ButtonRequest", "ChangeAttribute", "CharacterInfo", "CheckHack", "CheckSeed", "CreateTableUI", "CurTime-Sync", "CurTimeSync", "DisplayCharList", "ForceUpdateF1", "KickCharacter", "LIA_BigTable_Ack", "MyBigTableNetString", "NetStreamDS", "OpenInvMenu", "OptionsRequest", "RegenChat", "RequestDropdown", "RequestFactionRoster", "RequestRemoveWarning", "RunLocalOption", "RunOption", "ServerChatAddText", "SpawnMenuGiveItem", "SpawnMenuSpawnItem", "StringRequest", "TicketSystem", "TicketSystemClaim", "TicketSystemClose", "TransferMoneyFromP2P", "VendorAllowClass", "VendorAllowFaction", "VendorEdit", "VendorExit", "VendorFaction", "VendorMaxStock", "VendorMode", "VendorMoney", "VendorOpen", "VendorPrice", "VendorStock", "VendorSync", "VendorTrade", "VerifyCheats", "VerifyCheatsResponse", "ViewClaims", "WorkshopDownloader_Info", "WorkshopDownloader_Request", "WorkshopDownloader_Start", "actBar", "attrib", "blindFade", "blindTarget", "cMsg", "cfgList", "cfgSet", "charInfo", "charKick", "charSet", "charVar", "classUpdate", "cmd", "doorMenu", "doorPerm", "gVar", "invAct", "invData", "invQuantity", "item", "liaActiveTickets", "liaAllFlags", "liaAllPKs", "liaAllPlayers", "liaAllWarnings", "liaCharChoose", "liaCharCreate", "liaCharDelete", "liaCharFetchNames", "liaCharList", "liaCharacterData", "liaCharacterInvList", "liaCmdArgPrompt", "liaDBTableData", "liaDBTables", "liaData", "liaDataSync", "liaDatabaseViewData", "liaFactionRosterData", "liaFullCharList", "liaGroupPermChanged", "liaGroupsAdd", "liaGroupsRemove", "liaGroupsRename", "liaGroupsRequest", "liaGroupsSetPerm", "liaInventoryAdd", "liaInventoryData", "liaInventoryDelete", "liaInventoryInit", "liaInventoryRemove", "liaItemDelete", "liaItemInspect", "liaItemInstance", "liaModifyFlags", "liaNotify", "liaNotifyL", "liaPACPartAdd", "liaPACPartRemove", "liaPACPartReset", "liaPACSync", "liaPKsCount", "liaPlayerCharacters", "liaRequestActiveTickets", "liaRequestAllFlags", "liaRequestAllPKs", "liaRequestAllWarnings", "liaRequestDatabaseView", "liaRequestFactionRoster", "liaRequestFullCharList", "liaRequestPKsCount", "liaRequestPlayerCharacters", "liaRequestPlayers", "liaRequestStaffSummary", "liaRequestTableData", "liaRequestTicketsCount", "liaRequestWarningsCount", "liaStaffSummary", "liaStorageExit", "liaStorageOpen", "liaStorageTransfer", "liaStorageUnlock", "liaTeleportToEntity", "liaTicketsCount", "liaTransferItem", "liaWarningsCount", "lia_managesitrooms_action", "managesitrooms", "msg", "nDel", "nLcl", "nVar", "playerLoadedChar", "postPlayerLoadedChar", "prePlayerLoadedChar", "removeF1", "request_respawn", "rgnDone", "send_logs", "send_logs_request", "seqSet", "setWaypoint", "setWaypointWithLogo", "trunkInitStorage", "updateAdminGroups", "updateAdminPrivilegeIDs", "updateAdminPrivilegeMeta", "updateAdminPrivileges", "liaCharRequest"}
 for _, netString in ipairs(networkStrings) do
     util.AddNetworkString(netString)
 end
+
+net.Receive("liaCharRequest", function(_, client)
+    local charID = net.ReadUInt(32)
+    lia.char.getCharacter(charID, client, function(character)
+        if character then
+            character:sync(client)
+        end
+    end)
+end)

--- a/gamemode/core/meta/character.lua
+++ b/gamemode/core/meta/character.lua
@@ -1,4 +1,4 @@
-﻿local characterMeta = lia.meta.character or {}
+local characterMeta = lia.meta.character or {}
 characterMeta.__index = characterMeta
 characterMeta.id = characterMeta.id or 0
 characterMeta.vars = characterMeta.vars or {}
@@ -1311,7 +1311,7 @@ if SERVER then
     ]]
     function characterMeta:destroy()
         local id = self:getID()
-        lia.char.loaded[id] = nil
+        lia.char.removeCharacter(id)
     end
 
     --[[

--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -1,4 +1,4 @@
-﻿local playerMeta = FindMetaTable("Player")
+local playerMeta = FindMetaTable("Player")
 local vectorMeta = FindMetaTable("Vector")
 do
     playerMeta.steamName = playerMeta.steamName or playerMeta.Name
@@ -22,7 +22,7 @@ do
         end
 ]]
     function playerMeta:getChar()
-        return lia.char.loaded[self.getNetVar(self, "char")]
+        return lia.char.getCharacter(self.getNetVar(self, "char"), self)
     end
 
     --[[

--- a/gamemode/core/netcalls/client.lua
+++ b/gamemode/core/netcalls/client.lua
@@ -1,4 +1,4 @@
-﻿net.Receive("liaNotifyL", function()
+net.Receive("liaNotifyL", function()
     local message = net.ReadString()
     local length = net.ReadUInt(8)
     if length == 0 then return lia.notices.notifyLocalized(message) end
@@ -102,7 +102,7 @@ net.Receive("liaInventoryInit", function()
 
     lia.inventory.instances[id] = instance
     hook.Run("InventoryInitialized", instance)
-    for _, character in pairs(lia.char.loaded) do
+    for _, character in pairs(lia.char.getAll()) do
         for idx, inventory in pairs(character.vars.inv) do
             if inventory:getID() == id then character.vars.inv[idx] = instance end
         end
@@ -161,8 +161,9 @@ net.Receive("liaCharacterInvList", function()
         inventories[i] = lia.inventory.instances[net.ReadType()]
     end
 
-    local character = lia.char.loaded[charID]
-    if character then character.vars.inv = inventories end
+    lia.char.getCharacter(charID, nil, function(character)
+        if character then character.vars.inv = inventories end
+    end)
 end)
 
 net.Receive("liaItemDelete", function()
@@ -185,12 +186,13 @@ net.Receive("charSet", function()
     local value = net.ReadType()
     local id = net.ReadType()
     id = id or LocalPlayer():getChar() and LocalPlayer():getChar().id
-    local character = lia.char.loaded[id]
-    if character then
-        local oldValue = character.vars[key]
-        character.vars[key] = value
-        hook.Run("OnCharVarChanged", character, key, oldValue, value)
-    end
+    lia.char.getCharacter(id, nil, function(character)
+        if character then
+            local oldValue = character.vars[key]
+            character.vars[key] = value
+            hook.Run("OnCharVarChanged", character, key, oldValue, value)
+        end
+    end)
 end)
 
 net.Receive("charVar", function()
@@ -198,12 +200,13 @@ net.Receive("charVar", function()
     local value = net.ReadType()
     local id = net.ReadType()
     id = id or LocalPlayer():getChar() and LocalPlayer():getChar().id
-    local character = lia.char.loaded[id]
-    if character then
-        local oldVar = character:getVar()[key]
-        character:getVar()[key] = value
-        hook.Run("OnCharLocalVarChanged", character, key, oldVar, value)
-    end
+    lia.char.getCharacter(id, nil, function(character)
+        if character then
+            local oldVar = character:getVar()[key]
+            character:getVar()[key] = value
+            hook.Run("OnCharLocalVarChanged", character, key, oldVar, value)
+        end
+    end)
 end)
 
 net.Receive("item", function()
@@ -262,8 +265,9 @@ net.Receive("attrib", function()
     local id = net.ReadUInt(32)
     local key = net.ReadString()
     local value = net.ReadType()
-    local character = lia.char.loaded[id]
-    if character then character:getAttribs()[key] = value end
+    lia.char.getCharacter(id, nil, function(character)
+        if character then character:getAttribs()[key] = value end
+    end)
 end)
 
 net.Receive("nVar", function()
@@ -630,7 +634,7 @@ net.Receive("charInfo", function()
     local data = net.ReadTable()
     local id = net.ReadUInt(32)
     local client = net.BytesLeft() > 0 and net.ReadEntity() or nil
-    lia.char.loaded[id] = lia.char.new(data, id, client == nil and LocalPlayer() or client)
+    lia.char.addCharacter(id, lia.char.new(data, id, client == nil and LocalPlayer() or client))
 end)
 
 net.Receive("charKick", function()
@@ -642,24 +646,24 @@ end)
 net.Receive("prePlayerLoadedChar", function()
     local charID = net.ReadUInt(32)
     local currentID = net.ReadType()
-    local char = lia.char.loaded[charID]
-    local current = currentID and lia.char.loaded[currentID] or nil
+    local char = lia.char.getCharacter(charID)
+    local current = currentID and lia.char.getCharacter(currentID) or nil
     hook.Run("PrePlayerLoadedChar", LocalPlayer(), char, current)
 end)
 
 net.Receive("playerLoadedChar", function()
     local charID = net.ReadUInt(32)
     local currentID = net.ReadType()
-    local char = lia.char.loaded[charID]
-    local current = currentID and lia.char.loaded[currentID] or nil
+    local char = lia.char.getCharacter(charID)
+    local current = currentID and lia.char.getCharacter(currentID) or nil
     hook.Run("PlayerLoadedChar", LocalPlayer(), char, current)
 end)
 
 net.Receive("postPlayerLoadedChar", function()
     local charID = net.ReadUInt(32)
     local currentID = net.ReadType()
-    local char = lia.char.loaded[charID]
-    local current = currentID and lia.char.loaded[currentID] or nil
+    local char = lia.char.getCharacter(charID)
+    local current = currentID and lia.char.getCharacter(currentID) or nil
     hook.Run("PostPlayerLoadedChar", LocalPlayer(), char, current)
 end)
 
@@ -772,7 +776,7 @@ end)
 
 net.Receive("liaCharacterData", function()
     local charID = net.ReadUInt(32)
-    local character = lia.char.loaded[charID]
+    local character = lia.char.getCharacter(charID)
     if not character then return end
     if not character.dataVars then character.dataVars = {} end
     local keyCount = net.ReadUInt(32)

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -1,4 +1,4 @@
-﻿lia.command.add("playtime", {
+lia.command.add("playtime", {
     adminOnly = false,
     privilege = "viewOwnPlaytime",
     desc = "playtimeDesc",
@@ -340,7 +340,7 @@ lia.command.add("charlist", {
             local sendData = {}
             for _, row in ipairs(data) do
                 local charID = tonumber(row.id) or row.id
-                local stored = lia.char.loaded[charID]
+                local stored = lia.char.getCharacter(charID)
                 local info = stored and stored:getData() or {}
                 local allVars = {}
                 if stored then
@@ -1933,14 +1933,14 @@ lia.command.add("charunban", {
         local charFound
         local id = tonumber(queryArg)
         if id then
-            for _, v in pairs(lia.char.loaded) do
+            for _, v in pairs(lia.char.getAll()) do
                 if v:getID() == id then
                     charFound = v
                     break
                 end
             end
         else
-            for _, v in pairs(lia.char.loaded) do
+            for _, v in pairs(lia.char.getAll()) do
                 if lia.util.stringMatches(v:getName(), queryArg) then
                     charFound = v
                     break

--- a/gamemode/modules/administration/netcalls/client.lua
+++ b/gamemode/modules/administration/netcalls/client.lua
@@ -1,4 +1,4 @@
-﻿net.Receive("cfgList", function()
+net.Receive("cfgList", function()
     local changed = net.ReadTable()
     for key, value in pairs(changed) do
         if lia.config.stored[key] then lia.config.stored[key].value = value end
@@ -221,7 +221,9 @@ net.Receive("AdminModeSwapCharacter", function()
         local message = net.ReadString()
         if message == "" then
             d:resolve()
-            hook.Run("CharLoaded", lia.char.loaded[id])
+            lia.char.getCharacter(id, nil, function(character)
+                hook.Run("CharLoaded", character)
+            end)
         else
             d:reject(message)
         end

--- a/gamemode/modules/administration/netcalls/server.lua
+++ b/gamemode/modules/administration/netcalls/server.lua
@@ -1,4 +1,4 @@
-﻿net.Receive("cfgSet", function(_, client)
+net.Receive("cfgSet", function(_, client)
     local key = net.ReadString()
     local name = net.ReadString()
     local value = net.ReadType()
@@ -96,7 +96,7 @@ net.Receive("liaRequestFactionRoster", function(_, client)
         if result then
             for _, v in ipairs(result) do
                 local charID = tonumber(v.id)
-                local isOnline = lia.char.loaded[charID] ~= nil
+                local isOnline = lia.char.isLoaded(charID)
                 local lastOnlineText
                 if isOnline then
                     lastOnlineText = L("onlineNow")
@@ -113,7 +113,7 @@ net.Receive("liaRequestFactionRoster", function(_, client)
                 local classData = lia.class.list[classID]
                 local playTime = tonumber(v.playtime) or 0
                 if isOnline then
-                    local char = lia.char.loaded[charID]
+                    local char = lia.char.getCharacter(charID)
                     if char then
                         local loginTime = char:getLoginTime() or os.time()
                         playTime = char:getPlayTime() + os.time() - loginTime
@@ -151,7 +151,7 @@ LEFT JOIN lia_chardata AS d ON d.charID = c.id AND d.key = 'charBanInfo']], func
         }
 
         for _, row in ipairs(data or {}) do
-            local stored = lia.char.loaded[row.id]
+            local stored = lia.char.getCharacter(row.id)
             local bannedVal = tonumber(row.banned) or 0
             local isBanned = bannedVal ~= 0 and (bannedVal == -1 or bannedVal > os.time())
             local steamID = tostring(row.steamID)

--- a/gamemode/modules/administration/submodules/warns/libraries/server.lua
+++ b/gamemode/modules/administration/submodules/warns/libraries/server.lua
@@ -36,30 +36,31 @@ net.Receive("RequestRemoveWarning", function(_, client)
         return
     end
 
-    local targetChar = lia.char.loaded[charID]
-    if not targetChar then
-        client:notifyLocalized("characterNotFound")
-        return
-    end
-
-    local targetClient = targetChar:getPlayer()
-    if not IsValid(targetClient) then
-        client:notifyLocalized("playerNotFound")
-        return
-    end
-
-    MODULE:RemoveWarning(charID, warnIndex):next(function(warn)
-        if not warn then
-            client:notifyLocalized("invalidWarningIndex")
+    lia.char.getCharacter(charID, client, function(targetChar)
+        if not targetChar then
+            client:notifyLocalized("characterNotFound")
             return
         end
 
-        targetClient:notifyLocalized("warningRemovedNotify", client:Nick())
-        client:notifyLocalized("warningRemoved", warnIndex, targetClient:Nick())
-        hook.Run("WarningRemoved", client, targetClient, {
-            reason = warn.message,
-            admin = warn.warner
-        }, warnIndex)
+        local targetClient = targetChar:getPlayer()
+        if not IsValid(targetClient) then
+            client:notifyLocalized("playerNotFound")
+            return
+        end
+
+        MODULE:RemoveWarning(charID, warnIndex):next(function(warn)
+            if not warn then
+                client:notifyLocalized("invalidWarningIndex")
+                return
+            end
+
+            targetClient:notifyLocalized("warningRemovedNotify", client:Nick())
+            client:notifyLocalized("warningRemoved", warnIndex, targetClient:Nick())
+            hook.Run("WarningRemoved", client, targetClient, {
+                reason = warn.message,
+                admin = warn.warner
+            }, warnIndex)
+        end)
     end)
 end)
 

--- a/gamemode/modules/mainmenu/libraries/server.lua
+++ b/gamemode/modules/mainmenu/libraries/server.lua
@@ -1,9 +1,11 @@
-﻿function MODULE:PlayerLiliaDataLoaded(client)
+function MODULE:PlayerLiliaDataLoaded(client)
     lia.char.restore(client, function(charList)
         if not IsValid(client) then return end
         MsgN(L("loadedCharacters", table.concat(charList, ", "), client:Name()))
         for _, v in ipairs(charList) do
-            if lia.char.loaded[v] then lia.char.loaded[v]:sync(client) end
+            lia.char.getCharacter(v, client, function(character)
+                if character then character:sync(client) end
+            end)
         end
 
         for _, v in player.Iterator() do

--- a/gamemode/modules/mainmenu/module.lua
+++ b/gamemode/modules/mainmenu/module.lua
@@ -1,4 +1,4 @@
-﻿MODULE.name = "mainMenu"
+MODULE.name = "mainMenu"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.desc = "moduleMainMenuDesc"
@@ -33,7 +33,9 @@ else
             local message = net.ReadString()
             if message == "" then
                 d:resolve()
-                hook.Run("CharLoaded", lia.char.loaded[id])
+                lia.char.getCharacter(id, nil, function(character)
+                    hook.Run("CharLoaded", character)
+                end)
             else
                 d:reject(message)
             end
@@ -155,7 +157,7 @@ function MODULE:GetMaxPlayerChar(client)
         -- Count staff characters to add them to the limit
         local staffCount = 0
         for _, charID in pairs(client.liaCharList or {}) do
-            local character = lia.char.loaded[charID]
+            local character = lia.char.getCharacter(charID)
             if character and character:getFaction() == FACTION_STAFF then
                 staffCount = staffCount + 1
             end

--- a/gamemode/modules/recognition/libraries/shared.lua
+++ b/gamemode/modules/recognition/libraries/shared.lua
@@ -8,7 +8,7 @@ end
 function MODULE:isCharRecognized(character, id)
     if not lia.config.get("RecognitionEnabled", true) then return true end
     local client = character:getPlayer()
-    local other = lia.char.loaded[id]
+    local other = lia.char.getCharacter(id, client)
     local otherClient = other and other:getPlayer()
     if not IsValid(otherClient) then return false end
     if character.id == id then return true end
@@ -29,7 +29,8 @@ function MODULE:isCharRecognized(character, id)
 end
 
 function MODULE:isCharFakeRecognized(character, id)
-    local other = lia.char.loaded[id]
+    local other = lia.char.getCharacter(id, character:getPlayer())
+    if not other then return false end
     local CharNameList = character:getFakeName()
     local clientName = CharNameList[other:getID()]
     return lia.config.get("FakeNamesEnabled", false) and isFakeNameExistant(clientName, CharNameList)

--- a/gamemode/modules/teams/libraries/server.lua
+++ b/gamemode/modules/teams/libraries/server.lua
@@ -1,4 +1,4 @@
-﻿function MODULE:OnPlayerJoinClass(client, class, oldClass)
+function MODULE:OnPlayerJoinClass(client, class, oldClass)
     local info = lia.class.list[class]
     local info2 = lia.class.list[oldClass]
     if info then
@@ -155,7 +155,7 @@ end
 
 function MODULE:CanCharBeTransfered(character, faction)
     if faction.oneCharOnly then
-        for _, otherCharacter in next, lia.char.loaded do
+        for _, otherCharacter in next, lia.char.getAll() do
             if otherCharacter.steamID == character.steamID and faction.index == otherCharacter:getFaction() then return false, L("charAlreadyInFaction") end
         end
     end

--- a/gamemode/modules/teams/netcalls/server.lua
+++ b/gamemode/modules/teams/netcalls/server.lua
@@ -1,4 +1,4 @@
-﻿local function stripAgo(timeSince)
+local function stripAgo(timeSince)
     local agoStr = L("ago")
     local suffix = " " .. agoStr
     if timeSince:sub(-#suffix) == suffix then return timeSince:sub(1, -#suffix - 1) end
@@ -21,7 +21,7 @@ net.Receive("RequestFactionRoster", function(_, client)
         if data then
             for _, v in ipairs(data) do
                 local charID = tonumber(v.id)
-                local isOnline = lia.char.loaded[charID] ~= nil
+                local isOnline = lia.char.isLoaded(charID)
                 local lastOnlineText
                 if isOnline then
                     lastOnlineText = L("onlineNow")
@@ -38,7 +38,7 @@ net.Receive("RequestFactionRoster", function(_, client)
                 local classData = lia.class.list[classID]
                 local playTime = tonumber(v.playtime) or 0
                 if isOnline then
-                    local char = lia.char.loaded[charID]
+                    local char = lia.char.getCharacter(charID)
                     if char then
                         local loginTime = char:getLoginTime() or os.time()
                         playTime = char:getPlayTime() + os.time() - loginTime


### PR DESCRIPTION
## Summary
- Introduce `isLoaded`, `getAll`, `addCharacter`, and `removeCharacter` helpers alongside existing `getCharacter`
- Replace remaining `lia.char.loaded` usage with new retrieval helpers across modules
- Ensure character-dependent features fetch data from server when needed

## Testing
- `luacheck documentation/docs/hooks/gamemode_hooks.md gamemode/core/derma/mainmenu/character.lua gamemode/core/hooks/server.lua gamemode/core/libraries/character.lua gamemode/core/meta/character.lua gamemode/core/meta/player.lua gamemode/core/netcalls/client.lua gamemode/modules/administration/commands.lua gamemode/modules/administration/netcalls/client.lua gamemode/modules/administration/netcalls/server.lua gamemode/modules/mainmenu/libraries/server.lua gamemode/modules/mainmenu/module.lua gamemode/modules/mainmenu/netcalls/server.lua gamemode/modules/teams/libraries/server.lua gamemode/modules/teams/netcalls/server.lua` *(fails: 2961 warnings / 3 errors)*
- `luac -p gamemode/core/hooks/server.lua gamemode/core/libraries/character.lua gamemode/core/meta/character.lua gamemode/core/meta/player.lua gamemode/core/netcalls/client.lua gamemode/modules/administration/commands.lua gamemode/modules/administration/netcalls/client.lua gamemode/modules/administration/netcalls/server.lua gamemode/modules/mainmenu/libraries/server.lua gamemode/modules/mainmenu/module.lua gamemode/modules/mainmenu/netcalls/server.lua gamemode/modules/teams/libraries/server.lua gamemode/modules/teams/netcalls/server.lua gamemode/core/derma/mainmenu/character.lua` *(fails: '=' expected near 'end')*

------
https://chatgpt.com/codex/tasks/task_e_6896cb6bc2a083279e778f1063757d42