### PR TITLE
docs: update time library documentation

### DIFF
--- a/documentation/docs/libraries/lia.time.md
+++ b/documentation/docs/libraries/lia.time.md
@@ -6,7 +6,7 @@ This page lists time- and date-utilities.
 
 ## Overview
 
-The time library formats dates and converts relative times using Lua's built‑in `os.date` and `os.time` functions. It provides helpers for phrases such as “time since.”
+The time library formats dates and converts relative times using Lua's built-in `os.date` and `os.time` functions. It provides helpers for phrases such as "time since."
 
 ---
 
@@ -14,15 +14,15 @@ The time library formats dates and converts relative times using Lua's built‑i
 
 **Purpose**
 
-Returns a human-readable string describing how long ago a given time occurred (e.g. “5 minutes ago”).
+Returns a localized string describing how long ago a given time occurred (for example, "5 minutes ago").
 
 **Parameters**
 
-* `strTime` (*string | number*): Timestamp to measure from.
+* `strTime` (*number | string*): Time to measure from.
 
-  * Strings must use `YYYY-MM-DD` (or `YYYY-MM-DD HH:MM:SS`).
+  * Numbers are UNIX timestamps.
 
-  * Numbers are standard UNIX timestamps.
+  * Strings are parsed with `lia.time.ParseTime` and must yield `year`, `month`, and `day`. Only the date portion is used.
 
 **Realm**
 
@@ -30,7 +30,7 @@ Returns a human-readable string describing how long ago a given time occurred (e
 
 **Returns**
 
-* *string*: Readable “time since” string.
+* *string*: Localized "time since" string.
 
 **Example Usage**
 
@@ -50,13 +50,18 @@ hook.Add("PlayerInitialSpawn", "welcomeLastSeen", function(ply)
 end)
 ```
 
+**Edge Cases**
+
+* Returns `L("invalidDate")` if the string cannot be parsed.
+* Returns `L("invalidInput")` for non-number, non-string inputs.
+
 ---
 
 ### lia.time.toNumber
 
 **Purpose**
 
-Parses a timestamp string (`YYYY-MM-DD HH:MM:SS`) into its numeric components. If no argument is given, returns the current time table.
+Parses a timestamp string (`YYYY-MM-DD HH:MM:SS`) into its numeric components. If no argument is given, uses the current time.
 
 **Parameters**
 
@@ -68,7 +73,7 @@ Parses a timestamp string (`YYYY-MM-DD HH:MM:SS`) into its numeric components. I
 
 **Returns**
 
-* *table*: `{ year, month, day, hour, min, sec }`.
+* *table*: `{ year, month, day, hour, min, sec }` — keys are numbers. No validation is performed on the input string.
 
 **Example Usage**
 
@@ -93,9 +98,9 @@ end
 
 Returns the full current date/time using the `AmericanTimeStamps` config:
 
-* **Enabled**: `"Weekday, Month DD, YYYY, HH:MM:SSam/pm"`
+* **Enabled**: `"Weekday, Month DD, YYYY, HH:MM:SSam/pm"` (12-hour clock)
 
-* **Disabled**: `"Weekday, DD Month YYYY, HH:MM:SS"`
+* **Disabled**: `"Weekday, DD Month YYYY, HH:MM:SS"` (24-hour clock)
 
 **Parameters**
 
@@ -123,15 +128,42 @@ end)
 
 ---
 
+### lia.time.formatDHM
+
+**Purpose**
+
+Formats a number of seconds into a localized string describing days, hours, and minutes.
+
+**Parameters**
+
+* `seconds` (*number*): Seconds to convert. Negative or `nil` values are treated as `0`.
+
+**Realm**
+
+`Shared`
+
+**Returns**
+
+* *string*: Localized "X days Y hours Z minutes" string.
+
+**Example Usage**
+
+```lua
+-- Display a ban length
+print(lia.time.formatDHM(90061)) -- "1 days 1 hours 1 minutes"
+```
+
+---
+
 ### lia.time.GetHour
 
 **Purpose**
 
 Returns the current hour formatted by `AmericanTimeStamps`:
 
-* **Enabled** → `"Ham"` / `"Hpm"` (12-hour clock)
+* **Enabled** → string in the format `"Ham"`/`"Hpm"` (e.g. `"3pm"`)
 
-* **Disabled** → `H` (0 – 23, 24-hour clock)
+* **Disabled** → integer `0–23` (24-hour clock)
 
 **Parameters**
 
@@ -143,7 +175,7 @@ Returns the current hour formatted by `AmericanTimeStamps`:
 
 **Returns**
 
-* *string | number*: Hour with suffix (am/pm) or 24-hour integer.
+* *string | number*: Hour with suffix (`"am"`/`"pm"`) or 24-hour integer.
 
 **Example Usage**
 

--- a/gamemode/core/libraries/time.lua
+++ b/gamemode/core/libraries/time.lua
@@ -1,39 +1,4 @@
-﻿--[[
-# Time Library
-
-This page documents the functions for working with time and date utilities.
-
----
-
-## Overview
-
-The time library provides utilities for time and date manipulation within the Lilia framework. It handles time formatting, date parsing, and provides functions for calculating time differences and converting between different time formats. The library supports localized time strings and provides utilities for working with timestamps and date strings.
-]]
 lia.time = lia.time or {}
---[[
-    lia.time.TimeSince
-
-    Purpose:
-        Returns a human-readable string representing the time elapsed since the given date or timestamp.
-        Accepts either a timestamp (number) or a date string (which will be parsed).
-        The output is localized and will be in seconds, minutes, hours, or days ago.
-
-    Parameters:
-        strTime (number|string) - The time to compare against the current time. Can be a Unix timestamp or a date string.
-
-    Returns:
-        string - Localized string indicating how much time has passed since the input time.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Using a timestamp
-        print(lia.time.TimeSince(os.time() - 90)) -- "1 minutes ago" (localized)
-
-        -- Using a date string
-        print(lia.time.TimeSince("2024-06-01")) -- "X days ago" (localized)
-]]
 function lia.time.TimeSince(strTime)
     local timestamp
     if isnumber(strTime) then
@@ -65,26 +30,6 @@ function lia.time.TimeSince(strTime)
     end
 end
 
---[[
-    lia.time.toNumber
-
-    Purpose:
-        Converts a date string in the format "%Y-%m-%d %H:%M:%S" to a table containing its numeric components.
-        If no string is provided, uses the current date and time.
-
-    Parameters:
-        str (string, optional) - The date string to convert. Defaults to the current date and time.
-
-    Returns:
-        table - Table with keys: year, month, day, hour, min, sec (all numbers).
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local t = lia.time.toNumber("2024-06-01 15:30:45")
-        -- t = { year = 2024, month = 6, day = 1, hour = 15, min = 30, sec = 45 }
-]]
 function lia.time.toNumber(str)
     str = str or os.date("%Y-%m-%d %H:%M:%S", os.time())
     return {
@@ -97,27 +42,6 @@ function lia.time.toNumber(str)
     }
 end
 
---[[
-    lia.time.GetDate
-
-    Purpose:
-        Returns the current date and time as a formatted, localized string.
-        The format depends on the "AmericanTimeStamps" config setting.
-        Includes weekday, month, day, year, and time (with AM/PM if American format).
-
-    Parameters:
-        None.
-
-    Returns:
-        string - Localized, formatted date and time string.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        print(lia.time.GetDate())
-        -- "Monday, 01 June 2024, 15:30:45" (or American format if enabled)
-]]
 function lia.time.GetDate()
     local ct = os.date("*t")
     local american = lia.config.get("AmericanTimeStamps", false)
@@ -132,26 +56,6 @@ function lia.time.GetDate()
     return string.format("%s, %02d %s %04d, %02d:%02d:%02d", L(weekdayKeys[ct.wday]), ct.day, L(monthKeys[ct.month]), ct.year, ct.hour, ct.min, ct.sec)
 end
 
---[[
-    lia.time.formatDHM
-
-    Purpose:
-        Formats a number of seconds into a localized string showing days, hours, and minutes.
-        Useful for displaying durations in a human-readable way.
-
-    Parameters:
-        seconds (number) - The number of seconds to format.
-
-    Returns:
-        string - Localized string in the format "X days Y hours Z minutes".
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        print(lia.time.formatDHM(90061))
-        -- "1 days 1 hours 1 minutes" (localized)
-]]
 function lia.time.formatDHM(seconds)
     seconds = math.max(seconds or 0, 0)
     local days = math.floor(seconds / 86400)
@@ -162,26 +66,6 @@ function lia.time.formatDHM(seconds)
     return L("daysHoursMinutes", days, hours, minutes)
 end
 
---[[
-    lia.time.GetHour
-
-    Purpose:
-        Returns the current hour, formatted according to the "AmericanTimeStamps" config.
-        If American format is enabled, returns hour with AM/PM suffix; otherwise, returns 24-hour format.
-
-    Parameters:
-        None.
-
-    Returns:
-        string|number - The current hour (with AM/PM if American format, otherwise as a number).
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        print(lia.time.GetHour())
-        -- "3pm" (if American format) or 15 (if not)
-]]
 function lia.time.GetHour()
     local ct = os.date("*t")
     local american = lia.config.get("AmericanTimeStamps", false)


### PR DESCRIPTION
## Summary
- align time library docs with current implementation
- add missing `formatDHM` section and edge case notes
- remove obsolete comment blocks from library code

## Testing
- `luacheck gamemode/core/libraries/time.lua` (46 warnings, 0 errors)


------
https://chatgpt.com/codex/tasks/task_e_68983cb21920832780dcc6a7701a3d70