### PR TITLE
docs: update currency library docs

### DIFF
--- a/documentation/docs/libraries/lia.currency.md
+++ b/documentation/docs/libraries/lia.currency.md
@@ -6,7 +6,7 @@ This page covers money and currency related helpers.
 
 ## Overview
 
-The currency library formats money amounts, spawns physical money entities, and exposes the configured currency names. The symbol and name values come from the configuration options defined in `gamemode/core/libraries/config.lua`.
+The currency library formats money amounts, spawns physical money entities, and exposes the configured currency names. The symbol and name values come from the configuration options `CurrencySymbol`, `CurrencySingularName`, and `CurrencyPluralName` defined in `gamemode/core/libraries/config.lua`.
 
 ---
 
@@ -32,7 +32,7 @@ print(lia.currency.symbol)
 
 **Purpose**
 
-Localized singular currency name from the `CurrencySingularName` config (`currencySingular` by default).
+Localized singular currency name from the `CurrencySingularName` config (defaults to localization key `currencySingular`).
 
 **Realm**
 
@@ -50,7 +50,7 @@ print(lia.currency.singular)
 
 **Purpose**
 
-Localized plural currency name from the `CurrencyPluralName` config (`currencyPlural` by default).
+Localized plural currency name from the `CurrencyPluralName` config (defaults to localization key `currencyPlural`).
 
 **Realm**
 
@@ -68,11 +68,11 @@ print(lia.currency.plural)
 
 **Purpose**
 
-Formats a numeric amount into a currency string using `lia.currency.symbol`, `lia.currency.singular`, and `lia.currency.plural`. Automatically chooses the singular or plural name based on the amount.
+Formats a numeric amount into a currency string using `lia.currency.symbol`, `lia.currency.singular`, and `lia.currency.plural`. Uses the singular name only when the amount is exactly `1`; all other values use the plural name.
 
 **Parameters**
 
-* `amount` (*number*): Amount to format.
+* `amount` (*number*): Amount to format. No rounding or validation is performed.
 
 **Realm**
 
@@ -91,6 +91,7 @@ lia.currency.plural = "dollars"
 
 print(lia.currency.get(1))  -- "$1 dollar"
 print(lia.currency.get(10)) -- "$10 dollars"
+print(lia.currency.get(0))  -- "$0 dollars"
 ```
 
 ---
@@ -99,7 +100,7 @@ print(lia.currency.get(10)) -- "$10 dollars"
 
 **Purpose**
 
-Spawns a `lia_money` entity at the specified position with the given amount and optional angle. If the position or amount is invalid, `lia.information` is called with a localized error and no entity is created.
+Spawns a `lia_money` entity at the specified position with the given amount and optional angle. If `pos` is missing or `amount` is `nil` or negative, `lia.information` is called with a localized error and no entity is created.
 
 **Parameters**
 
@@ -107,7 +108,7 @@ Spawns a `lia_money` entity at the specified position with the given amount and 
 
 * `amount` (*number*): Non-negative monetary value. Rounded to the nearest whole number before assignment.
 
-* `angle` (*Angle*): Orientation of the entity. Defaults to `Angle(0, 0, 0)`. *Optional*.
+* `angle` (*Angle*): Orientation of the entity. Defaults to `angle_zero` (`Angle(0, 0, 0)`). *Optional*.
 
 **Realm**
 

--- a/gamemode/core/libraries/currency.lua
+++ b/gamemode/core/libraries/currency.lua
@@ -1,73 +1,13 @@
-﻿--[[
-# Currency Library
-
-This page documents the functions for working with currency and money systems.
-
----
-
-## Overview
-
-The currency library provides utilities for managing currency and money systems within the Lilia framework. It handles currency formatting, money entity spawning, and provides functions for working with currency amounts and symbols. The library supports configurable currency symbols and names, and provides utilities for creating and managing money entities in the world.
-]]
 lia.currency = lia.currency or {}
 lia.currency.symbol = lia.config.get("CurrencySymbol", "")
 lia.currency.singular = L(lia.config.get("CurrencySingularName", "currencySingular"))
 lia.currency.plural = L(lia.config.get("CurrencyPluralName", "currencyPlural"))
---[[
-    lia.currency.get
 
-    Purpose:
-        Returns a formatted string representing the given amount of currency, using the configured symbol and singular/plural names.
-        Handles proper singular/plural grammar based on the amount.
-
-    Parameters:
-        amount (number) - The amount of currency to format.
-
-    Returns:
-        string - The formatted currency string (e.g., "$1 Dollar" or "$5 Dollars").
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Get a string for 1 unit of currency
-        local single = lia.currency.get(1) -- "$1 Dollar"
-
-        -- Get a string for 50 units of currency
-        local multi = lia.currency.get(50) -- "$50 Dollars"
-]]
 function lia.currency.get(amount)
     return lia.currency.symbol .. (amount == 1 and "1 " .. lia.currency.singular or amount .. " " .. lia.currency.plural)
 end
 
 if SERVER then
-    --[[
-        lia.currency.spawn
-
-        Purpose:
-            Spawns a money entity at the specified position with the given amount and optional angle.
-            Notifies if the position or amount is invalid.
-
-        Parameters:
-            pos (Vector)      - The position to spawn the money entity.
-            amount (number)   - The amount of currency to assign to the entity.
-            angle (Angle)     - (Optional) The angle to set for the entity (defaults to angle_zero).
-
-        Returns:
-            Entity - The spawned money entity, or nil if invalid parameters.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            -- Spawn $100 at a specific position and angle
-            local pos = Vector(100, 200, 300)
-            local ang = Angle(0, 90, 0)
-            local moneyEnt = lia.currency.spawn(pos, 100, ang)
-
-            -- Spawn $50 at a position with default angle
-            local moneyEnt2 = lia.currency.spawn(Vector(0, 0, 0), 50)
-    ]]
     function lia.currency.spawn(pos, amount, angle)
         if not pos then
             lia.information(L("invalidCurrencyPosition"))
@@ -84,3 +24,4 @@ if SERVER then
         end
     end
 end
+


### PR DESCRIPTION
## Summary
- document currency configuration options and pluralisation behavior
- clarify spawn validation and defaults
- drop outdated inline docs from `currency.lua`

## Testing
- `luacheck gamemode/core/libraries/currency.lua` *(fails: mutating non-standard globals, undefined variables)*

------
https://chatgpt.com/codex/tasks/task_e_6898362385708327acdb4f1265bc3f5d