### PR TITLE
docs: sync option library

### DIFF
--- a/documentation/docs/libraries/lia.option.md
+++ b/documentation/docs/libraries/lia.option.md
@@ -22,7 +22,7 @@ Options are kept inside `lia.option.stored`; each entry contains:
 
 * `callback` (*function | nil*) – Runs as `callback(oldValue, newValue)` on change.
 
-* `type` (*string*) – Control type (`Boolean`, `Int`, …).
+* `type` (*string*) – Control type (`Boolean`, `Int`, `Float`, `Color`, or `Generic`).
 
 * `visible` (*boolean | function | nil*) – Whether the option appears in the config UI.
 
@@ -38,7 +38,7 @@ Whenever `lia.option.set` updates a value, the `liaOptionChanged` hook is fired 
 
 **Purpose**
 
-Registers a configurable option that can be networked.
+Registers a configurable option.
 
 **Parameters**
 
@@ -51,8 +51,15 @@ Registers a configurable option that can be networked.
 * `default` (*any*): Default value.
 
 * `callback` (*function | nil*): Runs on change. Optional.
-
-* `data` (*table*): Extra option data. Set `isQuick = true` to also list this option in the quick settings panel. String values like `category` or entries within an `options` table are localized automatically.
+* `data` (*table*): Additional option data. Required. Fields may include:
+  * `category` (*string*): Grouping for configuration menus.
+  * `min` (*number*): Minimum numeric value. Defaults to half of `default` for numeric types.
+  * `max` (*number*): Maximum numeric value. Defaults to double `default` for numeric types.
+  * `options` (*table*): Discrete choices; string entries are localized automatically.
+  * `type` (*string*): Overrides automatic type detection (`Boolean`, `Int`, `Float`, `Color`, `Generic`).
+  * `visible` (*boolean | function*): Whether the option is shown in the configuration UI.
+  * `shouldNetwork` (*boolean*): When `true`, `lia.option.set` triggers `liaOptionReceived` on the server.
+  * `isQuick` (*boolean*): Include this option in the quick settings panel.
 
 **Realm**
 
@@ -83,7 +90,7 @@ lia.option.add(
 
 **Purpose**
 
-Changes the value of an option, runs its callback, saves it, and networks if `shouldNetwork` is `true`.
+Changes the value of an option, runs its callback, saves it, and networks if `shouldNetwork` is `true`. If the option key is unregistered, the call is ignored.
 
 **Parameters**
 
@@ -93,7 +100,7 @@ Changes the value of an option, runs its callback, saves it, and networks if `sh
 
 **Realm**
 
-`Client`
+`Client` (also usable on the server)
 
 **Returns**
 
@@ -113,7 +120,7 @@ lia.option.set("thirdPersonEnabled", not enabled)
 
 **Purpose**
 
-Retrieves an option value or returns a fallback.
+Retrieves an option value or returns a fallback. Checks the current value first, then the option's default, then the provided fallback.
 
 **Parameters**
 
@@ -141,7 +148,7 @@ local dist = lia.option.get("thirdPersonDistance", 50)
 
 **Purpose**
 
-Writes all current option values to disk (file is keyed by server IP).
+Writes all current option values to `data/lilia/options/<gamemode>/<serverip>.txt` in JSON format. Only options with non-`nil` values are written.
 
 **Parameters**
 
@@ -167,7 +174,7 @@ lia.option.save()
 
 **Purpose**
 
-Loads saved option values from disk, applies them to `lia.option.stored`, and fires `InitializedOptions`.
+Loads saved option values from `data/lilia/options/<gamemode>/<serverip>.txt`, applies them to `lia.option.stored`, and fires `InitializedOptions`.
 
 **Parameters**
 

--- a/gamemode/core/libraries/option.lua
+++ b/gamemode/core/libraries/option.lua
@@ -1,49 +1,5 @@
-﻿--[[
-# Option Library
-
-This page documents the functions for working with user options and configuration settings.
-
----
-
-## Overview
-
-The option library provides a system for managing user-configurable options and settings within the Lilia framework. It handles option registration, storage, retrieval, and provides utilities for creating user interfaces for option management. The library supports various data types, validation, and networking of option changes between client and server.
-]]
-lia.option = lia.option or {}
+﻿lia.option = lia.option or {}
 lia.option.stored = lia.option.stored or {}
---[[
-    lia.option.add
-
-    Purpose:
-        Registers a new configurable option in the lia.option system. Options can be used for user or server configuration,
-        and can be of various types (Boolean, Int, Float, Color, etc). Options are stored in lia.option.stored and can be
-        retrieved, set, and displayed in configuration menus.
-
-    Parameters:
-        key (string)         - Unique identifier for the option.
-        name (string)        - Display name for the option (localized automatically).
-        desc (string)        - Description for the option (localized automatically).
-        default (any)        - Default value for the option.
-        callback (function)  - (Optional) Function to call when the option value changes. Receives (oldValue, newValue).
-        data (table)         - Table containing additional option data (category, min, max, decimals, type, visible, etc). String
-                              fields such as `category` and entries in an `options` table are localized automatically.
-
-    Returns:
-        None.
-
-    Realm:
-        Client.
-
-    Example Usage:
-        -- Add a boolean option for enabling a HUD element
-        lia.option.add("showHUD", "showHUD", "showHUDDesc", true, function(old, new)
-            print("HUD option changed from", old, "to", new)
-        end, {
-            category = "categoryHUD",
-            isQuick = true,
-            shouldNetwork = true
-        })
-]]
 function lia.option.add(key, name, desc, default, callback, data)
     assert(isstring(key), L("optionKeyString", type(key)))
     assert(isstring(name), L("optionNameString", type(name)))
@@ -83,27 +39,6 @@ function lia.option.add(key, name, desc, default, callback, data)
     }
 end
 
---[[
-    lia.option.set
-
-    Purpose:
-        Sets the value of a registered option. Triggers the option's callback (if any), runs the "liaOptionChanged" hook,
-        saves the options to disk, and optionally networks the change if shouldNetwork is true and on the server.
-
-    Parameters:
-        key (string)   - The unique identifier of the option to set.
-        value (any)    - The new value to assign to the option.
-
-    Returns:
-        None.
-
-    Realm:
-        Client.
-
-    Example Usage:
-        -- Set the "showHUD" option to false
-        lia.option.set("showHUD", false)
-]]
 function lia.option.set(key, value)
     local opt = lia.option.stored[key]
     if not opt then return end
@@ -115,27 +50,6 @@ function lia.option.set(key, value)
     if opt.shouldNetwork and SERVER then hook.Run("liaOptionReceived", nil, key, value) end
 end
 
---[[
-    lia.option.get
-
-    Purpose:
-        Retrieves the value of a registered option. If the option is not set, returns its default value.
-        If the option does not exist, returns the provided default argument.
-
-    Parameters:
-        key (string)      - The unique identifier of the option to retrieve.
-        default (any)     - (Optional) Value to return if the option is not found.
-
-    Returns:
-        value (any)       - The current value of the option, its default, or the provided default.
-
-    Realm:
-        Client.
-
-    Example Usage:
-        -- Get the value of the "showHUD" option, defaulting to true if not set
-        local showHUD = lia.option.get("showHUD", true)
-]]
 function lia.option.get(key, default)
     local opt = lia.option.stored[key]
     if opt then
@@ -145,26 +59,6 @@ function lia.option.get(key, default)
     return default
 end
 
---[[
-    lia.option.save
-
-    Purpose:
-        Saves all current option values to disk in JSON format. The save file is stored per-gamemode and per-server IP,
-        allowing for server-specific option persistence.
-
-    Parameters:
-        None.
-
-    Returns:
-        None.
-
-    Realm:
-        Client.
-
-    Example Usage:
-        -- Save all current options to disk
-        lia.option.save()
-]]
 function lia.option.save()
     local dir = "lilia/options/" .. engine.ActiveGamemode()
     file.CreateDir(dir)
@@ -180,26 +74,6 @@ function lia.option.save()
     if json then file.Write(path, json) end
 end
 
---[[
-    lia.option.load
-
-    Purpose:
-        Loads option values from disk for the current gamemode and server IP, restoring previously saved option states.
-        After loading, runs the "InitializedOptions" hook.
-
-    Parameters:
-        None.
-
-    Returns:
-        None.
-
-    Realm:
-        Client.
-
-    Example Usage:
-        -- Load all saved options for this server
-        lia.option.load()
-]]
 function lia.option.load()
     local dir = "lilia/options/" .. engine.ActiveGamemode()
     file.CreateDir(dir)


### PR DESCRIPTION
## Summary
- document option library parameters and behaviours
- remove outdated inline comments from option library

## Testing
- `luacheck gamemode/core/libraries/option.lua` *(fails: 229 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68983880ba948327aa7d5b49b72101e1