### PR TITLE
chore: remove single-line comments

### DIFF
--- a/gamemode/core/derma/mainmenu/character.lua
+++ b/gamemode/core/derma/mainmenu/character.lua
@@ -147,7 +147,7 @@ function PANEL:createStartButton()
     local workshopURL = lia.config.get("Workshop")
     local buttonsData = {}
 
-    -- Check for staff character existence
+    
     local hasStaffChar = false
     if lia.characters and #lia.characters > 0 then
         for _, charID in pairs(lia.characters) do
@@ -159,7 +159,7 @@ function PANEL:createStartButton()
         end
     end
 
-    -- Staff Character button (Create or Load) - Don't show if already on duty
+    
     if client:hasPrivilege("createStaffCharacter") and not client:isStaffOnDuty() then
         table.insert(buttonsData, {
             id = "staff",
@@ -171,7 +171,7 @@ function PANEL:createStartButton()
 
                 self:clickSound()
                 if hasStaffChar then
-                    -- Load staff character
+                    
                     for _, charID in pairs(lia.characters) do
                         local character = lia.char.getCharacter(charID)
                         if character and character:getFaction() == FACTION_STAFF then
@@ -186,7 +186,7 @@ function PANEL:createStartButton()
                         end
                     end
                 else
-                    -- Create staff character
+                    
                     self:createStaffCharacter()
                 end
             end
@@ -426,21 +426,21 @@ function PANEL:createStaffCharacter()
     local client = LocalPlayer()
     local steamName = client:Nick()
 
-    -- Create staff character with Steam name
+    
     local staffData = {
         name = steamName,
         faction = FACTION_STAFF,
-        model = 1, -- Use first model from staff faction
-        desc = "", -- We'll update this after spawn with Discord info
+        model = 1, 
+        desc = "", 
         skin = 0,
         groups = {}
     }
 
     lia.module.list["mainmenu"]:createCharacter(staffData):next(function(charID)
-        -- Character created successfully, now load it
+        
         lia.module.list["mainmenu"]:chooseCharacter(charID):next(function()
             self:Remove()
-            -- The Discord prompt will be handled by the spawn hook
+            
         end):catch(function(err)
             if err and err ~= "" then
                 LocalPlayer():notifyLocalized(err)

--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -692,7 +692,7 @@ function lia.administrator.renameGroup(oldName, newName)
     if SERVER then lia.administrator.save() end
 end
 
--- Register the staff character creation privilege
+
 lia.administrator.registerPrivilege({
     ID = "createStaffCharacter",
     Name = "createStaffCharacter",

--- a/gamemode/core/libraries/character.lua
+++ b/gamemode/core/libraries/character.lua
@@ -366,7 +366,7 @@ lia.char.registerVar("model", {
         local faction = lia.faction.indices[data.faction]
         if faction then
             if not data.model or not faction.models[data.model] then
-                -- Staff characters with privilege can bypass model validation
+                
                 if data.faction == FACTION_STAFF and client and client:hasPrivilege("createStaffCharacter") then
                     return true
                 end
@@ -482,7 +482,7 @@ lia.char.registerVar("faction", {
     end,
     onValidate = function(value, _, client)
         if not lia.faction.indices[value] then return false, "invalid", "faction" end
-        -- Staff characters bypass whitelist check
+        
         if value == FACTION_STAFF and client:hasPrivilege("createStaffCharacter") then return true end
         if not client:hasWhitelist(value) then return false, "illegalAccess" end
         return true
@@ -592,7 +592,7 @@ lia.char.registerVar("attribs", {
     isLocal = true,
     index = 4,
     onValidate = function(value, data, client)
-        -- Staff characters with privilege bypass attribute validation
+        
         if data and data.faction == FACTION_STAFF and client and client:hasPrivilege("createStaffCharacter") then
             return true
         end
@@ -1376,16 +1376,16 @@ if SERVER then
         local character = lia.char.loaded[charID]
         if not character then return false end
 
-        -- Save character data before unloading
+        
         character:save()
 
-        -- Clean up inventories
+        
         lia.inventory.cleanUpForCharacter(character)
 
-        -- Remove from loaded table
+        
         lia.char.loaded[charID] = nil
 
-        -- Call cleanup hook
+        
         hook.Run("CharCleanUp", character)
 
         return true
@@ -1431,19 +1431,19 @@ if SERVER then
             None.
     ]]
     function lia.char.loadSingleCharacter(charID, client, callback)
-        -- If character is already loaded, call callback immediately
+        
         if lia.char.loaded[charID] then
             if callback then callback(lia.char.loaded[charID]) end
             return
         end
 
-        -- Check if character belongs to this client (only if client is provided)
+        
         if client and not table.HasValue(client.liaCharList or {}, charID) then
             if callback then callback(nil) end
             return
         end
 
-        -- Load character from database
+        
         lia.db.selectOne("*", "characters", "id = " .. charID):next(function(result)
             if not result then
                 if callback then callback(nil) end
@@ -1465,11 +1465,11 @@ if SERVER then
                 end
             end
 
-            -- Create character object
+            
             local character = lia.char.new(charData, charID, client)
             hook.Run("CharRestored", character)
 
-            -- Load inventories
+            
             character.vars.inv = {}
             lia.inventory.loadAllFromCharID(charID):next(function(inventories)
                 if #inventories == 0 then

--- a/gamemode/core/libraries/factions.lua
+++ b/gamemode/core/libraries/factions.lua
@@ -568,10 +568,10 @@ if CLIENT then
         local data = lia.faction.indices[faction]
         if data then
             if data.isDefault then return true end
-            -- Special case for staff faction - check createStaffCharacter privilege
+            
             if faction == FACTION_STAFF then
                 local hasPriv = LocalPlayer():hasPrivilege("createStaffCharacter")
-                -- Follow same notification logic as admin.lua for non-existent privileges
+                
                 if not (lia.administrator.privileges and lia.administrator.privileges["createStaffCharacter"]) then
                     lia.information(L("privilegeNotExist", "createStaffCharacter"))
                     if IsValid(LocalPlayer()) and LocalPlayer().notifyLocalized then

--- a/gamemode/core/libraries/inventory.lua
+++ b/gamemode/core/libraries/inventory.lua
@@ -289,10 +289,10 @@ if SERVER then
             end)
     ]]
     function lia.inventory.loadAllFromCharID(charID)
-        -- Store original value for error reporting
+        
         local originalCharID = charID
 
-        -- Convert charID to number if it isn't already
+        
         charID = tonumber(charID)
         if not charID then
             lia.error(L("charIDMustBeNumber") .. " (received: " .. tostring(originalCharID) .. ", type: " .. type(originalCharID) .. ")")

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -85,8 +85,8 @@ lia.command.add("adminmode", {
                 if client:hasPrivilege("createStaffChar") then
                     local staffCharData = {
                         steamID = steamID,
-                        name = client:steamName(), -- Use Nick() to match main menu staff creation
-                        desc = "", -- Empty description to trigger Discord prompt hook (same as main menu)
+                        name = client:steamName(), 
+                        desc = "", 
                         faction = "staff",
                         model = lia.faction.indices["staff"] and lia.faction.indices["staff"].models[1] or "models/Humans/Group02/male_07.mdl"
                     }

--- a/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
@@ -40,7 +40,7 @@ local function GetSubMenuIcon(name)
     if subMenuIcons[baseKey] then return subMenuIcons[baseKey] end
     if subMenuIcons[L(name)] then return subMenuIcons[L(name)] end
     local setFactionLocalized = L("setFactionTitle"):match("^([^%(]+)") or L("setFactionTitle")
-    setFactionLocalized = setFactionLocalized:gsub("^%s*(.-)%s*$", "%1") -- Trim whitespace
+    setFactionLocalized = setFactionLocalized:gsub("^%s*(.-)%s*$", "%1") 
     if name:find(setFactionLocalized, 1, true) == 1 then return subMenuIcons["setFactionTitle"] end
     if name:find("Set Faction", 1, true) == 1 then return subMenuIcons["setFactionTitle"] end
     return nil

--- a/gamemode/modules/mainmenu/module.lua
+++ b/gamemode/modules/mainmenu/module.lua
@@ -112,7 +112,7 @@ else
         end
     end
 
-    -- Handle Discord prompt for staff characters
+    
     net.Receive("liaStaffDiscordPrompt", function()
         Derma_StringRequest(
             "Staff Character Setup",
@@ -128,7 +128,7 @@ else
                 end
             end,
             function()
-                -- User cancelled, set a default
+                
                 net.Start("liaStaffDiscordResponse")
                 net.WriteString("Discord not provided")
                 net.SendToServer()
@@ -150,11 +150,11 @@ function MODULE:CanPlayerCreateChar(client)
     end
 end
 
--- Hook to exclude staff characters from character limit
+
 function MODULE:GetMaxPlayerChar(client)
     local maxChars = lia.config.get("MaxCharacters")
     if SERVER then
-        -- Count staff characters to add them to the limit
+        
         local staffCount = 0
         for _, charID in pairs(client.liaCharList or {}) do
             local character = lia.char.getCharacter(charID)
@@ -162,10 +162,10 @@ function MODULE:GetMaxPlayerChar(client)
                 staffCount = staffCount + 1
             end
         end
-        -- Effectively give unlimited slots for staff characters
+        
         return maxChars + staffCount
     else
-        -- Count staff characters on client side
+        
         local staffCount = 0
         for _, charID in pairs(lia.characters or {}) do
             local character = lia.char.getCharacter(charID)

--- a/gamemode/modules/mainmenu/netcalls/server.lua
+++ b/gamemode/modules/mainmenu/netcalls/server.lua
@@ -8,20 +8,20 @@ net.Receive("liaCharChoose", function(_, client)
     local id = net.ReadUInt(32)
     local currentChar = client:getChar()
 
-    -- Check if we need to load the character first
+    
     if not lia.char.isLoaded(id) then
-        -- Verify the character belongs to this client
+        
         if not table.HasValue(client.liaCharList or {}, id) then
             return response(false, "invalidChar")
         end
 
-        -- Load the character
+        
         lia.char.loadSingleCharacter(id, client, function(character)
             if not character then
                 return response(false, "invalidChar")
             end
 
-            -- Perform character switching
+            
             local status, result = hook.Run("CanPlayerUseChar", client, character)
             if status == false then
                 if result[1] == "@" then result = result:sub(2) end
@@ -38,13 +38,13 @@ net.Receive("liaCharChoose", function(_, client)
                 currentChar:save()
             end
 
-            -- Unload all other characters (keep only the active one)
+            
             local unloadedCount = lia.char.unloadUnusedCharacters(client, id)
             if unloadedCount > 0 then
                 lia.information("Unloaded " .. unloadedCount .. " unused characters for " .. client:Name())
             end
 
-            -- Setup the new character
+            
             hook.Run("PrePlayerLoadedChar", client, character, currentChar)
             net.Start("prePlayerLoadedChar")
             net.WriteUInt(character:getID(), 32)
@@ -70,7 +70,7 @@ net.Receive("liaCharChoose", function(_, client)
         return
     end
 
-    -- Character is already loaded, proceed normally
+    
     local character = lia.char.getCharacter(id, client)
     if not character or character:getPlayer() ~= client then
         return response(false, "invalidChar")
@@ -92,7 +92,7 @@ net.Receive("liaCharChoose", function(_, client)
         currentChar:save()
     end
 
-    -- Unload all other characters (keep only the active one)
+    
     local unloadedCount = lia.char.unloadUnusedCharacters(client, id)
     if unloadedCount > 0 then
         lia.information("Unloaded " .. unloadedCount .. " unused characters for " .. client:Name())
@@ -188,13 +188,13 @@ net.Receive("liaCharDelete", function(_, client)
     end
 end)
 
--- Network strings are defined in gamemode/core/hooks/server.lua
 
--- Hook to prompt for Discord on first staff character spawn
+
+
 hook.Add("PlayerLoadedChar", "StaffCharacterDiscordPrompt", function(client, character)
     if character:getFaction() == FACTION_STAFF and (character:getDesc() == "" or character:getDesc():find("^A Staff Character")) then
-        -- This is a staff character with no description or default description
-        timer.Simple(2, function() -- Give time for the character to fully load
+        
+        timer.Simple(2, function() 
             if IsValid(client) and client:getChar() == character then
                 net.Start("liaStaffDiscordPrompt")
                 net.Send(client)
@@ -209,7 +209,7 @@ net.Receive("liaStaffDiscordResponse", function(_, client)
 
     if not character or character:getFaction() ~= FACTION_STAFF then return end
 
-    -- Build the description
+    
     local steamID = client:SteamID()
     local description = "A Staff Character, Discord: " .. discord .. ", SteamID: " .. steamID
 

--- a/gamemode/modules/teams/libraries/shared.lua
+++ b/gamemode/modules/teams/libraries/shared.lua
@@ -14,7 +14,7 @@ function MODULE:GetDefaultCharName(client, faction, data)
         if name then return name, override ~= false end
     end
 
-    -- For staff characters, provide a default name and bypass validation
+    
     if faction == FACTION_STAFF then
         return "Staff - " .. client:SteamName(), true
     end
@@ -29,7 +29,7 @@ function MODULE:GetDefaultCharDesc(client, faction)
     local info = lia.faction.indices[faction]
     if info and info.GetDefaultDesc then return info:GetDefaultDesc(client) end
 
-    -- For staff characters, provide a default description and bypass validation
+    
     if faction == FACTION_STAFF then
         return "A Staff Character, Discord: (Not Set), SteamID: " .. client:SteamID(), true
     end


### PR DESCRIPTION
## Summary
- strip inline comments from various Lua modules while preserving block comments

## Testing
- `find . -name '*.lua' -print0 | xargs -0 -n1 luac -p` *(fails: syntax error near 'end' for several files due to non-standard Lua syntax)*

------
https://chatgpt.com/codex/tasks/task_e_6896fc0330488327b865964e2e30f7c2