### PR TITLE
docs: sync class definitions

### DIFF
--- a/documentation/docs/definitions/class.md
+++ b/documentation/docs/definitions/class.md
@@ -18,33 +18,33 @@ The global `CLASS` table defines per-class settings such as display name, lore, 
 | `desc` | `string` | `"No Description"` | Description or lore of the class. |
 | `isDefault` | `boolean` | `false` | Whether the class is available by default. |
 | `isWhitelisted` | `boolean` | `false` | Whether the class requires whitelist to join. |
-| `faction` | `number` | `0` | Linked faction index (e.g., `FACTION_CITIZEN`). |
-| `color` | `Color` | `Color(255,255,255)` | UI color associated with the class. |
-| `weapons` | `table` | `{}` | Weapons granted to members of this class. |
+| `faction` | `number` | `required` | Linked faction index (e.g., `FACTION_CITIZEN`). |
+| `color` | `Color` | `nil` | UI color associated with the class; falls back to faction color when unset. |
+| `weapons` | `string` or `table` | `nil` | Weapons granted to members of this class. |
 | `pay` | `number` | `0` | Payment amount per interval. |
 | `payLimit` | `number` | `0` | Maximum accumulated pay. |
 | `payTimer` | `number` | `3600` | Seconds between paychecks when not overridden. |
 | `limit` | `number` | `0` | Maximum number of players in this class. |
-| `health` | `number` | `0` | Default starting health. |
-| `armor` | `number` | `0` | Default starting armor. |
+| `health` | `number` | `nil` | Starting health override. |
+| `armor` | `number` | `nil` | Starting armor override. |
 | `scale` | `number` | `1` | Player model scale multiplier. |
-| `runSpeed` | `number` | `0` | Default running speed. |
+| `runSpeed` | `number` | `nil` | Running speed or multiplier value. |
 | `runSpeedMultiplier` | `boolean` | `false` | Multiply base speed instead of replacing it. |
-| `walkSpeed` | `number` | `0` | Default walking speed. |
+| `walkSpeed` | `number` | `nil` | Walking speed or multiplier value. |
 | `walkSpeedMultiplier` | `boolean` | `false` | Multiply base walk speed instead of replacing it. |
-| `jumpPower` | `number` | `0` | Default jump power. |
+| `jumpPower` | `number` | `nil` | Jump power or multiplier value. |
 | `jumpPowerMultiplier` | `boolean` | `false` | Multiply base jump power instead of replacing it. |
 | `bloodcolor` | `number` | `0` | Blood color enumeration constant. |
-| `bodyGroups` | `table` | `{}` | Bodygroup name → index mapping applied on spawn. |
+| `bodyGroups` | `table` | `nil` | Bodygroup name → index mapping applied on spawn. |
 | `logo` | `string` | `""` | Material path for the class logo. |
 | `scoreboardHidden` | `boolean` | `false` | Hide class headers and logos in the scoreboard. |
 | `skin` | `number` | `0` | Player model skin index. |
-| `subMaterials` | `table` | `{}` | Sub-material overrides for the model. |
-| `model` | `string` | `""` | Model path or list of paths used by this class. |
-| `requirements` | `string` | `""` | Informational requirements text shown to players. |
+| `subMaterials` | `table` | `nil` | Sub-material overrides for the model. |
+| `model` | `string` or `table` | `nil` | Model path or list of paths used by this class. |
+| `requirements` | `string` or `table` | `nil` | Informational requirements text shown to players. |
 | `index` | `number` | `auto` | Unique team index assigned at registration. |
 | `uniqueID` | `string` | `filename` | Optional identifier; defaults to the file name when omitted. |
-| `commands` | `table` | `{}` | Command names members may always use. |
+| `commands` | `table` | `nil` | Command names members may always use. |
 | `canInviteToFaction` | `boolean` | `false` | Allows members of this class to invite players to their faction. |
 | `canInviteToClass` | `boolean` | `false` | Allows members of this class to invite others to their class. |
 
@@ -172,7 +172,7 @@ CLASS.isWhitelisted = false
 
 **Description:**
 
-Links this class to a specific faction index.
+Links this class to a specific faction index. This field is required; registration fails if the faction is missing or invalid.
 
 **Example Usage:**
 
@@ -190,7 +190,7 @@ CLASS.faction = FACTION_CITIZEN
 
 **Description:**
 
-UI color representing the class. Defaults to `Color(255, 255, 255)` if not specified.
+UI color representing the class. When omitted, the faction’s color is used.
 
 **Example Usage:**
 
@@ -206,16 +206,19 @@ CLASS.color = Color(255, 0, 0)
 
 **Type:**
 
-`table`
+`string` or `table`
 
 **Description:**
 
-Weapons granted to members of this class on spawn.
+Weapons granted to members of this class on spawn. Supply a single weapon class or a table of weapon class strings.
 
 **Example Usage:**
 
 ```lua
+-- give two weapons
 CLASS.weapons = {"weapon_pistol", "weapon_crowbar"}
+-- or grant one weapon
+CLASS.weapons = "weapon_pistol"
 ```
 
 #### `pay`
@@ -304,7 +307,7 @@ CLASS.limit = 10
 
 **Description:**
 
-Default starting health for class members.
+Overrides the player’s starting health when they spawn as this class. If omitted, health is unchanged.
 
 **Example Usage:**
 
@@ -322,7 +325,7 @@ CLASS.health = 150
 
 **Description:**
 
-Default starting armor.
+Overrides the player’s starting armor. If omitted, armor remains unchanged.
 
 **Example Usage:**
 
@@ -358,9 +361,7 @@ CLASS.scale = 1.2
 
 **Description:**
 
-Default running speed. Set a number to override or a multiplier in
-
-conjunction with `runSpeedMultiplier`.
+Overrides or multiplies the player's running speed. Set a number to replace the speed or a multiplier when used with `runSpeedMultiplier`. If unset, the run speed is unchanged.
 
 **Example Usage:**
 
@@ -401,7 +402,7 @@ CLASS.runSpeedMultiplier = true
 
 **Description:**
 
-Default walking speed.
+Overrides or multiplies the player's walking speed. If unset, the walk speed is unchanged.
 
 **Example Usage:**
 
@@ -437,7 +438,7 @@ CLASS.walkSpeedMultiplier = false
 
 **Description:**
 
-Default jump power.
+Overrides or multiplies the player's jump power. If unset, the jump power is unchanged.
 
 **Example Usage:**
 
@@ -493,7 +494,7 @@ CLASS.bloodcolor = BLOOD_COLOR_RED
 
 **Description:**
 
-Mapping of bodygroup names to index values applied when the player spawns.
+Mapping of bodygroup names to index values applied when the player spawns. If omitted, bodygroups are not modified.
 
 **Example Usage:**
 
@@ -568,7 +569,7 @@ CLASS.skin = 2
 
 **Description:**
 
-List of material paths that replace the model's sub-materials. The first entry applies to sub-material `0`, the second to `1`, and so on.
+List of material paths that replace the model's sub-materials. The first entry applies to sub-material `0`, the second to `1`, and so on. Leave `nil` for no overrides.
 
 **Example Usage:**
 
@@ -589,7 +590,7 @@ CLASS.subMaterials = {
 
 **Description:**
 
-Model path (or list of paths) assigned to this class.
+Model path (or list of paths) assigned to this class. When omitted, the character's existing model is used.
 
 **Example Usage:**
 
@@ -603,16 +604,19 @@ CLASS.model = "models/player/alyx.mdl"
 
 **Type:**
 
-`string`
+`string` or `table`
 
 **Description:**
 
-Text displayed to the player describing what is needed to join this class. This field does not restrict access on its own.
+Text displayed to the player describing what is needed to join this class. Accepts a string or list of strings. This field does not restrict access on its own.
 
 **Example Usage:**
 
 ```lua
-CLASS.requirements = "Flag V and Engineering 25+"
+-- single requirement string
+CLASS.requirements = "Flag V"
+-- or list multiple requirements
+CLASS.requirements = {"Flag V", "Engineering 25+"}
 ```
 
 ---
@@ -627,7 +631,7 @@ CLASS.requirements = "Flag V and Engineering 25+"
 
 Table of command names that members of this class may always use,
 
-overriding standard command permissions.
+overriding standard command permissions. If omitted, no extra commands are granted.
 
 **Example Usage:**
 

--- a/documentation/docs/libraries/lia.classes.md
+++ b/documentation/docs/libraries/lia.classes.md
@@ -111,11 +111,11 @@ end
 
 **Purpose**
 
-Retrieves the class table associated with the given numeric index.
+Retrieves the class table associated with the given identifier.
 
 **Parameters**
 
-* `identifier` (*number*): Numeric index of the class.
+* `identifier` (*number|string*): Class index or uniqueID.
 
 **Realm**
 
@@ -128,8 +128,10 @@ Retrieves the class table associated with the given numeric index.
 **Example Usage**
 
 ```lua
--- Retrieve the class table for the engineer class
+-- Retrieve the class table for the engineer class by index
 local classData = lia.class.get(CLASS_ENGINEER)
+-- or by uniqueID
+local classData2 = lia.class.get("engineer")
 ```
 
 ---

--- a/gamemode/core/libraries/classes.lua
+++ b/gamemode/core/libraries/classes.lua
@@ -1,47 +1,5 @@
-﻿--[[
-# Classes Library
-
-This page documents the functions for working with character classes and job systems.
-
----
-
-## Overview
-
-The classes library provides a system for managing character classes, jobs, and roles within the Lilia framework. It handles class registration, faction association, limits, and provides utilities for class validation and management. The library supports class-specific permissions, whitelisting, and provides a foundation for role-playing game mechanics.
-]]
 lia.class = lia.class or {}
 lia.class.list = lia.class.list or {}
---[[
-    lia.class.register
-
-    Purpose:
-        Registers a new class with the system, or updates an existing one if the uniqueID already exists.
-        Ensures the class has required fields, validates its faction, and stores it in lia.class.list.
-
-    Parameters:
-        uniqueID (string) - The unique identifier for the class.
-        data (table)      - Table containing class properties (name, desc, faction, limit, etc).
-
-    Returns:
-        class (table) - The registered or updated class table.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Register a new class for the "Combine" faction
-        lia.class.register("overwatch", {
-            name = "Overwatch Soldier",
-            desc = "A transhuman soldier of the Combine.",
-            faction = FACTION_COMBINE,
-            limit = 4,
-            isDefault = false,
-            isWhitelisted = true,
-            OnCanBe = function(self, client)
-                return client:IsAdmin()
-            end
-        })
-]]
 function lia.class.register(uniqueID, data)
     assert(isstring(uniqueID), L("classUniqueIDString"))
     assert(istable(data), L("classDataTable"))
@@ -77,26 +35,6 @@ function lia.class.register(uniqueID, data)
     return class
 end
 
---[[
-    lia.class.loadFromDir
-
-    Purpose:
-        Loads all class definition files from the specified directory, registering each as a class.
-        Each file should define a CLASS table. Ensures each class has required fields and a valid faction.
-
-    Parameters:
-        directory (string) - The directory path to search for class files (should be relative to the gamemode).
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Load all classes from the "classes" directory
-        lia.class.loadFromDir("gamemode/schema/classes")
-]]
 function lia.class.loadFromDir(directory)
     for _, v in ipairs(file.Find(directory .. "/*.lua", "LUA")) do
         local index = #lia.class.list + 1
@@ -134,30 +72,6 @@ function lia.class.loadFromDir(directory)
     end
 end
 
---[[
-    lia.class.canBe
-
-    Purpose:
-        Determines if a client is eligible to join a specified class.
-        Checks faction, current class, class limit, hooks, and custom OnCanBe logic.
-
-    Parameters:
-        client (Player) - The player to check eligibility for.
-        class (number)  - The class index to check.
-
-    Returns:
-        (boolean, string|none) - True if the client can join, or false and a reason string if not.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Check if a player can join class 2
-        local canJoin, reason = lia.class.canBe(ply, 2)
-        if not canJoin then
-            print("Cannot join class:", reason)
-        end
-]]
 function lia.class.canBe(client, class)
     local info = lia.class.list[class]
     if not info then return false, L("classNoInfo") end
@@ -169,53 +83,10 @@ function lia.class.canBe(client, class)
     return info.isDefault
 end
 
---[[
-    lia.class.get
-
-    Purpose:
-        Retrieves the class table for the given identifier (index or uniqueID).
-
-    Parameters:
-        identifier (number|string) - The class index or uniqueID.
-
-    Returns:
-        class (table|none) - The class table if found, or none.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Get the class table for index 1
-        local class = lia.class.get(1)
-        -- Get the class table for uniqueID "overwatch"
-        local class2 = lia.class.get("overwatch")
-]]
 function lia.class.get(identifier)
     return lia.class.list[identifier]
 end
 
---[[
-    lia.class.getPlayers
-
-    Purpose:
-        Returns a table of all players currently in the specified class.
-
-    Parameters:
-        class (number) - The class index to search for.
-
-    Returns:
-        players (table) - Table of player entities in the class.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Get all players in class 3
-        local players = lia.class.getPlayers(3)
-        for _, ply in ipairs(players) do
-            print(ply:Name())
-        end
-]]
 function lia.class.getPlayers(class)
     local players = {}
     for _, v in player.Iterator() do
@@ -225,25 +96,6 @@ function lia.class.getPlayers(class)
     return players
 end
 
---[[
-    lia.class.getPlayerCount
-
-    Purpose:
-        Returns the number of players currently in the specified class.
-
-    Parameters:
-        class (number) - The class index to count.
-
-    Returns:
-        count (number) - The number of players in the class.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Print the number of players in class 2
-        print("Players in class 2:", lia.class.getPlayerCount(2))
-]]
 function lia.class.getPlayerCount(class)
     local count = 0
     for _, v in player.Iterator() do
@@ -253,28 +105,6 @@ function lia.class.getPlayerCount(class)
     return count
 end
 
---[[
-    lia.class.retrieveClass
-
-    Purpose:
-        Finds the class index for a class by matching its uniqueID or name (case-insensitive, partial match allowed).
-
-    Parameters:
-        class (string) - The uniqueID or name (or partial) to search for.
-
-    Returns:
-        index (number|none) - The class index if found, or none.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Retrieve the class index for "overwatch"
-        local idx = lia.class.retrieveClass("overwatch")
-        if idx then
-            print("Class index is:", idx)
-        end
-]]
 function lia.class.retrieveClass(class)
     for key, classTable in pairs(lia.class.list) do
         if lia.util.stringMatches(classTable.uniqueID, class) or lia.util.stringMatches(classTable.name, class) then return key end
@@ -282,27 +112,6 @@ function lia.class.retrieveClass(class)
     return nil
 end
 
---[[
-    lia.class.hasWhitelist
-
-    Purpose:
-        Checks if the specified class requires a whitelist (i.e., is not default and is marked as whitelisted).
-
-    Parameters:
-        class (number) - The class index to check.
-
-    Returns:
-        (boolean) - True if the class is whitelisted, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Check if class 4 is whitelisted
-        if lia.class.hasWhitelist(4) then
-            print("Class 4 requires a whitelist.")
-        end
-]]
 function lia.class.hasWhitelist(class)
     local info = lia.class.list[class]
     if not info then return false end
@@ -310,28 +119,6 @@ function lia.class.hasWhitelist(class)
     return info.isWhitelisted
 end
 
---[[
-    lia.class.retrieveJoinable
-
-    Purpose:
-        Returns a table of all classes that the given client is eligible to join.
-
-    Parameters:
-        client (Player) - The player to check joinable classes for. If nil, uses LocalPlayer() on client.
-
-    Returns:
-        classes (table) - Table of class tables the client can join.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Get all joinable classes for a player
-        local joinable = lia.class.retrieveJoinable(ply)
-        for _, class in ipairs(joinable) do
-            print("Can join:", class.name)
-        end
-]]
 function lia.class.retrieveJoinable(client)
     client = client or CLIENT and LocalPlayer() or nil
     if not IsValid(client) then return {} end


### PR DESCRIPTION
## Summary
- align class field documentation with current implementation
- clarify lia.class.get accepts indices or unique IDs
- strip migrated documentation blocks from classes library

## Testing
- `luacheck gamemode/core/libraries/classes.lua` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: Unable to locate package luacheck)*

------
https://chatgpt.com/codex/tasks/task_e_689838a0ca548327a99d4fe429abd3b6