### PR TITLE
docs: sync library docs with code

### DIFF
--- a/documentation/docs/libraries/lia.attributes.md
+++ b/documentation/docs/libraries/lia.attributes.md
@@ -6,8 +6,7 @@ This page documents the functions for working with character attributes.
 
 ## Overview
 
-The attributes library loads attribute definitions from Lua files, keeps track of character values, and provides helper
-methods for modifying them. Each attribute is defined on a global `ATTRIBUTE` table inside its own file. When
+The attributes library loads attribute definitions from Lua files and provides helpers for initializing them on a character. Each attribute is defined on a global `ATTRIBUTE` table inside its own file. When
 `lia.attribs.loadFromDir` is called, each file is included in the shared realm, the attribute's name and description are
 localized (defaulting to `L("unknown")` and `L("noDesc")` when absent), and the definition is stored in `lia.attribs.list`
 using the file name without extension as the key. Files beginning with `sh_` have the prefix removed and the key

--- a/documentation/docs/libraries/lia.bars.md
+++ b/documentation/docs/libraries/lia.bars.md
@@ -57,7 +57,7 @@ If the identifier matches an existing bar, the old bar is removed first. Bars ar
 
 * `getValue` (*function*): Callback returning the bar's current value between 0 and 1.
 
-* `color` (*Color*): Fill colour for the bar. Defaults to a random pastel colour.
+* `color` (*Color*): Fill colour for the bar. Defaults to a random bright colour with each channel between 150 and 255.
 
 * `priority` (*number*): Draw order; lower values draw first. Defaults to end of list.
 
@@ -124,9 +124,9 @@ Draws a single horizontal bar at the specified screen coordinates, filling it pr
 
 * `y` (*number*): The y-coordinate of the bar’s top-left corner.
 
-* `w` (*number*): Width of the bar's fill area (padding of 3px is added on each side).
+* `w` (*number*): Usable width of the bar. The background panel is drawn six pixels wider to include a 3px border on each side.
 
-* `h` (*number*): Total height of the bar.
+* `h` (*number*): Total height of the bar, including the 3px border at the top and bottom.
 
 * `pos` (*number*): Current value to display (clamped to `max`).
 

--- a/documentation/docs/libraries/lia.chatbox.md
+++ b/documentation/docs/libraries/lia.chatbox.md
@@ -70,11 +70,11 @@ Registers a new chat class and sets up its command aliases.
 
 * `data` (*table*): Table of chat class properties.
 
-  * `arguments` (table) – Ordered argument definitions for the associated command.
+  * `arguments` (table) – Ordered argument definitions for the associated command. Defaults to an empty table.
 
-  * `desc` (string) – Description of the command shown in menus.
+  * `desc` (string) – Description of the command shown in menus. Defaults to an empty string.
 
-  * `prefix` (string | table) – Command prefixes that trigger this chat type. Slashless
+  * `prefix` (string | table) – Command prefixes that trigger this chat type. Duplicate prefixes are ignored and slashless
     variants are automatically added.
 
   * `radius` (number | function) – Hearing range or custom range logic. Used to
@@ -99,6 +99,10 @@ Registers a new chat class and sets up its command aliases.
   * `noSpaceAfter` (boolean) – Allows prefixes without a trailing space.
 
   * `deadCanChat` (boolean) – Permits dead players to use the chat type.
+
+  * `syntax` (string) – Automatically generated from `arguments` using `lia.command.buildSyntaxFromArguments` and localised with `L`.
+
+On the client, any defined prefixes are registered as command aliases via `lia.command.add` so they can be typed directly into chat.
 
 **Realm**
 
@@ -174,7 +178,9 @@ end)
 
 Broadcasts a chat message to all eligible receivers.
 It respects the chat class's `onCanSay` and `onCanHear` logic and passes text
-through the `PlayerMessageSend` hook before networking.
+through the `PlayerMessageSend` hook before networking. If `receivers` is not
+provided, a recipient list is built from players that satisfy `onCanHear`. If
+that list ends up empty, the message is discarded.
 
 **Parameters**
 

--- a/documentation/docs/libraries/lia.color.md
+++ b/documentation/docs/libraries/lia.color.md
@@ -44,7 +44,7 @@ local c = lia.color.stored.myPurple
 
 **Purpose**
 
-Creates a new `Color` based on the input color with the given channel offsets. Each component is clamped between 0 and 255. If the base color lacks an alpha channel, `255` is assumed. `aOffset` defaults to `0`.
+Creates a new `Color` based on the input color with the given channel offsets. `rOffset`, `gOffset`, and `bOffset` must be numbers. Each component is clamped between 0 and 255. If the base color lacks an alpha channel, `255` is assumed. `aOffset` defaults to `0`.
 
 **Parameters**
 
@@ -82,7 +82,7 @@ local moreOpaque = lia.color.Adjust(lia.color.stored.blue, 0, 0, 0, 50)
 
 **Purpose**
 
-Builds and returns a UI palette derived from the config’s base color.
+Builds and returns a UI palette derived from the config’s base color obtained via `lia.config.get("Color")`.
 
 **Parameters**
 


### PR DESCRIPTION
## Summary
- Documented color channel offset requirements and palette source
- Clarified bar API defaults and dimensions
- Expanded chatbox library documentation and receivers handling
- Tidy attributes library overview

## Testing
- `luacheck gamemode/core/libraries/color.lua gamemode/core/libraries/bars.lua gamemode/core/libraries/chatbox.lua gamemode/core/libraries/attributes.lua` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: Unable to locate package luacheck)*

------
https://chatgpt.com/codex/tasks/task_e_68982f05eb448327875f0e65a43a9633