### PR TITLE
docs: sync webimage docs

### DIFF
--- a/documentation/docs/libraries/lia.webimage.md
+++ b/documentation/docs/libraries/lia.webimage.md
@@ -18,17 +18,17 @@ The web-image library downloads remote images and caches them as materials. Cach
 
 **Purpose**
 
-Downloads an image from the given URL and saves it inside the web-image cache. If the file already exists it will be replaced with the new download. Should the request fail the previous cached file is used and passed to the callback.
+Downloads an image from the given URL and saves it inside the web-image cache. If the file already exists it will be replaced with the new download. Should the request fail the previous cached file is used and passed to the callback. When a new file is successfully downloaded the `WebImageDownloaded` hook is triggered with the saved name and path.
 
 **Parameters**
 
-* `name` (*string*): Unique file name including extension.
+* `n` (*string*): Unique file name including extension.
 
-* `url` (*string*): HTTP address of the image.
+* `u` (*string*): HTTP address of the image.
 
-* `callback` (*function | nil*): Called as `callback(mat, fromCache, err)` where `mat` is a `Material`, `fromCache` is `true` if loaded from disk, and `err` is an error string on failure.
+* `cb` (*function | nil*): Called as `cb(mat, fromCache[, err])` where `mat` is a `Material`, `fromCache` is `true` if loaded from disk, and `err` is an error string on failure.
 
-* `flags` (*string | nil*): Optional material flags passed to `Material()`.
+* `flags` (*string | nil*): Optional material flags passed to `Material()`. Defaults to `"noclamp smooth"` when omitted.
 
 **Realm**
 
@@ -64,9 +64,9 @@ Returns the material cached with `lia.webimage.register`. If the file is missing
 
 **Parameters**
 
-* `name` (*string*): File name used during registration.
+* `n` (*string*): Registered file name or URL.
 
-* `flags` (*string | nil*): Optional material flags.
+* `flags` (*string | nil*): Optional material flags. Defaults to `"noclamp smooth"` when omitted.
 
 **Realm**
 
@@ -100,7 +100,18 @@ local byURL = Material("https://example.com/logo.png")
 
 ---
 
+### Viewing Saved Images
+
+Run the `lia_saved_images` console command on the client to open a panel that lists all cached web images.
+
+---
+
 ### Clearing the Cache
 
-Use the `lia_wipewebimages` console command on the client to delete all cached web
-images from disk. New requests will download the images again.
+Use the `lia_wipewebimages` console command on the client to delete all cached web images from disk. New requests will download the images again.
+
+---
+
+### Test Menu
+
+The `test_webimage_menu` console command opens a simple interface for loading and previewing images from arbitrary URLs.

--- a/gamemode/core/libraries/webimage.lua
+++ b/gamemode/core/libraries/webimage.lua
@@ -1,14 +1,3 @@
-﻿--[[
-# Web Image Library
-
-This page documents the functions for working with web image downloading and caching.
-
----
-
-## Overview
-
-The web image library provides utilities for downloading, caching, and managing images from the web within the Lilia framework. It handles image downloading, local storage, and provides functions for converting web images into Garry's Mod materials. The library supports image caching, error handling, and provides utilities for managing web-based image content.
-]]
 lia.webimage = lia.webimage or {}
 local ip = string.Replace(string.Replace(game.GetIPAddress() or "unknown", ":", "_"), "%.", "_")
 local gamemode = engine.ActiveGamemode() or "unknown"
@@ -29,39 +18,6 @@ local function buildMaterial(p, flags)
     return Material("data/" .. p, flags or "noclamp smooth")
 end
 
---[[
-    lia.webimage.register
-
-    Purpose:
-        Registers a web image by downloading it from a URL and saving it locally for later use as a Material.
-        If the image is already cached or saved, it will be reused. Optionally, a callback can be provided
-        to be notified when the image is ready.
-
-    Parameters:
-        name (string)         - The local name to register the image as (used as the filename).
-        url (string)          - The URL to download the image from.
-        callback (function)   - (Optional) Function to call when the image is ready. Receives (material, fromCache, error).
-        flags (string)        - (Optional) Material flags to use when creating the Material.
-
-    Returns:
-        None.
-
-    Realm:
-        Client.
-
-    Example Usage:
-        -- Register a new web image and use it in a DImage panel
-        lia.webimage.register("myicon.png", "https://example.com/icon.png", function(mat, fromCache)
-            if mat and not mat:IsError() then
-                local img = vgui.Create("DImage")
-                img:SetMaterial(mat)
-                img:SetSize(64, 64)
-                img:Center()
-            else
-                print("Failed to load image!")
-            end
-        end)
-]]
 function lia.webimage.register(n, u, cb, flags)
     if isstring(u) then urlMap[u] = n end
     registered[n] = {
@@ -92,33 +48,6 @@ function lia.webimage.register(n, u, cb, flags)
     end)
 end
 
---[[
-    lia.webimage.get
-
-    Purpose:
-        Retrieves a Material for a previously registered or downloaded web image.
-        If the image is cached, it returns the cached Material. If the image exists on disk,
-        it loads and returns the Material. Otherwise, returns none.
-
-    Parameters:
-        name (string)     - The registered name or URL of the image.
-        flags (string)    - (Optional) Material flags to use when creating the Material.
-
-    Returns:
-        Material or nil - The Material object if found, or nil if not available.
-
-    Realm:
-        Client.
-
-    Example Usage:
-        -- Get a Material for a registered image and use it in a DImage
-        local mat = lia.webimage.get("myicon.png")
-        if mat then
-            local img = vgui.Create("DImage")
-            img:SetMaterial(mat)
-            img:SetSize(32, 32)
-        end
-]]
 function lia.webimage.get(n, flags)
     local key = urlMap[n] or n
     if cache[key] then return cache[key] end


### PR DESCRIPTION
## Summary
- update webimage library docs to match current API and behaviour
- document console commands for viewing and testing cached web images
- drop redundant embedded comments from webimage.lua

## Testing
- `luacheck gamemode/core/libraries/webimage.lua` *(fails: mutating non-standard global variable lia, accessing undefined variables, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689837d846d88327b5723dadbdb75b5f