### PR TITLE
docs: sync vector meta

### DIFF
--- a/documentation/docs/meta/vector.md
+++ b/documentation/docs/meta/vector.md
@@ -10,7 +10,7 @@ This document describes additional operations for 3D vectors.
 
 Vector meta functions provide calculations such as midpoints, distances and axis rotations to support movement, physics and placement tasks.
 
-`Center`, `Distance` and `RotateAroundAxis` return new vectors without changing their inputs. `Right` and `Up` modify the vector they are called on and also return it.
+`Center` and `RotateAroundAxis` return new vectors without changing their inputs. `Distance` returns a number. `Right` and `Up` modify the vector they are called on and also return it.
 
 ### Example Hook Usage
 
@@ -91,7 +91,7 @@ print(result)
 
 **Purpose**
 
-Rotates the vector around an axis by the specified degrees and returns the new vector.
+Rotates the vector around an axis by the specified degrees and returns a new vector without modifying the original.
 
 **Parameters**
 
@@ -122,13 +122,7 @@ print(result)
 
 **Purpose**
 
-Calculates the cross product of this vector and the provided up reference to derive a right-direction vector.
-
-The vector is overwritten via `self:Cross(self, vUp)` and then normalized,
-
-yielding a direction perpendicular to both inputs. This means the method
-
-modifies the calling vector and returns it.
+Calculates the cross product of this vector and the provided up reference to derive a right-direction vector. The vector is overwritten via `self:Cross(self, vUp)` and then normalized, yielding a direction perpendicular to both inputs. This means the method modifies the calling vector and returns it.
 
 If this vector has no horizontal component it defaults to `Vector(0, -1, 0)`.
 
@@ -149,8 +143,8 @@ If this vector has no horizontal component it defaults to `Vector(0, -1, 0)`.
 ```lua
 -- Get the right direction vector
 local forward = Vector(1, 0, 0)
-local result = forward:Right()
-print(result)
+local rightVec = forward:Right() -- forward is now the right vector
+print(rightVec)
 ```
 
 ---
@@ -159,9 +153,7 @@ print(result)
 
 **Purpose**
 
-Uses two cross products to determine an up-direction vector that is perpendicular to both this vector and the given up reference.
-
-First, the vector is overwritten with the cross product of itself and `vUp` using `self:Cross(self, vUp)`. This intermediate value, stored in `vRet`, is crossed with the original vector via `self:Cross(vRet, self)` to produce the final up direction. The method therefore modifies the calling vector before returning it.
+Uses two cross products to determine an up-direction vector that is perpendicular to both this vector and the given up reference. First, the vector is overwritten with the cross product of itself and `vUp` using `self:Cross(self, vUp)`. This intermediate value, stored in `vRet`, is crossed with the original vector via `self:Cross(vRet, self)` to produce the final up direction. The method therefore modifies the calling vector before returning it.
 
 When this vector lacks a horizontal component the fallback value is `Vector(-self.z, 0, 0)`.
 
@@ -182,8 +174,8 @@ When this vector lacks a horizontal component the fallback value is `Vector(-sel
 ```lua
 -- Get the up direction vector
 local forward = Vector(1, 0, 0)
-local result = forward:Up()
-print(result)
+local upVec = forward:Up() -- forward is now the up vector
+print(upVec)
 ```
 
 ---

--- a/gamemode/core/meta/vector.lua
+++ b/gamemode/core/meta/vector.lua
@@ -1,112 +1,28 @@
-﻿--[[
-# Vector Library
-
-This page documents the extended functions for working with Vector objects in the Lilia framework.
-
----
-
-## Overview
-
-The vector library extends the base Vector metatable with additional utility functions for common vector operations. These functions provide convenient methods for calculating distances, finding midpoints, rotating vectors, and other geometric operations that are commonly needed in game development.
-
-All functions are available on both client and server realms and work with the standard Source engine Vector objects.
-]]
 local vectorMeta = FindMetaTable("Vector")
---[[
-    Center
 
-    Purpose:
-        Returns the midpoint between this vector and another vector.
-
-    Parameters:
-        vec2 (Vector) - The other vector to find the center with.
-
-    Returns:
-        Vector - The center point between the two vectors.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local midpoint = vec1:Center(vec2)
-        print("Midpoint is: " .. tostring(midpoint))
-]]
 function vectorMeta:Center(vec2)
     return (self + vec2) / 2
 end
 
---[[
-    Distance
-
-    Purpose:
-        Calculates the Euclidean distance between this vector and another vector.
-
-    Parameters:
-        vec2 (Vector) - The other vector to measure distance to.
-
-    Returns:
-        number - The distance between the two vectors.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local dist = vec1:Distance(vec2)
-        print("Distance is: " .. dist)
-]]
 function vectorMeta:Distance(vec2)
     local x, y, z = self.x, self.y, self.z
     local x2, y2, z2 = vec2.x, vec2.y, vec2.z
     return math.sqrt((x - x2) ^ 2 + (y - y2) ^ 2 + (z - z2) ^ 2)
 end
 
---[[
-    RotateAroundAxis
-
-    Purpose:
-        Rotates this vector around a given axis by a specified number of degrees.
-
-    Parameters:
-        axis (Vector)   - The axis to rotate around.
-        degrees (number) - The angle in degrees to rotate.
-
-    Returns:
-        Vector - The rotated vector.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local rotated = vec:RotateAroundAxis(Vector(0,0,1), 90)
-        print("Rotated vector: " .. tostring(rotated))
-]]
 function vectorMeta:RotateAroundAxis(axis, degrees)
     local rad = math.rad(degrees)
     local cosTheta = math.cos(rad)
     local sinTheta = math.sin(rad)
-    return Vector(cosTheta * self.x + sinTheta * (axis.y * self.z - axis.z * self.y), cosTheta * self.y + sinTheta * (axis.z * self.x - axis.x * self.z), cosTheta * self.z + sinTheta * (axis.x * self.y - axis.y * self.x))
+    return Vector(
+        cosTheta * self.x + sinTheta * (axis.y * self.z - axis.z * self.y),
+        cosTheta * self.y + sinTheta * (axis.z * self.x - axis.x * self.z),
+        cosTheta * self.z + sinTheta * (axis.x * self.y - axis.y * self.x)
+    )
 end
 
 local right = Vector(0, -1, 0)
---[[
-    Right
 
-    Purpose:
-        Returns the right vector (perpendicular) relative to this vector and an optional up vector.
-
-    Parameters:
-        vUp (Vector) - (Optional) The up vector to use. Defaults to global vector_up.
-
-    Returns:
-        Vector - The right vector.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local rightVec = vec:Right()
-        print("Right vector: " .. tostring(rightVec))
-]]
 function vectorMeta:Right(vUp)
     if self[1] == 0 and self[2] == 0 then return right end
     if not vUp then vUp = vector_up end
@@ -115,25 +31,6 @@ function vectorMeta:Right(vUp)
     return vRet
 end
 
---[[
-    Up
-
-    Purpose:
-        Returns the up vector (perpendicular) relative to this vector and an optional up vector.
-
-    Parameters:
-        vUp (Vector) - (Optional) The up vector to use. Defaults to global vector_up.
-
-    Returns:
-        Vector - The up vector.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local upVec = vec:Up()
-        print("Up vector: " .. tostring(upVec))
-]]
 function vectorMeta:Up(vUp)
     if self[1] == 0 and self[2] == 0 then return Vector(-self[3], 0, 0) end
     if not vUp then vUp = vector_up end
@@ -142,3 +39,4 @@ function vectorMeta:Up(vUp)
     vRet:Normalize()
     return vRet
 end
+


### PR DESCRIPTION
## Summary
- document vector helpers in detail and clarify return values
- strip outdated comment docs from vector meta implementation

## Testing
- `luac -p gamemode/core/meta/vector.lua`


------
https://chatgpt.com/codex/tasks/task_e_68983890de6c8327a66454d3851f5f2e