### PR TITLE
docs: clarify attributes library

### DIFF
--- a/documentation/docs/libraries/lia.attributes.md
+++ b/documentation/docs/libraries/lia.attributes.md
@@ -7,10 +7,11 @@ This page documents the functions for working with character attributes.
 ## Overview
 
 The attributes library loads attribute definitions from Lua files and provides helpers for initializing them on a character. Each attribute is defined on a global `ATTRIBUTE` table inside its own file. When
-`lia.attribs.loadFromDir` is called, each file is included in the shared realm, the attribute's name and description are
-localized (defaulting to `L("unknown")` and `L("noDesc")` when absent), and the definition is stored in `lia.attribs.list`
+`lia.attribs.loadFromDir` is called, each file is included in the shared realm, the attribute's `name` and `desc` fields are
+replaced with their translated versions (defaulting to `L("unknown")` and `L("noDesc")` when absent), and the definition is stored in `lia.attribs.list`
 using the file name without extension as the key. Files beginning with `sh_` have the prefix removed and the key
-lowercased. The loader is invoked automatically when a module is initialized, so most schemas simply place their
+lowercased. If an attribute was already registered, its existing table is reused, allowing definitions to be extended across
+multiple files or reloads. The loader is invoked automatically when a module is initialized, so most schemas simply place their
 attribute files in `schema/attributes/`.
 
 For details on each `ATTRIBUTE` field, see the [Attribute Fields documentation](../definitions/attribute.md).
@@ -19,7 +20,7 @@ For details on each `ATTRIBUTE` field, see the [Attribute Fields documentation](
 
 **Purpose**
 
-Loads attribute definitions from each Lua file in the given directory, localizes their `name` and `desc` fields, and registers them in `lia.attribs.list`. Filenames supply the list key—if a file begins with `sh_`, the prefix is stripped and the key is lowercased. Missing `name` or `desc` fields default to `L("unknown")` and `L("noDesc")`.
+Loads attribute definitions from each Lua file in the given directory, localizes their `name` and `desc` fields, and registers them in `lia.attribs.list`. Filenames supply the list key—if a file begins with `sh_`, the prefix is stripped and the key is lowercased. If the attribute was previously registered, the existing table is reused. Missing `name` or `desc` fields default to `L("unknown")` and `L("noDesc")`.
 
 **Parameters**
 
@@ -56,7 +57,7 @@ lia.attribs.loadFromDir("schema/attributes")
 
 **Purpose**
 
-Initializes and refreshes attribute data for a player's character by looping through `lia.attribs.list`. For each attribute it retrieves the character's value (defaulting to 0) and calls the attribute's `OnSetup` callback if present. If the client has no character, the function returns without doing anything.
+Initializes or refreshes attribute data for a player's character by looping through `lia.attribs.list`. For each attribute it retrieves the character's value (defaulting to 0) and, if the attribute defines `OnSetup`, calls it as `attribute:OnSetup(client, value)`. If the client has no character, the function returns without doing anything.
 
 **Parameters**
 


### PR DESCRIPTION
## Summary
- document how `lia.attribs.loadFromDir` reuses existing tables and translates `name`/`desc`
- clarify that `lia.attribs.setup` invokes `OnSetup` with the client and attribute value

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898361775288327aacafa366d710d56