### PR TITLE
Clear character panel reference on removal

### DIFF
--- a/gamemode/core/derma/mainmenu/character.lua
+++ b/gamemode/core/derma/mainmenu/character.lua
@@ -205,7 +205,11 @@ function PANEL:createStartButton()
                     for _, charID in pairs(lia.characters) do
                         local character = lia.char.getCharacter(charID)
                         if character and character:getFaction() == FACTION_STAFF then
-                            lia.module.list["mainmenu"]:chooseCharacter(character:getID()):next(function() self:Remove() end):catch(function(err) if err and err ~= "" then LocalPlayer():notifyLocalized(err) end end)
+                            lia.module.list["mainmenu"]:chooseCharacter(character:getID()):next(function()
+                                if IsValid(lia.gui.character) then
+                                    lia.gui.character:Remove()
+                                end
+                            end):catch(function(err) if err and err ~= "" then LocalPlayer():notifyLocalized(err) end end)
                             break
                         end
                     end
@@ -427,7 +431,13 @@ function PANEL:createStaffCharacter()
         groups = {}
     }
 
-    lia.module.list["mainmenu"]:createCharacter(staffData):next(function(charID) lia.module.list["mainmenu"]:chooseCharacter(charID):next(function() self:Remove() end):catch(function(err) if err and err ~= "" then LocalPlayer():notifyLocalized(err) end end) end):catch(function(err) LocalPlayer():notifyLocalized(err or "Failed to create staff character") end)
+    lia.module.list["mainmenu"]:createCharacter(staffData):next(function(charID)
+        lia.module.list["mainmenu"]:chooseCharacter(charID):next(function()
+            if IsValid(lia.gui.character) then
+                lia.gui.character:Remove()
+            end
+        end):catch(function(err) if err and err ~= "" then LocalPlayer():notifyLocalized(err) end end)
+    end):catch(function(err) LocalPlayer():notifyLocalized(err or "Failed to create staff character") end)
 end
 
 function PANEL:updateSelectedCharacter()
@@ -765,6 +775,9 @@ function PANEL:warningSound()
 end
 
 function PANEL:OnRemove()
+    if lia.gui.character == self then
+        lia.gui.character = nil
+    end
     hook.Run("CharacterMenuClosed")
     self:restoreExternalEntities()
     hook.Remove("PrePlayerDraw", "liaMainMenuPrePlayerDraw")


### PR DESCRIPTION
## Summary
- ensure character menu reference is cleared when the menu closes so staff character creation or loading removes `liaCharacter`
- remove `liaCharacter` menu panel after choosing or creating a staff character so it doesn't persist

## Testing
- `luac -p gamemode/core/derma/mainmenu/character.lua`


------
https://chatgpt.com/codex/tasks/task_e_6898177fd9408327a82b7fe4170f44f9