### PR TITLE
Use lia.information for character load logging

### DIFF
--- a/gamemode/modules/mainmenu/libraries/server.lua
+++ b/gamemode/modules/mainmenu/libraries/server.lua
@@ -1,7 +1,7 @@
 function MODULE:PlayerLiliaDataLoaded(client)
     lia.char.restore(client, function(charList)
         if not IsValid(client) then return end
-        MsgN(L("loadedCharacters", table.concat(charList, ", "), client:Name()))
+        lia.information(L("loadedCharacters", table.concat(charList, ", "), client:Name()))
         for _, v in ipairs(charList) do
             lia.char.getCharacter(v, client, function(character)
                 if character then character:sync(client) end


### PR DESCRIPTION
## Summary
- use `lia.information` when logging loaded characters

## Testing
- `luacheck gamemode/modules/mainmenu/libraries/server.lua`


------
https://chatgpt.com/codex/tasks/task_e_68981f0fd6208327bb355e5fc6d0c28a