### PR TITLE
docs: update keybind library docs

### DIFF
--- a/documentation/docs/libraries/lia.keybind.md
+++ b/documentation/docs/libraries/lia.keybind.md
@@ -1,21 +1,21 @@
 # Keybind Library
 
-This page describes functions to register custom keybinds.
+This page describes functions for registering and managing custom keybinds.
 
 ---
 
 ## Overview
 
-The keybind library stores user-defined keyboard bindings. It is loaded **client-side** and automatically loads any saved bindings from `data/lilia/keybinds/`. Press- and release-callbacks are dispatched through the `PlayerButtonDown` and `PlayerButtonUp` hooks. The library also adds a “Keybinds” page to the config menu via the `PopulateConfigurationButtons` hook so players can change their binds in-game.
+The keybind library runs **client-side** and stores user-defined key bindings in `lia.keybind.stored`. Bindings are saved to `data/lilia/keybinds/<gamemode>/<server-ip>.json` and loaded automatically on start. Press and release callbacks are dispatched through `PlayerButtonDown` and `PlayerButtonUp`, and a “Keybinds” page is added to the configuration menu via `PopulateConfigurationButtons`.
 
-Keybinds are kept inside `lia.keybind.stored`; each entry contains:
+Each entry in `lia.keybind.stored` contains:
 
-* `default` (*number*) – The default key code assigned when registered.
-* `value` (*number*) – The currently bound key code.
-* `callback` (*function | nil*) – Invoked when the key is pressed.
-* `release` (*function | nil*) – Invoked when the key is released.
+* `default` (*number*) – key code assigned on registration.
+* `value` (*number*) – current key code (initially the default).
+* `callback` (*function | nil*) – invoked when the key is pressed.
+* `release` (*function | nil*) – invoked when the key is released.
 
-Numeric key codes also map back to their action identifiers for quick lookup.
+Numeric key codes are also mapped back to their action identifiers for reverse lookup. The library registers some actions by default (e.g. `openInventory` and `adminMode`) but leaves them unbound.
 
 ---
 
@@ -23,17 +23,14 @@ Numeric key codes also map back to their action identifiers for quick lookup.
 
 **Purpose**
 
-Registers a new keybind for an action, ensuring a default value is set and mapping the key code back to the action for reverse lookup.
+Register a keybind action and optional callbacks. The default key is stored and a reverse mapping from key code to action is created. Existing user selections are preserved.
 
 **Parameters**
 
-* `k` (*string | number*): Key identifier (string name or key code).
-
-* `d` (*string*): Unique identifier for the keybind action.
-
-* `cb` (*function*): Callback executed when the key is pressed.
-
-* `rcb` (*function*): Callback executed when the key is released. *Optional*.
+* `k` (*string | number*): Key identifier. A string is matched case-insensitively against the internal key map. Invalid keys abort registration.
+* `d` (*string*): Action identifier.
+* `cb` (*function | nil*): Called when the key is pressed. Optional.
+* `rcb` (*function | nil*): Called when the key is released. Optional.
 
 **Realm**
 
@@ -69,13 +66,12 @@ lia.keybind.add(
 
 **Purpose**
 
-Returns the key code assigned to a keybind action, falling back to the registered default or a caller-supplied default.
+Fetch the key code for a keybind action. It checks the current value, then the registered default, and finally the caller-supplied fallback.
 
 **Parameters**
 
 * `a` (*string*): Action identifier.
-
-* `df` (*number*): Fallback key code. *Optional*.
+* `df` (*number | nil*): Fallback key code if the action is unknown. Optional.
 
 **Realm**
 
@@ -83,13 +79,13 @@ Returns the key code assigned to a keybind action, falling back to the registere
 
 **Returns**
 
-* *number*: Key code associated with the action (or fallback).
+* *number | nil*: Key code associated with the action or the fallback.
 
 **Example Usage**
 
 ```lua
 local invKey = lia.keybind.get("Open Inventory", KEY_I)
-print("Inventory key:", input.GetKeyName(invKey))
+print("Inventory key:", input.GetKeyName(invKey or KEY_NONE))
 ```
 
 ---
@@ -98,7 +94,7 @@ print("Inventory key:", input.GetKeyName(invKey))
 
 **Purpose**
 
-Writes all current keybinds to `data/lilia/keybinds/<gamemode>/<server-ip>.json` (stored as JSON).
+Persist all current keybinds to `data/lilia/keybinds/<gamemode>/<server-ip>.json`. Only entries with a `value` field are written and legacy `.txt` files are cleaned up.
 
 **Parameters**
 
@@ -125,7 +121,7 @@ lia.keybind.save()
 
 **Purpose**
 
-Loads keybinds from disk. If none exist, defaults registered via `lia.keybind.add` are applied and then saved. After loading, a reverse lookup table is rebuilt and the `InitializedKeybinds` hook fires.
+Load keybinds from disk. If none exist, defaults registered via `lia.keybind.add` are applied and saved. After loading, numeric indexes are cleared, reverse lookup mappings are rebuilt, and the `InitializedKeybinds` hook fires.
 
 **Parameters**
 

--- a/gamemode/core/libraries/keybind.lua
+++ b/gamemode/core/libraries/keybind.lua
@@ -1,14 +1,3 @@
-﻿--[[
-# Keybind Library
-
-This page documents the functions for working with keybind management and input handling.
-
----
-
-## Overview
-
-The keybind library provides a system for managing keyboard bindings and input handling within the Lilia framework. It handles keybind registration, storage, and provides utilities for creating customizable keybind systems. The library supports various key types, keybind persistence, and provides a foundation for user-configurable input systems.
-]]
 lia.keybind = lia.keybind or {}
 lia.keybind.stored = lia.keybind.stored or {}
 local KeybindKeys = {
@@ -123,33 +112,6 @@ local KeybindKeys = {
     ["last"] = KEY_LAST
 }
 
---[[
-    lia.keybind.add
-
-    Purpose:
-        Registers a new keybind action with the system, associating a key, an action name, and optional callback functions
-        for when the key is pressed or released. This allows custom actions to be triggered by user-defined keybinds.
-
-    Parameters:
-        k (string|number)      - The key to bind (as a string name or key code).
-        d (string)             - The unique action name for this keybind.
-        cb (function|none)      - The callback function to call when the key is pressed (optional).
-        rcb (function|none)     - The callback function to call when the key is released (optional).
-
-    Returns:
-        None.
-
-    Realm:
-        Client.
-
-    Example Usage:
-        -- Register a keybind for opening a custom menu with F4
-        lia.keybind.add("f4", "openCustomMenu", function(ply)
-            if IsValid(ply) then
-                MyCustomMenu:Open()
-            end
-        end)
-]]
 function lia.keybind.add(k, d, cb, rcb)
     local c = isstring(k) and KeybindKeys[string.lower(k)] or k
     if not c then return end
@@ -161,52 +123,12 @@ function lia.keybind.add(k, d, cb, rcb)
     lia.keybind.stored[c] = d
 end
 
---[[
-    lia.keybind.get
-
-    Purpose:
-        Retrieves the key code currently bound to a given action. If the action is not found, returns the provided default value.
-
-    Parameters:
-        a (string)         - The action name to look up.
-        df (number|none)    - The default key code to return if the action is not found (optional).
-
-    Returns:
-        keyCode (number|none) - The key code bound to the action, or the default value if not found.
-
-    Realm:
-        Client.
-
-    Example Usage:
-        -- Get the key code for the "openCustomMenu" action, defaulting to KEY_F4 if not set
-        local key = lia.keybind.get("openCustomMenu", KEY_F4)
-]]
 function lia.keybind.get(a, df)
     local act = lia.keybind.stored[a]
     if act then return act.value or act.default or df end
     return df
 end
 
---[[
-    lia.keybind.save
-
-    Purpose:
-        Saves all current keybinds to a JSON file specific to the current gamemode and server IP.
-        This persists user keybind preferences across sessions.
-
-    Parameters:
-        None.
-
-    Returns:
-        None.
-
-    Realm:
-        Client.
-
-    Example Usage:
-        -- Save the current keybind configuration after the user changes a keybind
-        lia.keybind.save()
-]]
 function lia.keybind.save()
     local dp = "lilia/keybinds/" .. engine.ActiveGamemode()
     file.CreateDir(dp)
@@ -226,27 +148,6 @@ function lia.keybind.save()
     end
 end
 
---[[
-    lia.keybind.load
-
-    Purpose:
-        Loads keybinds from the saved JSON file for the current gamemode and server IP.
-        If a legacy text file exists, it migrates the data to JSON. If no saved keybinds are found,
-        it resets all keybinds to their default values and saves them.
-
-    Parameters:
-        None.
-
-    Returns:
-        None.
-
-    Realm:
-        Client.
-
-    Example Usage:
-        -- Load keybinds when the client joins the server or when initializing the UI
-        lia.keybind.load()
-]]
 function lia.keybind.load()
     local dp = "lilia/keybinds/" .. engine.ActiveGamemode()
     file.CreateDir(dp)


### PR DESCRIPTION
## Summary
- document `lia.keybind` API accurately
- strip obsolete in-file documentation blocks

## Testing
- `luacheck gamemode/core/libraries/keybind.lua`

------
https://chatgpt.com/codex/tasks/task_e_68983bf196f483278e5ca63b4f875585