### PR TITLE
docs: update languages library documentation

### DIFF
--- a/documentation/docs/libraries/lia.languages.md
+++ b/documentation/docs/libraries/lia.languages.md
@@ -6,9 +6,7 @@ This page explains how translations and phrases are loaded.
 
 ## Overview
 
-The languages library loads localisation files from directories, resolves phrase keys to translated text, and supports runtime language switching. Language files live in `languages/<langname>.lua` inside schemas or modules; each file defines a `LANGUAGE` table of phrases. Loaded phrases are cached in `lia.lang.stored`, while user-facing language names are kept in `lia.lang.names`.
-
-Language files may also set a global `NAME` variable containing the display name for that language. When `lia.lang.loadFromDir` includes such a file, the name is inserted into `lia.lang.names` alongside the phrases. The framework automatically loads its bundled translations from `gamemode/languages` during initialisation.
+The languages library loads localisation files from directories, resolves phrase keys to translated text, and supports runtime language switching. Language files live in `languages/<langname>.lua` inside schemas or modules; each file defines a `LANGUAGE` table of phrases. Loaded phrases are cached in `lia.lang.stored`, while display names defined through a global `NAME` variable are kept in `lia.lang.names`. During start-up the framework automatically loads its bundled translations from `lilia/gamemode/languages` and then fires the `OnLocalizationLoaded` hook.
 
 ---
 
@@ -16,7 +14,7 @@ Language files may also set a global `NAME` variable containing the display name
 
 **Purpose**
 
-Loads every Lua language file in a directory and merges their `LANGUAGE` tables into the cache.
+Loads every Lua language file in a directory and merges their `LANGUAGE` tables into the cache. Keys and values are coerced to strings and an optional global `NAME` is stored in `lia.lang.names`.
 
 **Parameters**
 
@@ -43,7 +41,7 @@ lia.lang.loadFromDir(SCHEMA.folder .. "/languages")
 
 **Purpose**
 
-Adds or merges key-value pairs into an existing language table.
+Adds or merges key-value pairs into an existing language table. Keys and values are converted to strings and existing entries are overwritten.
 
 **Parameters**
 
@@ -71,11 +69,39 @@ lia.lang.AddTable("english", {
 
 ---
 
+### lia.lang.getLanguages
+
+**Purpose**
+
+Returns a sorted list of the identifiers for all loaded languages with their first letter capitalised.
+
+**Parameters**
+
+*None*
+
+**Realm**
+
+`Shared`
+
+**Returns**
+
+* `table`: Alphabetically sorted language names.
+
+**Example Usage**
+
+```lua
+for _, lang in ipairs(lia.lang.getLanguages()) do
+    print(lang)
+end
+```
+
+---
+
 ### L
 
 **Purpose**
 
-Returns the translated phrase for a key in the active language, using `string.format` with any additional arguments.
+Returns the translated phrase for a key in the active language, using `string.format` with any additional arguments. Missing translations return the key itself. If fewer arguments are supplied than `%s` placeholders, the extras default to empty strings. The active language defaults to `"english"` when not configured.
 
 **Parameters**
 
@@ -89,7 +115,7 @@ Returns the translated phrase for a key in the active language, using `string.fo
 
 **Returns**
 
-* *string*: Translated phrase, or the key itself if no translation exists.
+* `string`: Translated phrase, or the key itself if no translation exists.
 
 **Example Usage**
 

--- a/gamemode/core/libraries/languages.lua
+++ b/gamemode/core/libraries/languages.lua
@@ -1,38 +1,8 @@
-﻿--[[
-# Languages Library
-
-This page documents the functions for working with localization and language management.
-
----
-
-## Overview
-
-The languages library provides a comprehensive localization system for managing multiple languages within the Lilia framework. It handles language file loading, translation management, and provides utilities for adding and retrieving localized strings. The library supports dynamic language switching and provides a foundation for multi-language support.
-]]
+-- luacheck: globals lia file LANGUAGE NAME hook table.Merge L
 lia.lang = lia.lang or {}
 lia.lang.names = lia.lang.names or {}
 lia.lang.stored = lia.lang.stored or {}
---[[
-    lia.lang.loadFromDir
 
-    Purpose:
-        Loads all language definition files from the specified directory, registering their contents into lia.lang.stored.
-        Each language file should define a LANGUAGE table and optionally a NAME variable for the display name.
-        This function ensures all language keys and values are stored as strings and merges them into the global language table.
-
-    Parameters:
-        directory (string) - The directory path to search for language files (should be relative to the gamemode).
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Load all language files from the "lilia/gamemode/languages" directory
-        lia.lang.loadFromDir("lilia/gamemode/languages")
-]]
 function lia.lang.loadFromDir(directory)
     for _, v in ipairs(file.Find(directory .. "/*.lua", "LUA")) do
         local niceName
@@ -60,30 +30,6 @@ function lia.lang.loadFromDir(directory)
     end
 end
 
---[[
-    lia.lang.AddTable
-
-    Purpose:
-        Adds or merges a table of language key-value pairs into the specified language in lia.lang.stored.
-        All keys and values are converted to strings to ensure consistency.
-
-    Parameters:
-        name (string) - The language name (e.g., "english", "german").
-        tbl (table)   - The table of key-value pairs to add to the language.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Add a set of translations to the "english" language
-        lia.lang.AddTable("english", {
-            hello = "Hello!",
-            goodbye = "Goodbye!"
-        })
-]]
 function lia.lang.AddTable(name, tbl)
     local lowerName = tostring(name):lower()
     lia.lang.stored[lowerName] = lia.lang.stored[lowerName] or {}
@@ -92,27 +38,6 @@ function lia.lang.AddTable(name, tbl)
     end
 end
 
---[[
-    lia.lang.getLanguages
-
-    Purpose:
-        Retrieves a sorted list of all available language display names currently loaded in lia.lang.stored.
-
-    Parameters:
-        None.
-
-    Returns:
-        languages (table) - A sorted table of language display names (first letter capitalized).
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Print all available languages
-        for _, lang in ipairs(lia.lang.getLanguages()) do
-            print(lang)
-        end
-]]
 function lia.lang.getLanguages()
     local languages = {}
     for key, _ in pairs(lia.lang.stored) do
@@ -124,27 +49,6 @@ function lia.lang.getLanguages()
     return languages
 end
 
---[[
-    L
-
-    Purpose:
-        Retrieves a localized string for the given key from the current language, formatting it with any additional arguments.
-        If the key is not found, returns the key itself. Arguments are inserted into the string using %s placeholders.
-
-    Parameters:
-        key (string)      - The language key to look up.
-        ... (vararg)      - Optional arguments to format into the localized string.
-
-    Returns:
-        localized (string) - The formatted, localized string.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Assuming "greeting" = "Hello, %s!" in the current language
-        print(L("greeting", "John")) -- Output: Hello, John!
-]]
 function L(key, ...)
     local stored = lia.lang.stored or {}
     local lang = lia.config and lia.config.get("Language", "english") or "english"
@@ -168,3 +72,4 @@ end
 
 lia.lang.loadFromDir("lilia/gamemode/languages")
 hook.Run("OnLocalizationLoaded")
+


### PR DESCRIPTION
## Summary
- document `lia.lang.getLanguages`
- clarify `loadFromDir`, `AddTable`, and `L` behavior
- remove embedded docs from `languages.lua`

## Testing
- `luacheck gamemode/core/libraries/languages.lua documentation/docs/libraries/lia.languages.md`
- `markdownlint --disable MD013 MD036 -- documentation/docs/libraries/lia.languages.md`


------
https://chatgpt.com/codex/tasks/task_e_68983bec1ee08327bfc9cfd5b5504fab