### PR TITLE
docs: update color library

### DIFF
--- a/documentation/docs/libraries/lia.color.md
+++ b/documentation/docs/libraries/lia.color.md
@@ -6,7 +6,7 @@ This page lists helper functions for working with colors.
 
 ## Overview
 
-The color library centralizes color utilities used throughout the UI. It provides helpers for registering reusable colors, adjusting their channels to create variants, and fetching the main palette from the configuration. Many common color names are pre-registered and stored in `lia.color.stored`.
+The color library centralizes color utilities used throughout the UI. It provides helpers for registering reusable colors, adjusting their channels to create variants, and fetching the main palette from the configuration. Many common color names are pre-registered and stored in `lia.color.stored`. Registered names can also be passed to the client-side global `Color` function to retrieve the corresponding color (unknown names return pure white).
 
 ---
 
@@ -34,8 +34,8 @@ Registers a named color for later lookup by string name.
 
 ```lua
 -- Register a custom purple shade and fetch it later
-lia.color.register("myPurple", { 128, 0, 180 })
-local c = lia.color.stored.myPurple
+lia.color.register("myPurple", {128, 0, 180})
+local c = lia.color.stored.mypurple
 ```
 
 ---


### PR DESCRIPTION
## Summary
- clarify that registered color names can be retrieved using the client-side global `Color` function
- mark all color library helpers as client-side

## Testing
- `npm test` (fails: ENOENT could not read package.json)
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898363539808327b4cb049a9adf6a99