### PR TITLE
docs: align attributes library documentation

### DIFF
--- a/documentation/docs/libraries/lia.attributes.md
+++ b/documentation/docs/libraries/lia.attributes.md
@@ -6,7 +6,13 @@ This page documents the functions for working with character attributes.
 
 ## Overview
 
-The attributes library loads attribute definitions from Lua files, keeps track of character values, and provides helper methods for modifying them. Each attribute is defined on a global `ATTRIBUTE` table inside its own file. When `lia.attribs.loadFromDir` is called the file is included **shared**, default values are filled in, and the definition is stored in `lia.attribs.list` using the file name (without extension or the `sh_` prefix) as the key. The loader is invoked automatically when a module is initialized, so most schemas simply place their attribute files in `schema/attributes/`.
+The attributes library loads attribute definitions from Lua files, keeps track of character values, and provides helper
+methods for modifying them. Each attribute is defined on a global `ATTRIBUTE` table inside its own file. When
+`lia.attribs.loadFromDir` is called, each file is included in the shared realm, the attribute's name and description are
+localized (defaulting to `L("unknown")` and `L("noDesc")` when absent), and the definition is stored in `lia.attribs.list`
+using the file name without extension as the key. Files beginning with `sh_` have the prefix removed and the key
+lowercased. The loader is invoked automatically when a module is initialized, so most schemas simply place their
+attribute files in `schema/attributes/`.
 
 For details on each `ATTRIBUTE` field, see the [Attribute Fields documentation](../definitions/attribute.md).
 
@@ -14,7 +20,7 @@ For details on each `ATTRIBUTE` field, see the [Attribute Fields documentation](
 
 **Purpose**
 
-Loads attribute definitions from every Lua file in the given directory and registers them in `lia.attribs.list`.
+Loads attribute definitions from each Lua file in the given directory, localizes their `name` and `desc` fields, and registers them in `lia.attribs.list`. Filenames supply the list key—if a file begins with `sh_`, the prefix is stripped and the key is lowercased. Missing `name` or `desc` fields default to `L("unknown")` and `L("noDesc")`.
 
 **Parameters**
 
@@ -51,7 +57,7 @@ lia.attribs.loadFromDir("schema/attributes")
 
 **Purpose**
 
-Initializes and refreshes attribute data for a player's character, invoking any `OnSetup` callbacks defined by individual attributes.
+Initializes and refreshes attribute data for a player's character by looping through `lia.attribs.list`. For each attribute it retrieves the character's value (defaulting to 0) and calls the attribute's `OnSetup` callback if present. If the client has no character, the function returns without doing anything.
 
 **Parameters**
 

--- a/gamemode/core/libraries/attributes.lua
+++ b/gamemode/core/libraries/attributes.lua
@@ -1,39 +1,6 @@
-﻿--[[
-# Attributes Library
-
-This page documents the functions for working with character attributes.
-
----
-
-## Overview
-
-The attributes library loads attribute definitions from Lua files, keeps track of character values, and provides helper methods for modifying them. Each attribute is defined on a global `ATTRIBUTE` table inside its own file. When `lia.attribs.loadFromDir` is called the file is included **shared**, default values are filled in, and the definition is stored in `lia.attribs.list` using the file name (without extension or the `sh_` prefix) as the key. The loader is invoked automatically when a module is initialized, so most schemas simply place their attribute files in `schema/attributes/`.
-
-For details on each `ATTRIBUTE` field, see the [Attribute Fields documentation](../definitions/attribute.md).
-]]
 lia.attribs = lia.attribs or {}
 lia.attribs.list = lia.attribs.list or {}
---[[
-    lia.attribs.loadFromDir
 
-    Purpose:
-        Loads all attribute definition files from the specified directory, registering them into lia.attribs.list.
-        Each attribute file should define an ATTRIBUTE table. This function ensures the attribute's name and description
-        are localized, and stores the attribute in the global attribute list.
-
-    Parameters:
-        directory (string) - The directory path to search for attribute files (should be relative to the gamemode).
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Load all attributes from the "attributes" directory
-        lia.attribs.loadFromDir("gamemode/schema/attributes")
-]]
 function lia.attribs.loadFromDir(directory)
     for _, v in ipairs(file.Find(directory .. "/*.lua", "LUA")) do
         local niceName = v:sub(1, 3) == "sh_" and v:sub(4, -5):lower() or v:sub(1, -5)
@@ -47,28 +14,6 @@ function lia.attribs.loadFromDir(directory)
 end
 
 if SERVER then
-    --[[
-        lia.attribs.setup
-
-        Purpose:
-            Sets up all attributes for a given client by invoking the OnSetup callback for each attribute, if defined.
-            This is typically called when a character is loaded or respawned, to apply attribute effects.
-
-        Parameters:
-            client (Player) - The player entity whose attributes should be set up.
-
-        Returns:
-            None.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            -- Setup attributes for a player after character load
-            hook.Add("PlayerLoadedChar", "SetupAttributes", function(client)
-                lia.attribs.setup(client)
-            end)
-    ]]
     function lia.attribs.setup(client)
         local character = client:getChar()
         if not character then return end
@@ -78,3 +23,4 @@ if SERVER then
         end
     end
 end
+


### PR DESCRIPTION
## Summary
- remove outdated comment block from attributes library
- document attribute loading and setup behavior including localization and defaults

## Testing
- `luacheck gamemode/core/libraries/attributes.lua`
- `markdownlint documentation/docs/libraries/lia.attributes.md` *(fails: MD013 line-length, MD036 no-emphasis-as-heading)*

------
https://chatgpt.com/codex/tasks/task_e_6898286bdca4832798a3a90bb27a6f39