### PR TITLE
docs: update fonts library documentation

### DIFF
--- a/documentation/docs/libraries/lia.fonts.md
+++ b/documentation/docs/libraries/lia.fonts.md
@@ -6,14 +6,14 @@ This page lists utilities for creating fonts.
 
 ## Overview
 
-The fonts library wraps `surface.CreateFont` for commonly used fonts. It registers each font once, stores the definition in `lia.font.stored`, and then re-creates those fonts automatically when the screen resolution or relevant config values change.
+The fonts library wraps and overrides `surface.CreateFont` to cache each definition in `lia.font.stored`. Fonts are automatically re-created when the screen resolution changes or when relevant config values update.
 
 Registered fonts rely on two config options:
 
-* `Font` – Core UI font family.
-* `GenericFont` – Secondary UI font family.
+* `Font` – Core UI font family. Default: `PoppinsMedium`.
+* `GenericFont` – Secondary UI font family. Default: `PoppinsMedium`.
 
-Changing either option triggers `lia.font.refresh` to rebuild every stored font.
+Changing either option emits the `RefreshFonts` hook, which runs `lia.font.refresh` to rebuild every stored font.
 
 Fonts are refreshed whenever `lia.font.refresh` runs; afterward, the `PostLoadFonts` hook fires with the current UI and generic font names. Register custom fonts inside that hook so they persist across refreshes.
 
@@ -23,12 +23,11 @@ Fonts are refreshed whenever `lia.font.refresh` runs; afterward, the `PostLoadFo
 
 **Purpose**
 
-Creates and stores a font via `surface.CreateFont`. The definition is kept in an internal list so the font can be regenerated later.
+Creates and stores a font via `surface.CreateFont`. Arguments must be a string name and a table of font properties; otherwise an error is raised. Each call caches the definition so the font can be regenerated later.
 
 **Parameters**
 
 * `fontName` (*string*): Font identifier.
-
 * `fontData` (*table*): Font properties table (family, size, weight, etc.).
 
 **Realm**
@@ -124,7 +123,7 @@ The base gamemode registers the following fonts for use in menus and panels:
 
 **Purpose**
 
-Returns an alphabetically sorted list of all font identifiers that have been registered.
+Returns an alphabetically sorted list of all cached font identifiers. If no fonts have been registered, an empty table is returned.
 
 **Parameters**
 
@@ -153,7 +152,7 @@ end
 
 **Purpose**
 
-Recreates every stored font definition. This function runs automatically when screen resolution changes or when the `Font` / `GenericFont` configs update. After recreating the fonts, it triggers the `PostLoadFonts` hook with the active `currentFont` and `genericFont`.
+Clears and re-creates every stored font definition. The library hooks this function to both `OnScreenSizeChanged` and the custom `RefreshFonts` event, so it runs when the resolution changes or when the `Font`/`GenericFont` configs update. After recreating the fonts, it triggers the `PostLoadFonts` hook with the active `currentFont` and `genericFont`.
 
 **Parameters**
 

--- a/gamemode/core/libraries/fonts.lua
+++ b/gamemode/core/libraries/fonts.lua
@@ -1,51 +1,6 @@
-﻿--[[
-# Attributes Library
-
-This page documents the functions for working with character attributes.
-
----
-
-## Overview
-
-The attributes library loads attribute definitions from Lua files, keeps track of character values, and provides helper methods for modifying them. Each attribute is defined on a global `ATTRIBUTE` table inside its own file. When `lia.attribs.loadFromDir` is called the file is included **shared**, default values are filled in, and the definition is stored in `lia.attribs.list` using the file name (without extension or the `sh_` prefix) as the key. The loader is invoked automatically when a module is initialized, so most schemas simply place their attribute files in `schema/attributes/`.
-
-For details on each `ATTRIBUTE` field, see the [Attribute Fields documentation](../definitions/attribute.md).
-]]
 lia.font = lia.font or {}
 lia.font.stored = lia.font.stored or {}
 if CLIENT then
-    --[[
-        lia.font.register
-
-        Purpose:
-            Registers a new font with the specified name and font data. This function wraps surface.CreateFont and ensures
-            the font is created and available for use in the UI. It validates the input and will error if the arguments are invalid.
-
-        Parameters:
-            fontName (string) - The unique name to register the font under.
-            fontData (table)  - A table containing font properties (such as font, size, weight, antialias, etc).
-
-        Returns:
-            None.
-
-        Realm:
-            Client.
-
-        Example Usage:
-            -- Register a custom font for a title
-            lia.font.register("MyTitleFont", {
-                font = "Arial",
-                size = 32,
-                weight = 700,
-                antialias = true
-            })
-
-            -- Later, use the font in a draw operation
-            surface.SetFont("MyTitleFont")
-            surface.SetTextColor(255, 255, 255)
-            surface.SetTextPos(100, 100)
-            surface.DrawText("Welcome to the Server!")
-    ]]
     function lia.font.register(fontName, fontData)
         if not (isstring(fontName) and istable(fontData)) then return lia.error(L("invalidFont")) end
         surface.CreateFont(fontName, fontData)
@@ -485,32 +440,6 @@ if CLIENT then
         size = 64
     })
 
-    --[[
-        lia.font.getAvailableFonts
-
-        Purpose:
-            Retrieves a sorted list of all font names that have been registered and stored in lia.font.stored.
-            This is useful for populating font selection menus or debugging available fonts.
-
-        Parameters:
-            None.
-
-        Returns:
-            list (table) - A sorted table of font name strings.
-
-        Realm:
-            Client.
-
-        Example Usage:
-            -- Print all available font names to the console
-            for _, fontName in ipairs(lia.font.getAvailableFonts()) do
-                print("Available font:", fontName)
-            end
-
-            -- Use in a font selection dropdown
-            local fontOptions = lia.font.getAvailableFonts()
-            myDropdown:SetOptions(fontOptions)
-    ]]
     function lia.font.getAvailableFonts()
         local list = {}
         for name in pairs(lia.font.stored) do
@@ -521,30 +450,6 @@ if CLIENT then
         return list
     end
 
-    --[[
-        lia.font.refresh
-
-        Purpose:
-            Recreates all fonts currently stored in lia.font.stored by calling surface.CreateFont for each.
-            This is typically used when the screen resolution changes or when font configuration is updated,
-            ensuring that all fonts are refreshed and up-to-date. Also triggers the "PostLoadFonts" hook.
-
-        Parameters:
-            None.
-
-        Returns:
-            None.
-
-        Realm:
-            Client.
-
-        Example Usage:
-            -- Refresh all fonts after changing the main font in config
-            lia.font.refresh()
-
-            -- Automatically refresh fonts when the screen size changes
-            hook.Add("OnScreenSizeChanged", "liaFontsRefreshFonts", lia.font.refresh)
-    ]]
     function lia.font.refresh()
         local storedFonts = lia.font.stored
         lia.font.stored = {}


### PR DESCRIPTION
## Summary
- document `lia.font.register`, `lia.font.getAvailableFonts`, and `lia.font.refresh`
- note config defaults and automatic font refreshing
- clean up redundant comments in fonts library

## Testing
- `luacheck gamemode` (fails: 13442 warnings / 18 errors)

------
https://chatgpt.com/codex/tasks/task_e_68983c0551f48327b04533f5bacb588f