### PR TITLE
docs: update currency library documentation

### DIFF
--- a/documentation/docs/libraries/lia.currency.md
+++ b/documentation/docs/libraries/lia.currency.md
@@ -10,11 +10,65 @@ The currency library formats money amounts, spawns physical money entities, and 
 
 ---
 
+### lia.currency.symbol
+
+**Purpose**
+
+Currency symbol prefix retrieved from the `CurrencySymbol` config (empty string by default).
+
+**Realm**
+
+`Shared`
+
+**Example Usage**
+
+```lua
+print(lia.currency.symbol)
+```
+
+---
+
+### lia.currency.singular
+
+**Purpose**
+
+Localized singular currency name from the `CurrencySingularName` config (`currencySingular` by default).
+
+**Realm**
+
+`Shared`
+
+**Example Usage**
+
+```lua
+print(lia.currency.singular)
+```
+
+---
+
+### lia.currency.plural
+
+**Purpose**
+
+Localized plural currency name from the `CurrencyPluralName` config (`currencyPlural` by default).
+
+**Realm**
+
+`Shared`
+
+**Example Usage**
+
+```lua
+print(lia.currency.plural)
+```
+
+---
+
 ### lia.currency.get
 
 **Purpose**
 
-Formats a numeric amount into a currency string using `lia.currency.symbol`, `lia.currency.singular`, and `lia.currency.plural`.
+Formats a numeric amount into a currency string using `lia.currency.symbol`, `lia.currency.singular`, and `lia.currency.plural`. Automatically chooses the singular or plural name based on the amount.
 
 **Parameters**
 
@@ -35,7 +89,8 @@ lia.currency.symbol = "$"
 lia.currency.singular = "dollar"
 lia.currency.plural = "dollars"
 
-print(lia.currency.get(10))
+print(lia.currency.get(1))  -- "$1 dollar"
+print(lia.currency.get(10)) -- "$10 dollars"
 ```
 
 ---
@@ -44,15 +99,15 @@ print(lia.currency.get(10))
 
 **Purpose**
 
-Creates a `lia_money` entity at the specified position with the given amount.
+Spawns a `lia_money` entity at the specified position with the given amount and optional angle. If the position or amount is invalid, `lia.information` is called with a localized error and no entity is created.
 
 **Parameters**
 
 * `pos` (*Vector*): Spawn position for the currency entity.
 
-* `amount` (*number*): Monetary value for the entity.
+* `amount` (*number*): Non-negative monetary value. Rounded to the nearest whole number before assignment.
 
-* `angle` (*Angle*): Orientation of the entity. Optional.
+* `angle` (*Angle*): Orientation of the entity. Defaults to `Angle(0, 0, 0)`. *Optional*.
 
 **Realm**
 
@@ -60,15 +115,16 @@ Creates a `lia_money` entity at the specified position with the given amount.
 
 **Returns**
 
-* *Entity*: The spawned currency entity if successful; `nil` otherwise.
+* *Entity or nil*: The spawned currency entity if successful; `nil` otherwise.
 
 **Example Usage**
 
 ```lua
 local pos = client:GetEyeTrace().HitPos
-local ang = Angle(0, client:EyeAngles().y, 0)
+local money = lia.currency.spawn(pos, 50) -- default angle
 
-local money = lia.currency.spawn(pos, 100, ang)
+local ang = Angle(0, client:EyeAngles().y, 0)
+local money2 = lia.currency.spawn(pos, 100, ang)
 ```
 
 ---


### PR DESCRIPTION
## Summary
- document currency symbol and name fields
- clarify automatic singular/plural formatting and entity spawning behavior

## Testing
- `luacheck gamemode/core/libraries/currency.lua`

------
https://chatgpt.com/codex/tasks/task_e_689828797ad883279fafb60933acd8eb