### PR TITLE
docs: refresh data library docs

### DIFF
--- a/documentation/docs/libraries/lia.data.md
+++ b/documentation/docs/libraries/lia.data.md
@@ -1,30 +1,28 @@
 # Data Library
 
-This page describes persistent data storage helpers.
+Helpers for serializing Lua data and storing persistent values.
 
 ---
 
 ## Overview
 
-The data library keeps persistent values inside a single `lia_data` database table. Each row is keyed by the current gamemode folder and map using the `_folder` and `_map` columns. All saved key/value pairs are stored together inside the `_data` column as JSON. Values are cached in memory inside `lia.data.stored` for quick access. Entity persistence loaded via `lia.data.loadPersistenceData` is kept in `lia.data.persistCache`.
+The data library stores arbitrary key/value pairs in the `lia_data` SQL table. Each entry is
+scoped by the gamemode folder and map and cached in `lia.data.stored`. Serialization helpers
+encode vectors, angles and colour tables into simple tables so they can be stored in JSON
+and later restored.
 
 ---
 
-### lia.data.set
+### lia.data.encodetable
 
 **Purpose**
 
-Saves the provided value under the specified key in the single `lia_data` table and caches it in `lia.data.stored`.
+Recursively converts values (including `Vector`, `Angle` and colour tables) into
+serialisable tables.
 
 **Parameters**
 
-* `key` (*string*): Key under which the data is stored.
-
-* `value` (*any*): Value to store.
-
-* `global` (*boolean*): Store without gamemode or map restrictions.
-
-* `ignoreMap` (*boolean*): Omit the map name from the stored entry.
+* `value` (*any*): Data to encode.
 
 **Realm**
 
@@ -32,16 +30,177 @@ Saves the provided value under the specified key in the single `lia_data` table 
 
 **Returns**
 
-* *string*: The path where the data was saved.
+* *any*: Encoded representation.
 
 **Example Usage**
 
 ```lua
-concommand.Add("save_spawn", function(ply)
-    if ply:IsAdmin() then
-        lia.data.set("spawn_pos", ply:GetPos(), true)
-    end
-end)
+local encoded = lia.data.encodetable({pos = Vector(1, 2, 3)})
+-- encoded.pos == {1, 2, 3}
+```
+
+---
+
+### lia.data.decode
+
+**Purpose**
+
+Recursively restores values encoded by `lia.data.encodetable`, turning
+tables or strings representing vectors or angles back into their original types.
+
+**Parameters**
+
+* `value` (*any*): Data to decode.
+
+**Realm**
+
+`Server`
+
+**Returns**
+
+* *any*: Decoded value.
+
+**Example Usage**
+
+```lua
+local vec = lia.data.decode({1, 2, 3})
+-- vec == Vector(1, 2, 3)
+```
+
+---
+
+### lia.data.serialize
+
+**Purpose**
+
+Encodes a value with `lia.data.encodetable` and converts it to a JSON string.
+
+**Parameters**
+
+* `value` (*any*): Value to serialise.
+
+**Realm**
+
+`Server`
+
+**Returns**
+
+* *string*: JSON representation.
+
+**Example Usage**
+
+```lua
+local json = lia.data.serialize({pos = Vector(1, 2, 3)})
+```
+
+---
+
+### lia.data.deserialize
+
+**Purpose**
+
+Parses JSON or PON strings (or tables) and decodes any vectors or angles.
+
+**Parameters**
+
+* `raw` (*string|table*): Serialised data.
+
+**Realm**
+
+`Server`
+
+**Returns**
+
+* *any | nil*: Decoded value or `nil` if the input cannot be parsed.
+
+**Example Usage**
+
+```lua
+local data = lia.data.deserialize(json)
+```
+
+---
+
+### lia.data.decodeVector
+
+**Purpose**
+
+Converts a table or string in common vector formats (including JSON and PON)
+into a `Vector`.
+
+**Parameters**
+
+* `raw` (*any*): Data to decode.
+
+**Realm**
+
+`Server`
+
+**Returns**
+
+* *Vector | nil*: Resulting vector, or `nil` if the value cannot be converted.
+
+**Example Usage**
+
+```lua
+local pos = lia.data.decodeVector("[1, 2, 3]")
+```
+
+---
+
+### lia.data.decodeAngle
+
+**Purpose**
+
+Converts a table or string in common angle formats (including JSON and PON)
+into an `Angle`.
+
+**Parameters**
+
+* `raw` (*any*): Data to decode.
+
+**Realm**
+
+`Server`
+
+**Returns**
+
+* *Angle | nil*: Resulting angle, or `nil` if the value cannot be converted.
+
+**Example Usage**
+
+```lua
+local ang = lia.data.decodeAngle("{0, 90, 0}")
+```
+
+---
+
+### lia.data.set
+
+**Purpose**
+
+Stores a value under the given key and writes the entire cache to the `lia_data`
+table. Data can be scoped to a specific gamemode and map.
+
+**Parameters**
+
+* `key` (*string*): Storage key.
+* `value` (*any*): Value to store.
+* `global` (*boolean*): Ignore gamemode and map.
+* `ignoreMap` (*boolean*): Ignore the map but still use the gamemode.
+
+**Realm**
+
+`Server`
+
+**Returns**
+
+* *string*: Path used to identify where the data was saved.
+
+**Example Usage**
+
+```lua
+lia.data.set("spawnPos", Vector(0, 0, 0))
 ```
 
 ---
@@ -50,15 +209,13 @@ end)
 
 **Purpose**
 
-Removes the stored value corresponding to the key from the `lia_data` table and clears the cached entry in `lia.data.stored`.
+Removes a key from the cache and updates the `lia_data` table.
 
 **Parameters**
 
-* `key` (*string*): Key corresponding to the data to delete.
-
-* `global` (*boolean*): Store without gamemode or map restrictions.
-
-* `ignoreMap` (*boolean*): Omit the map name from the stored entry.
+* `key` (*string*): Key to remove.
+* `global` (*boolean*): Ignore gamemode and map.
+* `ignoreMap` (*boolean*): Ignore the map but still use the gamemode.
 
 **Realm**
 
@@ -66,12 +223,12 @@ Removes the stored value corresponding to the key from the `lia_data` table and 
 
 **Returns**
 
-* *boolean*: Always `true`; the deletion query is queued.
+* *boolean*: Always `true`; the deletion is queued asynchronously.
 
 **Example Usage**
 
 ```lua
-lia.data.delete("spawn_pos")
+lia.data.delete("spawnPos")
 ```
 
 ---
@@ -80,13 +237,12 @@ lia.data.delete("spawn_pos")
 
 **Purpose**
 
-Retrieves the stored value for the specified key from the cache.
+Retrieves a stored value, deserialising it if required.
 
 **Parameters**
 
-* `key` (*string*): Key corresponding to the data.
-
-* `default` (*any*): Default value to return if no data is found.
+* `key` (*string*): Key to fetch.
+* `default` (*any*): Value returned when the key does not exist.
 
 **Realm**
 
@@ -94,17 +250,12 @@ Retrieves the stored value for the specified key from the cache.
 
 **Returns**
 
-* *any*: The stored value or the default if not found.
+* *any*: Stored value or the provided default.
 
 **Example Usage**
 
 ```lua
-hook.Add("PlayerSpawn", "UseSavedSpawn", function(ply)
-    local pos = lia.data.get("spawn_pos", vector_origin)
-    if pos then
-        ply:SetPos(pos)
-    end
-end)
+local pos = lia.data.get("spawnPos", Vector(0, 0, 0))
 ```
 
 ---
@@ -113,7 +264,8 @@ end)
 
 **Purpose**
 
-Loads the appropriate entry from the `lia_data` table into `lia.data.stored`.
+Loads global, gamemode and map‑specific entries from the `lia_data` table
+into `lia.data.stored`.
 
 **Parameters**
 
@@ -131,162 +283,6 @@ Loads the appropriate entry from the `lia_data` table into `lia.data.stored`.
 
 ```lua
 lia.data.loadTables()
-
-```
-
----
-### lia.data.encodetable
-
-**Purpose**
-
-Recursively converts vectors, angles, and colours into plain tables so they can be serialised.
-
-**Parameters**
-
-* `value` (*any*): Data to encode.
-
-**Realm**
-
-`Server`
-
-**Returns**
-
-* *any*: The encoded representation.
-
-**Example Usage**
-
-```lua
-local tbl = lia.data.encodetable(Vector(0, 0, 0))
-```
-
----
-
-### lia.data.decode
-
-**Purpose**
-
-Restores vectors, angles and colours from data processed by `lia.data.encodetable`.
-
-**Parameters**
-
-* `value` (*any*): Data to decode.
-
-**Realm**
-
-`Server`
-
-**Returns**
-
-* *any*: The decoded value.
-
-**Example Usage**
-
-```lua
-local vec = lia.data.decode({0, 0, 0})
-```
-
----
-
-### lia.data.serialize
-
-**Purpose**
-
-Encodes a value and converts it into a JSON string.
-
-**Parameters**
-
-* `value` (*any*): Value to serialize.
-
-**Realm**
-
-`Server`
-
-**Returns**
-
-* *string*: JSON representation of the value.
-
-**Example Usage**
-
-```lua
-local json = lia.data.serialize({pos = Vector(1, 2, 3)})
-```
-
----
-
-### lia.data.deserialize
-
-**Purpose**
-
-Parses a stored string and decodes any vectors, angles or colours.
-
-**Parameters**
-
-* `raw` (*string*): Serialized data.
-
-**Realm**
-
-`Server`
-
-**Returns**
-
-* *any | nil*: Decoded value or `nil` on failure.
-
-**Example Usage**
-
-```lua
-local val = lia.data.deserialize(jsonData)
-```
-
----
-
-### lia.data.decodeVector
-
-**Purpose**
-
-Converts a stored string back into a `Vector`.
-
-**Parameters**
-
-* `raw` (*string*): Serialized vector.
-
-**Realm**
-
-`Server`
-
-**Returns**
-
-* *Vector | any*: Decoded vector or the original value.
-
-**Example Usage**
-
-```lua
-local pos = lia.data.decodeVector("[1, 2, 3]")
-```
-
----
-
-### lia.data.decodeAngle
-
-**Purpose**
-
-Converts a stored string back into an `Angle`.
-
-**Parameters**
-
-* `raw` (*string*): Serialized angle.
-
-**Realm**
-
-`Server`
-
-**Returns**
-
-* *Angle | any*: Decoded angle or the original value.
-
-**Example Usage**
-
-```lua
-local ang = lia.data.decodeAngle("{0, 90, 0}")
 ```
 
 ---
@@ -295,7 +291,7 @@ local ang = lia.data.decodeAngle("{0, 90, 0}")
 
 **Purpose**
 
-Ensures the persistence database tables contain all required columns.
+Ensures all default columns exist in the `lia_persistence` table.
 
 **Parameters**
 
@@ -307,13 +303,13 @@ Ensures the persistence database tables contain all required columns.
 
 **Returns**
 
-* *deferred*: Resolves once the columns exist.
+* *Promise*: Resolves once the columns are present.
 
 **Example Usage**
 
 ```lua
 lia.data.loadPersistence():next(function()
-    print("Persistence columns ready")
+    print("Ready")
 end)
 ```
 
@@ -323,7 +319,9 @@ end)
 
 **Purpose**
 
-Writes a list of entity tables to the database so they persist across restarts.
+Writes a list of entity tables to `lia_persistence`. Extra fields on entities
+are stored in dynamically created columns. The cache `lia.data.persistCache`
+is updated.
 
 **Parameters**
 
@@ -340,7 +338,9 @@ Writes a list of entity tables to the database so they persist across restarts.
 **Example Usage**
 
 ```lua
-lia.data.savePersistence(myEntities)
+lia.data.savePersistence({
+    {class = "prop_physics", pos = Vector(1,2,3), angles = Angle(0,0,0), model = "models/props_c17/oildrum001.mdl"}
+})
 ```
 
 ---
@@ -349,11 +349,12 @@ lia.data.savePersistence(myEntities)
 
 **Purpose**
 
-Loads persisted entity data into `lia.data.persistCache`.
+Fetches persisted entities for the current gamemode and map, decodes all fields
+and stores the result in `lia.data.persistCache`.
 
 **Parameters**
 
-* `callback` (*function*): Called with the loaded entities.
+* `callback` (*function*): Receives the loaded entities.
 
 **Realm**
 
@@ -366,8 +367,8 @@ Loads persisted entity data into `lia.data.persistCache`.
 **Example Usage**
 
 ```lua
-lia.data.loadPersistenceData(function(ents)
-    print("Loaded", #ents, "entities")
+lia.data.loadPersistenceData(function(entities)
+    print(#entities, "entities loaded")
 end)
 ```
 
@@ -377,7 +378,7 @@ end)
 
 **Purpose**
 
-Returns the cached entity table populated by `lia.data.loadPersistenceData`.
+Returns the cached entities loaded by `lia.data.loadPersistenceData`.
 
 **Parameters**
 
@@ -389,12 +390,12 @@ Returns the cached entity table populated by `lia.data.loadPersistenceData`.
 
 **Returns**
 
-* *table*: Cached persistence data.
+* *table*: Cached entity data.
 
 **Example Usage**
 
 ```lua
-local saved = lia.data.getPersistence()
+local entities = lia.data.getPersistence()
 ```
 
 ---

--- a/gamemode/core/libraries/data.lua
+++ b/gamemode/core/libraries/data.lua
@@ -1,45 +1,5 @@
-﻿--[[
-# Data Library
-
-This page documents the functions for working with data serialization and storage.
-
----
-
-## Overview
-
-The data library provides utilities for encoding, decoding, and managing data structures within the Lilia framework. It handles serialization of complex data types like Vectors, Angles, and Colors, and provides functions for data persistence and retrieval. The library supports various data formats and provides utilities for working with stored data.
-]]
 lia.data = lia.data or {}
 lia.data.stored = lia.data.stored or {}
---[[
-    lia.data.encodetable
-
-    Purpose:
-        Recursively encodes tables, vectors, angles, and color tables into a serializable format suitable for storage (e.g., JSON).
-        Converts Vectors to {x, y, z}, Angles to {p, y, r}, and color tables to {r, g, b, a}.
-
-    Parameters:
-        value (any) - The value to encode. Can be a table, Vector, Angle, or color table.
-
-    Returns:
-        Encoded value (table or primitive).
-
-    Realm:
-        Server.
-
-    Example Usage:
-        local vec = Vector(1, 2, 3)
-        local encodedVec = lia.data.encodetable(vec)
-        -- encodedVec is {1, 2, 3}
-
-        local ang = Angle(10, 20, 30)
-        local encodedAng = lia.data.encodetable(ang)
-        -- encodedAng is {10, 20, 30}
-
-        local color = {r = 255, g = 128, b = 64, a = 200}
-        local encodedColor = lia.data.encodetable(color)
-        -- encodedColor is {255, 128, 64, 200}
-]]
 function lia.data.encodetable(value)
     if isvector(value) then
         return {value.x, value.y, value.z}
@@ -108,82 +68,14 @@ local function deepDecode(value)
     return value
 end
 
---[[
-    lia.data.decode
-
-    Purpose:
-        Recursively decodes a value, converting tables or strings that represent Angles or Vectors back into their respective types.
-        Useful for restoring data that was previously encoded and serialized.
-
-    Parameters:
-        value (any) - The value to decode. Can be a table, string, or primitive.
-
-    Returns:
-        Decoded value (table, Vector, Angle, or primitive).
-
-    Realm:
-        Server.
-
-    Example Usage:
-        local encoded = {1, 2, 3}
-        local vec = lia.data.decode(encoded)
-        -- vec is Vector(1, 2, 3)
-
-        local encodedAng = {10, 20, 30}
-        local ang = lia.data.decode(encodedAng)
-        -- ang is Angle(10, 20, 30)
-]]
 function lia.data.decode(value)
     return deepDecode(value)
 end
 
---[[
-    lia.data.serialize
-
-    Purpose:
-        Serializes a value (table, Vector, Angle, etc.) into a JSON string for storage.
-        Uses lia.data.encodetable to ensure all data is in a serializable format.
-
-    Parameters:
-        value (any) - The value to serialize.
-
-    Returns:
-        (string) - JSON-encoded string.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        local data = {pos = Vector(1, 2, 3), ang = Angle(10, 20, 30)}
-        local json = lia.data.serialize(data)
-        -- json is a string like '{"pos":[1,2,3],"ang":[10,20,30]}'
-]]
 function lia.data.serialize(value)
     return util.TableToJSON(lia.data.encodetable(value) or {})
 end
 
---[[
-    lia.data.deserialize
-
-    Purpose:
-        Deserializes a JSON string or table into a Lua table, and decodes any encoded Vectors or Angles.
-        Supports both JSON and PON formats.
-
-    Parameters:
-        raw (string|table) - The raw data to deserialize.
-
-    Returns:
-        (table|any) - The deserialized and decoded value, or nil if input is invalid.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        local json = '{"pos":[1,2,3],"ang":[10,20,30]}'
-        local data = lia.data.deserialize(json)
-        -- data.pos is Vector(1, 2, 3)
-        -- data.ang is Angle(10, 20, 30)
-]]
 function lia.data.deserialize(raw)
     if not raw then return nil end
     local decoded
@@ -203,31 +95,6 @@ function lia.data.deserialize(raw)
     return lia.data.decode(decoded)
 end
 
---[[
-    lia.data.decodeVector
-
-    Purpose:
-        Decodes a value into a Vector, supporting tables, JSON strings, and PON strings.
-        Returns nil if the input is invalid or cannot be converted.
-
-    Parameters:
-        raw (any) - The value to decode as a Vector.
-
-    Returns:
-        (Vector|any) - The decoded Vector, or the original value if not convertible.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        local json = '[1,2,3]'
-        local vec = lia.data.decodeVector(json)
-        -- vec is Vector(1, 2, 3)
-
-        local tbl = {1, 2, 3}
-        local vec2 = lia.data.decodeVector(tbl)
-        -- vec2 is Vector(1, 2, 3)
-]]
 function lia.data.decodeVector(raw)
     if not raw then return nil end
     local decoded
@@ -247,31 +114,6 @@ function lia.data.decodeVector(raw)
     return _decodeVector(decoded)
 end
 
---[[
-    lia.data.decodeAngle
-
-    Purpose:
-        Decodes a value into an Angle, supporting tables, JSON strings, and PON strings.
-        Returns nil if the input is invalid or cannot be converted.
-
-    Parameters:
-        raw (any) - The value to decode as an Angle.
-
-    Returns:
-        (Angle|any) - The decoded Angle, or the original value if not convertible.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        local json = '[10,20,30]'
-        local ang = lia.data.decodeAngle(json)
-        -- ang is Angle(10, 20, 30)
-
-        local tbl = {10, 20, 30}
-        local ang2 = lia.data.decodeAngle(tbl)
-        -- ang2 is Angle(10, 20, 30)
-]]
 function lia.data.decodeAngle(raw)
     if not raw then return nil end
     local decoded
@@ -297,32 +139,6 @@ local function buildCondition(gamemode, map)
     return cond
 end
 
---[[
-    lia.data.set
-
-    Purpose:
-        Sets a key-value pair in the persistent data store, optionally scoped to a gamemode and map.
-        Updates both the in-memory cache and the database asynchronously.
-
-    Parameters:
-        key (string)      - The key to set.
-        value (any)       - The value to store.
-        global (boolean)  - If true, stores globally (ignores gamemode and map).
-        ignoreMap (bool)  - If true, ignores the map when scoping.
-
-    Returns:
-        (string) - The path used for storage.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        lia.data.set("spawnPos", Vector(100, 200, 300))
-        -- Stores the spawn position for the current gamemode and map.
-
-        lia.data.set("globalSetting", true, true)
-        -- Stores a global setting, not tied to any gamemode or map.
-]]
 function lia.data.set(key, value, global, ignoreMap)
     local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
     local map = ignoreMap and NULL or game.GetMap()
@@ -350,31 +166,6 @@ function lia.data.set(key, value, global, ignoreMap)
     return path
 end
 
---[[
-    lia.data.delete
-
-    Purpose:
-        Deletes a key from the persistent data store, optionally scoped to a gamemode and map.
-        Updates both the in-memory cache and the database asynchronously.
-
-    Parameters:
-        key (string)      - The key to delete.
-        global (boolean)  - If true, deletes globally (ignores gamemode and map).
-        ignoreMap (bool)  - If true, ignores the map when scoping.
-
-    Returns:
-        (boolean) - Always true.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        lia.data.delete("spawnPos")
-        -- Removes the spawn position for the current gamemode and map.
-
-        lia.data.delete("globalSetting", true)
-        -- Removes a global setting, not tied to any gamemode or map.
-]]
 function lia.data.delete(key, global, ignoreMap)
     local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
     local map = ignoreMap and nil or game.GetMap()
@@ -400,27 +191,6 @@ function lia.data.delete(key, global, ignoreMap)
     return true
 end
 
---[[
-    lia.data.loadTables
-
-    Purpose:
-        Loads persistent data from the database for the current gamemode and map, as well as global and gamemode-only data.
-        Populates lia.data.stored with the loaded data.
-
-    Parameters:
-        None.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        -- Typically called automatically on server start, but can be called manually:
-        lia.data.loadTables()
-        -- Loads all relevant persistent data into lia.data.stored.
-]]
 function lia.data.loadTables()
     local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
     local map = game.GetMap()
@@ -472,55 +242,10 @@ local function ensurePersistenceColumns(cols)
     return d
 end
 
---[[
-    lia.data.loadPersistence
-
-    Purpose:
-        Ensures that all required columns exist in the persistence table for entity saving/loading.
-        Adds any missing columns for default entity fields.
-
-    Parameters:
-        None.
-
-    Returns:
-        (Promise) - Resolves when all columns are ensured.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        lia.data.loadPersistence():next(function()
-            print("Persistence columns are ready!")
-        end)
-]]
 function lia.data.loadPersistence()
     return ensurePersistenceColumns(baseCols)
 end
 
---[[
-    lia.data.savePersistence
-
-    Purpose:
-        Saves a list of entities to the persistence table in the database, including dynamic fields.
-        Ensures all necessary columns exist before saving.
-
-    Parameters:
-        entities (table) - A list of entity tables to persist.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        local entities = {
-            {class = "prop_physics", pos = Vector(1,2,3), angles = Angle(0,0,0), model = "models/props_c17/oildrum001.mdl"},
-            {class = "npc_citizen", pos = Vector(4,5,6), angles = Angle(0,90,0), model = "models/Humans/Group01/male_01.mdl"}
-        }
-        lia.data.savePersistence(entities)
-        -- Saves the provided entities to the database for the current gamemode and map.
-]]
 function lia.data.savePersistence(entities)
     local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
     local map = game.GetMap()
@@ -569,29 +294,6 @@ function lia.data.savePersistence(entities)
     end)
 end
 
---[[
-    lia.data.loadPersistenceData
-
-    Purpose:
-        Loads all persisted entities for the current gamemode and map from the database.
-        Decodes all fields and passes the result to the provided callback.
-
-    Parameters:
-        callback (function) - Function to call with the loaded entities table.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        lia.data.loadPersistenceData(function(entities)
-            for _, ent in ipairs(entities) do
-                print("Loaded entity:", ent.class, ent.pos, ent.angles)
-            end
-        end)
-]]
 function lia.data.loadPersistenceData(callback)
     local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
     local map = game.GetMap()
@@ -617,27 +319,6 @@ function lia.data.loadPersistenceData(callback)
     end)
 end
 
---[[
-    lia.data.get
-
-    Purpose:
-        Retrieves a value from the persistent data store by key, decoding it if necessary.
-        If the value is not found, returns the provided default.
-
-    Parameters:
-        key (string)      - The key to retrieve.
-        default (any)     - The default value to return if the key is not found.
-
-    Returns:
-        (any) - The stored value, or the default if not found.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        local spawnPos = lia.data.get("spawnPos", Vector(0,0,0))
-        -- Returns the stored spawn position, or Vector(0,0,0) if not set.
-]]
 function lia.data.get(key, default)
     local stored = lia.data.stored[key]
     if stored ~= nil then
@@ -650,27 +331,6 @@ function lia.data.get(key, default)
     return default
 end
 
---[[
-    lia.data.getPersistence
-
-    Purpose:
-        Retrieves the current cache of persisted entities loaded from the database.
-
-    Parameters:
-        None.
-
-    Returns:
-        (table) - The list of persisted entities, or an empty table if none are loaded.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        local entities = lia.data.getPersistence()
-        for _, ent in ipairs(entities) do
-            print(ent.class, ent.pos)
-        end
-]]
 function lia.data.getPersistence()
     return lia.data.persistCache or {}
 end


### PR DESCRIPTION
## Summary
- document data serialization helpers and persistence utilities in `lia.data` with up-to-date parameters, return values, examples and edge cases
- remove outdated inline comment blocks from `data.lua`

## Testing
- `luacheck gamemode/core/libraries/data.lua` *(fails: 135 warnings, 0 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68983be28270832793474a07a012cdaf