### PR TITLE
Use localized privilege names

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -357,9 +357,10 @@ function lia.administrator.registerPrivilege(priv)
         if shouldGrant(groupName, min) then perms[id] = true end
     end
 
+    local name = L(priv.Name or priv.ID)
     if CAMI then camiRegisterPrivilege(priv.ID, min) end
     hook.Run("OnPrivilegeRegistered", {
-        Name = priv.Name or priv.ID,
+        Name = name,
         ID = priv.ID,
         MinAccess = min,
         Category = getPrivilegeCategory(id)

--- a/gamemode/core/libraries/modularity.lua
+++ b/gamemode/core/libraries/modularity.lua
@@ -16,7 +16,7 @@ local ModuleFiles = {"pim.lua", "client.lua", "server.lua", "config.lua", "comma
 local function loadPermissions(Privileges)
     if not Privileges or not istable(Privileges) then return end
     for _, privilegeData in ipairs(Privileges) do
-        local privilegeName = privilegeData.Name
+        local privilegeName = L(privilegeData.Name or privilegeData.ID)
         local privilegeCategory = privilegeData.Category or MODULE.name
         lia.administrator.registerPrivilege({
             Name = privilegeName,


### PR DESCRIPTION
## Summary
- Ensure module-provided privileges register using localized names
- Localize privilege names when registering custom privileges

## Testing
- `luacheck .` *(fails: 13846 warnings / 17 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689810f2f2848327b32a4dc634de2da8