### PR TITLE
docs: document DarkRP map keyvalues

### DIFF
--- a/documentation/docs/libraries/lia.darkrp.md
+++ b/documentation/docs/libraries/lia.darkrp.md
@@ -227,3 +227,34 @@ lia.darkrp.createCategory()
 ```
 
 ---
+
+### Map KeyValue Compatibility
+
+**Purpose**
+
+Processes select DarkRP-specific key-values on door entities so maps configured for DarkRP behave as expected.
+
+**Handled KeyValues**
+
+* `DarkRPNonOwnable`: marks the door as unsellable by setting the `noSell` network variable.
+* `DarkRPTitle`: sets the door's display name.
+* `DarkRPCanLockpick`: when set to a truthy value, prevents lockpicking by setting the `noPick` flag.
+
+**Realm**
+
+`Server`
+
+**Returns**
+
+* *nil*: This hook runs automatically and does not return a value.
+
+**Example Usage**
+
+Add the key-values below to a door entity in Hammer:
+
+```text
+"DarkRPTitle" "Police Armory"
+"DarkRPNonOwnable" "1"
+```
+
+---


### PR DESCRIPTION
## Summary
- document handled DarkRP map keyvalues for door compatibility
- expand DarkRP compatibility docs

## Testing
- `luacheck gamemode/core/libraries/darkrp.lua`

------
https://chatgpt.com/codex/tasks/task_e_6898364acd048327b1e91e49520db758