### PR TITLE
docs: update config library documentation

### DIFF
--- a/documentation/docs/libraries/lia.config.md
+++ b/documentation/docs/libraries/lia.config.md
@@ -6,7 +6,15 @@ This page explains how to add and access configuration settings.
 
 ## Overview
 
-The config library stores server configuration values with descriptions and default settings. It also provides callbacks when values change, so modules can react to new options.
+The configuration library provides a centralized system for managing settings across the framework. It supports:
+
+* **Type-safe values** with automatic detection for strings, numbers, booleans, colors and tables.
+* **Validation rules** such as minimum/maximum ranges and selectable options.
+* **Change callbacks** for reacting to updates at runtime.
+* **Client-server synchronization** so changes propagate to connected players.
+* **Category organization** and description text for use in UI.
+* **Default value management** with persistence to the database.
+* **Access control** and support for hot reloading and cross-module sharing.
 
 ---
 
@@ -24,9 +32,9 @@ Registers a new config option with the given key, display name, default value, a
 
 * `value` (*any*): Default stored value.
 
-* `callback` (*function*): Function run when the value changes. *Optional*.
+* `callback` (*function*): Function run when the value changes. Receives `(oldValue, newValue)`. *Optional*.
 
-* `data` (*table*): Table describing the option. Common fields include `desc`, `category`, `type`, `min`, `max`, `decimals`, `options`, and `noNetworking`. Any string values for `desc`, `category`, or within `options` are localized automatically.
+* `data` (*table*): Table describing the option. Common fields include `desc`, `category`, `type`, `min`, `max`, `decimals`, `options`, and `noNetworking`. Any string values for `desc`, `category`, or within `options` are localized automatically. If `type` is omitted, it is inferred from `value`.
 
 **Realm**
 
@@ -102,11 +110,11 @@ Sets a config value directly without running callbacks or networking the update.
 
 * `value` (*any*): New value to set.
 
-* `noSave` (*boolean*): If `true`, value is not written to disk.
+* `noSave` (*boolean*): If `true`, value is not written to disk. *Default*: `false`.
 
 **Realm**
 
-`Server`
+`Shared`
 
 **Returns**
 
@@ -124,7 +132,7 @@ lia.config.forceSet("someSetting", true, true)
 
 **Purpose**
 
-Sets a config value, saves it server-side, triggers callbacks with the old and new values, and networks the update unless the config is marked `noNetworking`.
+Sets a config value and updates `lia.config.stored`. On the server it broadcasts a `cfgSet` net message to clients (unless the option is marked `noNetworking`), runs the change callback with `(oldValue, newValue)`, and saves the result.
 
 **Parameters**
 
@@ -152,7 +160,7 @@ lia.config.set("maxPlayers", 24)
 
 **Purpose**
 
-Retrieves the current value of a config entry. If unset, returns the stored default or the provided fallback.
+Retrieves the current value of a config entry. If unset, returns the stored default or the provided fallback. Color tables are converted to `Color` objects automatically.
 
 **Parameters**
 
@@ -180,7 +188,7 @@ local players = lia.config.get("maxPlayers", 64)
 
 **Purpose**
 
-Loads config values from the database and stores them in `lia.config`. Missing entries are inserted with their defaults.
+On the server, loads config values from the database for the current schema and inserts any missing entries with their defaults. On the client, requests the config list from the server.
 
 **Parameters**
 
@@ -188,7 +196,7 @@ Loads config values from the database and stores them in `lia.config`. Missing e
 
 **Realm**
 
-`Shared`
+`Server` and `Client`
 
 **Returns**
 
@@ -236,7 +244,7 @@ Sends all changed config values to a client. If no client is provided, the value
 
 **Parameters**
 
-* `client` (*Player*): Player to receive the config data.
+* `client` (*Player* | nil*): Player to receive the config data. If omitted, all clients receive it.
 
 **Realm**
 
@@ -278,7 +286,5 @@ Writes all changed config values to the database so they persist across restarts
 ```lua
 lia.config.save()
 ```
-
----
 
 ---

--- a/gamemode/core/libraries/config.lua
+++ b/gamemode/core/libraries/config.lua
@@ -1,33 +1,3 @@
-﻿--[[
-# Configuration Library
-
-This page documents the functions for working with configuration variables and settings.
-
----
-
-## Overview
-
-The configuration library provides a centralized system for managing configuration variables throughout the Lilia framework. It handles the registration, storage, and retrieval of config values with support for different data types, validation, and change callbacks. The system supports networking configuration changes to clients and provides a robust foundation for customizable server settings.
-
-The library features include:
-- **Type-Safe Configuration**: Support for various data types including strings, numbers, booleans, colors, and complex objects
-- **Validation System**: Built-in validation with custom validation rules and error handling
-- **Change Callbacks**: Automatic notification when configuration values change with custom callback support
-- **Client-Server Synchronization**: Automatic networking of configuration changes to connected clients
-- **Category Organization**: Hierarchical organization of configurations by category for better management
-- **Default Value Management**: Automatic handling of default values with fallback mechanisms
-- **Database Persistence**: Automatic saving and loading of configuration values to/from database
-- **Access Control**: Permission-based access to configuration modification and viewing
-- **Validation Rules**: Custom validation rules with min/max values, pattern matching, and custom validators
-- **Change History**: Optional tracking of configuration changes for audit purposes
-- **Hot Reloading**: Support for runtime configuration changes without server restart
-- **Import/Export**: Configuration backup and restore functionality
-- **UI Integration**: Built-in support for configuration management interfaces
-- **Performance Optimization**: Efficient caching and lookup mechanisms for configuration values
-- **Cross-Module Support**: Configuration sharing between different modules and addons
-
-The configuration system provides a flexible and powerful foundation for managing server settings, player preferences, and module configurations. It ensures consistency across the framework and provides an intuitive interface for both developers and administrators.
-]]
 lia.config = lia.config or {}
 lia.config.stored = lia.config.stored or {}
 --[[
@@ -461,7 +431,7 @@ lia.config.add("WalkRatio", "walkRatio", 0.5, nil, {
     category = "character",
     type = "Float",
     min = 0.1,
-    max = 1.0
+    max = 1.0,
     decimals = 2
 })
 


### PR DESCRIPTION
## Summary
- expand overview and usage docs for `lia.config`
- clarify function behavior, realms, and defaults
- fix syntax issue in `config.lua` and remove redundant header comment

## Testing
- `luacheck gamemode/core/libraries/config.lua`

------
https://chatgpt.com/codex/tasks/task_e_689838a585ec83279854ff90f5a5d4a3