### PR TITLE
docs: sync logger library docs with implementation

### DIFF
--- a/documentation/docs/libraries/lia.logger.md
+++ b/documentation/docs/libraries/lia.logger.md
@@ -1,42 +1,14 @@
 # Logger Library
 
-This page documents logging utilities.
+This page documents the functions for working with Lilia's logging and audit system.
 
 ---
 
 ## Overview
 
-The logger library writes structured log entries to the console and to the `lia_logs` SQL table (gamemode, category, text, character ID, SteamID). Built-in log types live in `gamemode/modules/administration/submodules/logging/logs.lua`; custom types can be added with `lia.log.addType`.
+The logger library records structured log entries to the console and to the `logs` SQL table (timestamp, gamemode, category, message, character ID, SteamID). Built‑in log types are defined in `lia.log.types` within `gamemode/core/libraries/logger.lua`; custom types can be registered with `lia.log.addType`.
 
-Each database row stores the timestamp, SteamID, and (if relevant) character ID so that every entry can be associated with a specific player.
-
----
-
-### lia.log.loadTables
-
-**Purpose**
-
-Initialises the logging system.
-
-**Parameters**
-
-* *None*
-
-**Realm**
-
-`Server`
-
-**Returns**
-
-* *nil*: This function does not return a value.
-
-**Example Usage**
-
-```lua
-hook.Add("DatabaseConnected", "LoadLogs", function()
-    lia.log.loadTables()
-end)
-```
+Each database row stores the timestamp, SteamID and, when applicable, the character ID so that every entry can be associated with a specific player.
 
 ---
 
@@ -44,7 +16,7 @@ end)
 
 **Purpose**
 
-Registers a log type by supplying a generator function and a category.
+Registers a log type by supplying a generator function and a category. Existing types with the same identifier are overwritten.
 
 **Parameters**
 
@@ -82,11 +54,11 @@ lia.log.add(client, "mytype", "a backflip")
 
 **Purpose**
 
-Returns the formatted log string (and its category) for a given type without writing anything.
+Returns the formatted log string (and its category) for a given type without writing anything. If the type is unknown or the generator function errors, `nil` is returned.
 
 **Parameters**
 
-* `client` (*Player*): Player tied to the entry.
+* `client` (*Player* or *nil*): Player tied to the entry (optional for server events).
 
 * `logType` (*string*): Log-type identifier.
 
@@ -98,7 +70,7 @@ Returns the formatted log string (and its category) for a given type without wri
 
 **Returns**
 
-* *string*, *string*: Log text and its category, or `nil`.
+* *string*, *string*: Log text and its category, or `nil` if the log type is invalid.
 
 **Example Usage**
 
@@ -113,11 +85,11 @@ print(cat .. ": " .. text)
 
 **Purpose**
 
-Creates a log entry, fires `OnServerLog`, prints to console, and inserts into `lia_logs`.
+Creates a log entry, fires `OnServerLog`, prints to console, and inserts into the `logs` table together with the player's SteamID and character ID (when available). If the log type is unknown or the generator fails, nothing is written. Missing or non-string categories fall back to the localized string for "uncategorized".
 
 **Parameters**
 
-* `client` (*Player*): Player associated with the event.
+* `client` (*Player* or *nil*): Player associated with the event (optional).
 
 * `logType` (*string*): Log-type identifier.
 
@@ -138,7 +110,5 @@ hook.Add("PlayerDeath", "ExampleDeathLog", function(victim, attacker)
     lia.log.add(victim, "playerDeath", attacker)
 end)
 ```
-
----
 
 ---


### PR DESCRIPTION
## Summary
- remove obsolete `lia.log.loadTables` section
- clarify logging storage in `logs` table and mention `lia.log.types`
- document edge cases and defaults for `lia.log.addType`, `lia.log.getString`, and `lia.log.add`

## Testing
- `luac -p gamemode/core/libraries/logger.lua` *(fails: unexpected symbol near '')*


------
https://chatgpt.com/codex/tasks/task_e_689837c045cc8327a70e7d5f17c4fba6