### PR TITLE
docs: update workshop library docs

### DIFF
--- a/documentation/docs/libraries/lia.workshop.md
+++ b/documentation/docs/libraries/lia.workshop.md
@@ -1,6 +1,6 @@
 # Workshop Library
 
-This page documents Workshop-addon helpers.
+This page documents helpers for managing Steam Workshop addons.
 
 ---
 
@@ -20,7 +20,7 @@ The server sends this list a short time after each player spawns. When the clien
 
 **Purpose**
 
-Registers a Steam Workshop addon ID so clients will download it.
+Registers a Steam Workshop addon ID so clients will download it. When a new ID is added, a bootstrap message informs users and a second message indicates the download has started.
 
 **Parameters**
 
@@ -47,7 +47,7 @@ lia.workshop.AddWorkshop("1234567890")
 
 **Purpose**
 
-Collects Workshop IDs from every registered source.
+Collects Workshop IDs from every registered source, including mounted addons and each module's `WorkshopContent` field. Each discovered ID is recorded so duplicate notifications are avoided.
 
 **Parameters**
 
@@ -76,7 +76,7 @@ end
 
 **Purpose**
 
-Sends the cached Workshop-ID list to a player.
+Sends the cached Workshop-ID list to a player using the `WorkshopDownloader_Start` net message.
 
 **Parameters**
 
@@ -100,11 +100,40 @@ end)
 
 ---
 
-### lia.workshop.checkPrompt
+
+### lia.workshop.hasContentToDownload
 
 **Purpose**
 
-Displays the Workshop download prompt or automatically requests the addons based on the client's `autoDownloadWorkshop` option.
+Checks whether the client is missing any Workshop content required by the server. The internally required Lilia package is ignored.
+
+**Parameters**
+
+* *None*
+
+**Realm**
+
+`Client`
+
+**Returns**
+
+* `boolean`: `true` if there is content to download, `false` otherwise.
+
+**Example Usage**
+
+```lua
+if lia.workshop.hasContentToDownload() then
+    print("You need to download additional Workshop content!")
+end
+```
+
+---
+
+### lia.workshop.mountContent
+
+**Purpose**
+
+Prompts the user to download and mount all missing Workshop content. Before downloading, it totals the sizes of the missing addons and displays a confirmation dialog.
 
 **Parameters**
 
@@ -121,8 +150,9 @@ Displays the Workshop download prompt or automatically requests the addons based
 **Example Usage**
 
 ```lua
-hook.Add("InitializedOptions", "WorkshopCheck", function()
-    lia.workshop.checkPrompt()
+-- Mount all missing Workshop content when a button is pressed
+concommand.Add("lia_mount_workshop", function()
+    lia.workshop.mountContent()
 end)
 ```
 

--- a/gamemode/core/libraries/workshop.lua
+++ b/gamemode/core/libraries/workshop.lua
@@ -1,39 +1,8 @@
-﻿--[[
-# Workshop Library
-
-This page documents the functions for working with Steam Workshop content and addon management.
-
----
-
-## Overview
-
-The workshop library provides utilities for managing Steam Workshop content within the Lilia framework. It handles Workshop ID tracking, addon downloading, and provides functions for gathering and managing required Workshop content. The library supports automatic Workshop content detection and provides utilities for ensuring all required addons are available.
-]]
 lia.workshop = lia.workshop or {}
 if SERVER then
     lia.workshop.ids = lia.workshop.ids or {}
     lia.workshop.known = lia.workshop.known or {}
     lia.workshop.cache = lia.workshop.cache or {}
-    --[[
-        lia.workshop.AddWorkshop
-
-        Purpose:
-            Adds a Workshop addon ID to the list of required Workshop content for the server.
-            Notifies users via bootstrap messages when a new Workshop ID is added and when it begins downloading.
-
-        Parameters:
-            id (string or number) - The Workshop ID to add.
-
-        Returns:
-            None.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            -- Add a Workshop addon to the server's required content
-            lia.workshop.AddWorkshop("1234567890")
-    ]]
     function lia.workshop.AddWorkshop(id)
         id = tostring(id)
         if not lia.workshop.ids[id] then lia.bootstrap(L("workshopDownloader"), L("workshopAdded", id)) end
@@ -49,29 +18,6 @@ if SERVER then
         end
     end
 
-    --[[
-        lia.workshop.gather
-
-        Purpose:
-            Gathers all Workshop IDs required by the server, including those added manually and those specified by modules.
-            Also marks all found IDs as known.
-
-        Parameters:
-            None.
-
-        Returns:
-            (table) - A table of all required Workshop IDs as keys.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            -- Gather all Workshop IDs and print them
-            local ids = lia.workshop.gather()
-            for id in pairs(ids) do
-                print("Workshop ID required:", id)
-            end
-    ]]
     function lia.workshop.gather()
         local ids = table.Copy(lia.workshop.ids)
         for _, addon in pairs(engine.GetAddons() or {}) do
@@ -98,27 +44,6 @@ if SERVER then
     end
 
     hook.Add("InitializedModules", "liaWorkshopInitializedModules", function() lia.workshop.cache = lia.workshop.gather() end)
-    --[[
-        lia.workshop.send
-
-        Purpose:
-            Sends the current Workshop cache (list of required Workshop IDs) to a specific player via a network message.
-
-        Parameters:
-            ply (Player) - The player to send the Workshop cache to.
-
-        Returns:
-            None.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            -- Send the Workshop cache to a player when they join
-            hook.Add("PlayerInitialSpawn", "SendWorkshopCache", function(ply)
-                lia.workshop.send(ply)
-            end)
-    ]]
     function lia.workshop.send(ply)
         net.Start("WorkshopDownloader_Start")
         net.WriteTable(lia.workshop.cache)
@@ -171,26 +96,6 @@ else
         return false
     end
 
-    --[[
-        lia.workshop.hasContentToDownload
-
-        Purpose:
-            Checks if there is any Workshop content required by the server that the client does not have mounted or downloaded locally.
-
-        Parameters:
-            None.
-
-        Returns:
-            (boolean) - True if there is content to download, false otherwise.
-
-        Realm:
-            Client.
-
-        Example Usage:
-            if lia.workshop.hasContentToDownload() then
-                print("You need to download additional Workshop content!")
-            end
-    ]]
     function lia.workshop.hasContentToDownload()
         for id in pairs(lia.workshop.serverIds or {}) do
             if id ~= FORCE_ID and not mounted(id) and not mountLocal(id) then return true end
@@ -312,28 +217,6 @@ else
     end)
 
     net.Receive("WorkshopDownloader_Info", function() refresh(net.ReadTable()) end)
-    --[[
-        lia.workshop.mountContent
-
-        Purpose:
-            Prompts the user to download and mount all missing Workshop content required by the server.
-            Calculates the total size of missing content and shows a confirmation dialog before starting the download.
-
-        Parameters:
-            None.
-
-        Returns:
-            None.
-
-        Realm:
-            Client.
-
-        Example Usage:
-            -- Mount all missing Workshop content when a button is pressed
-            concommand.Add("lia_mount_workshop", function()
-                lia.workshop.mountContent()
-            end)
-    ]]
     function lia.workshop.mountContent()
         local ids = lia.workshop.serverIds or {}
         local needed = {}


### PR DESCRIPTION
## Summary
- Sync workshop library docs with current Lua implementation
- Document missing `hasContentToDownload` and `mountContent` helpers
- Remove outdated `checkPrompt` reference and in-source doc blocks

## Testing
- `luacheck gamemode/core/libraries/workshop.lua documentation/docs/libraries/lia.workshop.md` *(fails: 124 warnings)*
- `npx --yes markdownlint-cli documentation/docs/libraries/lia.workshop.md` *(fails: line length and style warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68983c8e7acc83279c8586fc9be6a8a1