### PR TITLE
docs: sync tool meta documentation

### DIFF
--- a/documentation/docs/meta/tool.md
+++ b/documentation/docs/meta/tool.md
@@ -20,6 +20,19 @@ They ensure consistent behavior across custom tools in Lilia.
 
 Creates a new tool object with default values.
 
+The returned table includes:
+
+* `Mode`: `nil`
+* `SWEP`: `nil`
+* `Owner`: `nil`
+* `ClientConVar`: `{}`
+* `ServerConVar`: `{}`
+* `Objects`: `{}`
+* `Stage`: `0`
+* `Message`: `L("start")`
+* `LastMessage`: `0`
+* `AllowedCVar`: `0`
+
 **Parameters**
 
 * None
@@ -50,6 +63,12 @@ tool.Owner = client -- client that spawned the tool
 
 Creates client and server ConVars for this tool.
 
+Client-side, every entry in `ClientConVar` becomes a persistent
+convar named `<mode>_<cvar>` with its default value.
+
+Server-side, a convar named `toolmode_allow_<mode>` is created with a
+default value of `1` and stored in `self.AllowedCVar`.
+
 **Parameters**
 
 * None
@@ -67,6 +86,91 @@ Creates client and server ConVars for this tool.
 ```lua
 -- Ensure console variables exist for configuration
 tool:CreateConVars()
+```
+
+
+---
+
+### UpdateData
+
+**Purpose**
+
+Placeholder for updating tool data. Override in specific tools.
+
+**Parameters**
+
+* None
+
+**Realm**
+
+`Shared`
+
+**Returns**
+
+* `None`: This function does not return a value.
+
+**Example Usage**
+
+```lua
+function TOOL:UpdateData()
+    self.Stage = 1
+end
+```
+
+---
+
+### FreezeMovement
+
+**Purpose**
+
+Placeholder to freeze player movement while using the tool.
+
+**Parameters**
+
+* None
+
+**Realm**
+
+`Shared`
+
+**Returns**
+
+* `None`: This function does not return a value.
+
+**Example Usage**
+
+```lua
+function TOOL:FreezeMovement()
+    return true -- stop movement
+end
+```
+
+---
+
+### DrawHUD
+
+**Purpose**
+
+Draws custom HUD information for the tool.
+
+**Parameters**
+
+* None
+
+**Realm**
+
+`Client`
+
+**Returns**
+
+* `None`: This function does not return a value.
+
+**Example Usage**
+
+```lua
+function TOOL:DrawHUD()
+    draw.SimpleText("Using tool", "DermaDefault", 8, 8, color_white)
+end
 ```
 
 ---
@@ -162,7 +266,7 @@ Retrieves a numeric client ConVar value.
 
 * `property` (*string*): ConVar name without mode prefix.
 
-* `default` (*number*): Value returned if the ConVar doesn't exist.
+* `default` (*number*): Value returned if the ConVar doesn't exist. Converted to a number and falling back to `0` if not provided or non-numeric.
 
 **Realm**
 
@@ -170,7 +274,7 @@ Retrieves a numeric client ConVar value.
 
 **Returns**
 
-* number: The numeric value of the ConVar.
+* number: The numeric value of the ConVar or the provided default.
 
 **Example Usage**
 
@@ -197,13 +301,14 @@ Determines whether this tool is allowed to be used.
 
 **Returns**
 
-* boolean: True if the tool is allowed.
+* boolean: `true` on the client. On the server, the value of `self.AllowedCVar`.
 
 **Example Usage**
 
 ```lua
 -- Gate tool usage behind an admin check
 function TOOL:Allowed()
+    if CLIENT then return true end
     return self.AllowedCVar:GetBool() and self:GetOwner():IsAdmin()
 end
 ```
@@ -299,6 +404,9 @@ local result = tool:GetSWEP()
 
 Returns the player who owns the associated weapon.
 
+Internally it retrieves `self:GetSWEP().Owner` and falls back to
+`self:GetOwner()` if that is unavailable.
+
 **Parameters**
 
 * None
@@ -309,7 +417,7 @@ Returns the player who owns the associated weapon.
 
 **Returns**
 
-* Player: Owner of the tool.
+* Player: Owner of the tool or `nil` if unavailable.
 
 **Example Usage**
 
@@ -431,7 +539,6 @@ Clears stored objects when the tool reloads.
 ```lua
 function TOOL:Reload()
     self:ClearObjects()
-    self:ReleaseGhostEntity()
 end
 ```
 
@@ -460,7 +567,6 @@ Called when the tool is equipped. Releases ghost entity.
 ```lua
 function TOOL:Deploy()
     self:ReleaseGhostEntity()
-    self:CreateConVars()
 end
 ```
 
@@ -489,7 +595,6 @@ Called when the tool is holstered. Releases ghost entity.
 ```lua
 function TOOL:Holster()
     self:ReleaseGhostEntity()
-    self:ClearObjects()
 end
 ```
 
@@ -499,7 +604,7 @@ end
 
 **Purpose**
 
-Called every tick; releases ghost entities by default.
+Called every tick; releases the ghost entity.
 
 **Parameters**
 
@@ -517,8 +622,7 @@ Called every tick; releases ghost entities by default.
 
 ```lua
 function TOOL:Think()
-    self:CheckObjects()
-    updateGhost(self:GetOwner(), self.GhostEntity)
+    self:ReleaseGhostEntity()
 end
 ```
 
@@ -546,7 +650,7 @@ Validates stored objects and clears them if invalid.
 
 ```lua
 -- Validate all stored objects each tick
-local result = tool:CheckObjects()
+tool:CheckObjects()
 ```
 
 ---
@@ -573,7 +677,7 @@ Removes all stored objects from the tool.
 
 ```lua
 -- Remove any objects the tool is storing
-local result = tool:ClearObjects()
+tool:ClearObjects()
 ```
 
 ---
@@ -600,7 +704,7 @@ Removes the ghost entity used for previewing placements.
 
 ```lua
 -- Remove the placement preview entity
-local result = tool:ReleaseGhostEntity()
+tool:ReleaseGhostEntity()
 ```
 
 ---


### PR DESCRIPTION
## Summary
- expand Create documentation with default tool fields
- document UpdateData, FreezeMovement, and DrawHUD placeholders
- align Allowed, Reload, Deploy, Holster, and Think sections with current tool logic

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_689838984a448327b40b1c6c31d4f9df