### PR TITLE
docs: sync menu library docs

### DIFF
--- a/documentation/docs/libraries/lia.menu.md
+++ b/documentation/docs/libraries/lia.menu.md
@@ -1,28 +1,26 @@
 # Menu Library
 
-This page describes small menu-creation helpers.
+Client-side helpers for simple world-space context menus.
 
 ---
 
 ## Overview
 
-The menu library offers convenience functions for building simple context menus. Menus are defined by label/callback pairs and automatically appear at the player’s cross-hair or attached to a specified entity. Active menus are stored in `lia.menu.list` on the client.
+The menu library offers convenience functions for building simple context menus. Menus are defined by label/callback pairs and automatically appear at the player's crosshair or follow a specified entity. Active menus are stored in `lia.menu.list` on the client. Menus fade out and are removed if the player moves more than **96 units** away or the attached entity becomes invalid.
 
 ### Menu-entry fields
 
 Each entry in `lia.menu.list` is a table containing:
 
 * `position` (*Vector*) – World position where the menu is drawn.
-
 * `entity` (*Entity | nil*) – Entity the menu follows, if attached.
-
 * `items` (*table*) – Sorted array of `{ label, callback }` pairs.
-
 * `width` (*number*) – Pixel width used for rendering.
-
 * `height` (*number*) – Combined pixel height of all rows.
-
 * `onRemove` (*function | nil*) – Executed when the menu is removed.
+* `alpha` (*number*) – Internal fade alpha used while drawing.
+* `displayed` (*boolean | nil*) – Internal flag used for fade-in logic.
+* `entPos` (*Vector | nil*) – Internal cached position for attached entities.
 
 ---
 
@@ -34,11 +32,9 @@ Creates a context menu from a table of label/callback pairs.
 
 **Parameters**
 
-* `opts` (*table*): Map of label → callback.
-
-* `pos` (*Vector | Entity | nil*): World position or entity to attach to.
-
-* `onRemove` (*function | nil*): Function executed when the menu is removed.
+* `opts` (*table*): Map of label → callback. Labels are converted to strings and sorted alphabetically.
+* `pos` (*Vector | Entity | nil*): World position for the menu or entity to attach to. When an entity is supplied, the menu tracks that entity at the point under the player's crosshair. Defaults to the player's eye-trace hit position.
+* `onRemove` (*function | nil*): Function executed when the menu is removed for any reason (player moves away, entity becomes invalid, manual removal, etc.).
 
 **Realm**
 
@@ -68,7 +64,7 @@ end)
 
 **Purpose**
 
-Draws every active menu on the player’s HUD.
+Draws every active menu on the player's HUD and handles fade-in/fade-out. Menus are removed if the player is too far or the attached entity becomes invalid.
 
 **Parameters**
 
@@ -107,8 +103,11 @@ Returns the ID and callback of the menu item currently under the cursor.
 **Returns**
 
 * *number | nil*: ID of the active menu.
-
 * *function | nil*: Callback for the hovered item.
+
+**Notes**
+
+Only menus within 96 units and under the player's crosshair are considered.
 
 **Example Usage**
 
@@ -131,7 +130,6 @@ Removes the menu with the given ID and runs its callback (if present).
 **Parameters**
 
 * `id` (*number*): Identifier returned by `lia.menu.add`.
-
 * `callback` (*function | nil*): Function executed after removal.
 
 **Realm**

--- a/gamemode/core/libraries/menu.lua
+++ b/gamemode/core/libraries/menu.lua
@@ -1,14 +1,3 @@
-﻿--[[
-# Menu Library
-
-This page documents the functions for working with context menus and interactive UI elements.
-
----
-
-## Overview
-
-The menu library provides a system for creating and managing context menus and interactive UI elements within the Lilia framework. It handles menu positioning, rendering, and user interaction, supporting both world-space and screen-space menus. The library provides utilities for building dynamic menus with customizable options and callbacks.
-]]
 lia.menu = lia.menu or {}
 lia.menu.list = lia.menu.list or {}
 local surface_SetFont = surface.SetFont


### PR DESCRIPTION
## Summary
- document menu library features and internal fields
- remove outdated inline docs from `menu.lua`

## Testing
- `luacheck gamemode/core/libraries/menu.lua` *(fails: expected '=' near 'end')*


------
https://chatgpt.com/codex/tasks/task_e_689837d02040832787acfb5920b707ac