### PR TITLE
docs: update notice library documentation

### DIFF
--- a/documentation/docs/libraries/lia.notice.md
+++ b/documentation/docs/libraries/lia.notice.md
@@ -6,7 +6,7 @@ This page describes how popup notices are displayed.
 
 ## Overview
 
-The notice library displays temporary popup notifications at the top of the player’s screen. Server functions send network messages to clients, which create `liaNotice` panels client-side. These panels are stored in `lia.notices` and automatically expire about 7.5 seconds after creation.
+The notice library displays temporary popup notifications at the top‑right of the player’s screen. Server functions send network messages to clients, which create `liaNotice` panels client-side. These panels are stored in `lia.notices`, repositioned to stack, play a short sound on appearance and automatically expire roughly 7.75 seconds after creation.
 
 ---
 
@@ -54,7 +54,7 @@ Sends a localised notice. If `recipient` is not a `Player`, it is treated as the
 
 * `recipient` (*Player | nil*): Target player, or first format argument if not a `Player`.
 
-* … (*any*): Additional `string.format` values.
+* … (*any*): Additional `string.format` values, converted to strings for transmission.
 
 **Realm**
 
@@ -80,7 +80,7 @@ lia.notices.notifyLocalized("questFoundItem", nil, "golden_key")
 
 **Purpose**
 
-Creates a `liaNotice` panel on the local client. The notice fades after \~7.5 seconds.
+Creates a `liaNotice` panel on the local client, prints the message to console, plays `garrysmod/content_downloaded.wav` shortly after, stacks it with existing notices and removes it about 7.75 seconds later.
 
 **Parameters**
 
@@ -110,7 +110,7 @@ lia.notices.notify("Welcome back!")
 
 **Purpose**
 
-Translates a localisation key with `L` and shows the result on the local client.
+Translates `key` with `L(key, …)` and displays the result on the local client using `lia.notices.notify`.
 
 **Parameters**
 

--- a/gamemode/core/libraries/notice.lua
+++ b/gamemode/core/libraries/notice.lua
@@ -1,39 +1,4 @@
-﻿--[[
-# Notice Library
-
-This page documents the functions for working with notification systems and user feedback.
-
----
-
-## Overview
-
-The notice library provides a system for displaying notifications and messages to players within the Lilia framework. It handles both localized and non-localized notifications, supports different display styles, and provides utilities for sending notices to individual players or broadcasting to all players. The library manages notice positioning and timing on the client side.
-]]
 if SERVER then
-    --[[
-        lia.notices.notify
-
-        Purpose:
-            Sends a notification message to a specific player or broadcasts it to all players.
-            The message will be displayed as a notice on the client(s).
-
-        Parameters:
-            message (string)   - The message to display.
-            recipient (Player) - (Optional) The player to send the notice to. If nil, broadcasts to all players.
-
-        Returns:
-            None.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            -- Send a notice to a specific player
-            lia.notices.notify("You have received a new item!", ply)
-
-            -- Broadcast a notice to all players
-            lia.notices.notify("The server will restart in 5 minutes!")
-    ]]
     function lia.notices.notify(message, recipient)
         net.Start("liaNotify")
         net.WriteString(message)
@@ -44,31 +9,6 @@ if SERVER then
         end
     end
 
-    --[[
-        lia.notices.notifyLocalized
-
-        Purpose:
-            Sends a localized notification to a specific player or broadcasts it to all players.
-            The message is looked up using a localization key and optional arguments.
-
-        Parameters:
-            key (string)         - The localization key for the message.
-            recipient (Player)   - (Optional) The player to send the notice to. If not a Player, treated as an argument.
-            ... (vararg)         - Additional arguments to format into the localized message.
-
-        Returns:
-            None.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            -- Send a localized notice to a specific player
-            lia.notices.notifyLocalized("itemReceived", ply, "Health Kit")
-
-            -- Broadcast a localized notice to all players
-            lia.notices.notifyLocalized("serverRestartWarning", "5 minutes")
-    ]]
     function lia.notices.notifyLocalized(key, recipient, ...)
         local args = {...}
         if recipient and type(recipient) ~= "Player" then
@@ -97,29 +37,6 @@ else
         end
     end
 
-    --[[
-        lia.notices.notify
-
-        Purpose:
-            Displays a notification message on the client's screen as a notice.
-            The notice will animate in, play a sound, and disappear after a set time.
-
-        Parameters:
-            message (string) - The message to display.
-
-        Returns:
-            None.
-
-        Realm:
-            Client.
-
-        Example Usage:
-            -- Show a notice to the local player
-            lia.notices.notify("You have joined the server!")
-
-            -- Show a notice with a dynamic message
-            lia.notices.notify("Welcome, " .. LocalPlayer():Nick() .. "!")
-    ]]
     function lia.notices.notify(message)
         local notice = vgui.Create("liaNotice")
         local i = table.insert(lia.notices, notice)
@@ -149,54 +66,12 @@ else
         MsgN(message)
     end
 
-    --[[
-        lia.notices.notifyLocalized
-
-        Purpose:
-            Displays a localized notification message on the client's screen as a notice.
-            The message is looked up using a localization key and optional arguments.
-
-        Parameters:
-            key (string)   - The localization key for the message.
-            ... (vararg)   - Additional arguments to format into the localized message.
-
-        Returns:
-            None.
-
-        Realm:
-            Client.
-
-        Example Usage:
-            -- Show a localized notice to the local player
-            lia.notices.notifyLocalized("welcomeMessage", LocalPlayer():Nick())
-
-            -- Show a localized notice with multiple arguments
-            lia.notices.notifyLocalized("itemPickup", "Health Kit", 3)
-    ]]
     function lia.notices.notifyLocalized(key, ...)
         lia.notices.notify(L(key, ...))
     end
 
-    --[[
-        notification.AddLegacy
-
-        Purpose:
-            Overrides the default notification.AddLegacy to use lia.notices.notify for displaying legacy notifications.
-
-        Parameters:
-            text (string) - The message to display.
-
-        Returns:
-            None.
-
-        Realm:
-            Client.
-
-        Example Usage:
-            -- Show a legacy notification
-            notification.AddLegacy("This is a legacy notification!")
-    ]]
     function notification.AddLegacy(text)
         lia.notices.notify(tostring(text))
     end
 end
+


### PR DESCRIPTION
## Summary
- document notice library behavior and options
- drop redundant in-source notice documentation

## Testing
- `luacheck gamemode/core/libraries/notice.lua`

------
https://chatgpt.com/codex/tasks/task_e_689837c673788327ac62fa7833b1ae28