### PR TITLE
docs: sync commands library docs with code

### DIFF
--- a/documentation/docs/libraries/lia.commands.md
+++ b/documentation/docs/libraries/lia.commands.md
@@ -14,7 +14,7 @@ The commands library registers console and chat commands. It parses arguments, c
 
 **Purpose**
 
-Generates a human-readable syntax string from a command's argument definitions.
+Generates a human-readable syntax string from a command's argument definitions. Each argument's `type` is normalized to `string`, `player`, `table`, or `bool` (`boolean` maps to `bool`).
 
 **Parameters**
 
@@ -222,7 +222,7 @@ Attempts to parse the input text as a slash command. When `realCommand` and `arg
 
 **Returns**
 
-* *boolean*: `true` if the text was parsed as a valid command, `false` otherwise.
+* *boolean*: `true` if the text was treated as a command (even if unknown), `false` otherwise.
 
 **Example Usage**
 

--- a/gamemode/core/libraries/commands.lua
+++ b/gamemode/core/libraries/commands.lua
@@ -1,14 +1,3 @@
-﻿--[[
-# Attributes Library
-
-This page documents the functions for working with console commands and command registration.
-
----
-
-## Overview
-
-The commands library provides a system for registering and managing console commands within the Lilia framework. It handles command registration, privilege checking, aliases, and provides a unified interface for command execution. The library supports both client and server-side commands with proper access control and privilege management.
-]]
 lia.command = lia.command or {}
 lia.command.list = lia.command.list or {}
 function lia.command.buildSyntaxFromArguments(args)
@@ -32,45 +21,6 @@ function lia.command.buildSyntaxFromArguments(args)
     return table.concat(tokens, " ")
 end
 
---[[
-    lia.command.add
-
-    Purpose:
-        Registers a new command with the Lilia command system. This function sets up the command's argument definitions,
-        description, privilege requirements, and access control. It also handles command aliases and ensures the command is
-        accessible via the appropriate privilege level.
-
-    Parameters:
-        command (string) - The name of the command to register.
-        data (table) - A table containing command properties:
-            - arguments (table): Ordered argument definitions for the command (optional).
-            - desc (string): The description of the command (optional).
-            - privilege (string): The privilege required to use the command (optional).
-            - superAdminOnly (boolean): If true, only superadmins can use the command (optional).
-            - adminOnly (boolean): If true, only admins can use the command (optional).
-            - alias (string/table): Aliases for the command (optional).
-            - onRun (function): The function to execute when the command is run (required).
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        lia.command.add("kick", {
-            arguments = {
-                {name = "target", type = "player"},
-                {name = "reason", type = "string", optional = true}
-            },
-            desc = "Kicks a player from the server.",
-            privilege = "Kick Players",
-            adminOnly = true,
-            onRun = function(client, arguments)
-                -- Implementation here
-            end
-        })
-]]
 function lia.command.add(command, data)
     data.arguments = data.arguments or {}
     data.syntax = lia.command.buildSyntaxFromArguments(data.arguments)
@@ -137,31 +87,6 @@ function lia.command.add(command, data)
     hook.Run("liaCommandAdded", command, data)
 end
 
---[[
-    lia.command.hasAccess
-
-    Purpose:
-        Determines whether a client has access to a specific command, based on privilege, admin level,
-        faction/class command whitelists, and hooks.
-
-    Parameters:
-        client (Player) - The player to check access for.
-        command (string) - The command name.
-        data (table) - (Optional) The command data table. If not provided, it will be looked up.
-
-    Returns:
-        hasAccess (boolean) - Whether the client has access to the command.
-        privilegeName (string) - The privilege name or access description.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local canUse, privilege = lia.command.hasAccess(ply, "kick")
-        if canUse then
-            print("Player can use /kick with privilege:", privilege)
-        end
-]]
 function lia.command.hasAccess(client, command, data)
     if not data then data = lia.command.list[command] end
     if not data then return false, "unknown" end
@@ -184,25 +109,6 @@ function lia.command.hasAccess(client, command, data)
     return hasAccess, privilegeName
 end
 
---[[
-    lia.command.extractArgs
-
-    Purpose:
-        Parses a command argument string into a table of arguments, handling quoted strings as single arguments.
-
-    Parameters:
-        text (string) - The raw argument string to parse.
-
-    Returns:
-        arguments (table) - A table of parsed arguments.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local args = lia.command.extractArgs('John "This is a reason" 123')
-        -- args = {"John", "This is a reason", "123"}
-]]
 function lia.command.extractArgs(text)
     local skip = 0
     local arguments = {}
@@ -262,27 +168,8 @@ local function isPlaceholder(arg)
 end
 
 if SERVER then
-    --[[
-        lia.command.run
+    
 
-        Purpose:
-            Executes a registered command for a given client with the provided arguments. Handles notification of results
-            and logs the command execution.
-
-        Parameters:
-            client (Player) - The player executing the command.
-            command (string) - The command name.
-            arguments (table) - (Optional) Table of arguments to pass to the command.
-
-        Returns:
-            None.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            lia.command.run(ply, "kick", {"STEAM_0:1:12345", "Spamming"})
-    ]]
     function lia.command.run(client, command, arguments)
         local commandTbl = lia.command.list[command:lower()]
         if commandTbl then
@@ -303,28 +190,8 @@ if SERVER then
         end
     end
 
-    --[[
-        lia.command.parse
+    
 
-        Purpose:
-            Parses a chat message or command string, determines the command and its arguments, and executes it.
-            Handles argument prompting for missing required arguments.
-
-        Parameters:
-            client (Player) - The player who sent the command.
-            text (string) - The raw chat or command string.
-            realCommand (string) - (Optional) The command name if already extracted.
-            arguments (table) - (Optional) Arguments if already parsed.
-
-        Returns:
-            (boolean) - True if a command was found and processed, false otherwise.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            lia.command.parse(ply, "/kick John Spamming")
-    ]]
     function lia.command.parse(client, text, realCommand, arguments)
         if realCommand or utf8.sub(text, 1, 1) == "/" then
             local match = realCommand or text:lower():match("/" .. "([_%w]+)")
@@ -376,28 +243,8 @@ if SERVER then
         return false
     end
 else
-    --[[
-        lia.command.openArgumentPrompt
+    
 
-        Purpose:
-            Opens a GUI prompt for the player to fill in missing command arguments, based on the command's syntax.
-            Used when a command is invoked without all required arguments.
-
-        Parameters:
-            cmdKey (string) - The command name.
-            fields (table/string) - Table of missing fields or argument string.
-            prefix (table) - (Optional) Arguments already provided.
-
-        Returns:
-            None.
-
-        Realm:
-            Client.
-
-        Example Usage:
-            -- Opens a prompt for the "ban" command, requiring a player and duration
-            lia.command.openArgumentPrompt("ban", {player = "player", duration = "number"})
-    ]]
     function lia.command.openArgumentPrompt(cmdKey, missing, prefix)
         local command = lia.command.list[cmdKey]
         if not command then return end
@@ -607,25 +454,8 @@ else
         end
     end
 
-    --[[
-        lia.command.send
+    
 
-        Purpose:
-            Sends a command and its arguments to the server via net message, for execution as if the player had typed it.
-
-        Parameters:
-            command (string) - The command name.
-            ... (vararg) - Arguments to send with the command.
-
-        Returns:
-            None.
-
-        Realm:
-            Client.
-
-        Example Usage:
-            lia.command.send("kick", "STEAM_0:1:12345", "Spamming")
-    ]]
     function lia.command.send(command, ...)
         net.Start("cmd")
         net.WriteString(command)


### PR DESCRIPTION
## Summary
- document argument type normalization for `buildSyntaxFromArguments`
- clarify command parsing return behavior
- remove outdated inline docs from commands library

## Testing
- `luacheck gamemode/core/libraries/commands.lua`

------
https://chatgpt.com/codex/tasks/task_e_68983626d8a48327b90483685c11e23c