### PR TITLE
docs: document panel meta and remove inline comments

### DIFF
--- a/documentation/docs/meta/panel.md
+++ b/documentation/docs/meta/panel.md
@@ -16,11 +16,7 @@ Panel meta functions support scaled positioning, listen for inventory changes, a
 
 **Purpose**
 
-Sets up hooks so this panel reacts to activity on an `Inventory`. Any existing
-hooks for the same inventory are removed first. When inventory events fire the
-panel calls its own method with the same name (or `InventoryItemDataChanged` for
-`ItemDataChanged`) and appends the inventory as the final argument. Hooks are
-automatically removed if the inventory is deleted.
+Sets up hooks so this panel reacts to activity on an `Inventory`. Any existing hooks for the same inventory are removed first. When inventory events fire the panel calls its own method with the same name (or `InventoryItemDataChanged` for `ItemDataChanged`) and appends the inventory as the final argument. Each hook confirms the panel still exists and implements the handler before invoking it. Hooks are automatically removed if the inventory is deleted.
 
 The following events are forwarded:
 
@@ -29,12 +25,11 @@ The following events are forwarded:
 * `InventoryDataChanged`
 * `InventoryItemAdded`
 * `InventoryItemRemoved`
-* `ItemDataChanged` → `InventoryItemDataChanged`
+* `ItemDataChanged` → `InventoryItemDataChanged` (only if the item belongs to the inventory)
 
 **Parameters**
 
-* `inventory` (*Inventory*): Required. Inventory to listen to. An error is
-  thrown if `nil`.
+* `inventory` (*Inventory*): Required inventory to listen to. An error is thrown if `nil`.
 
 **Realm**
 
@@ -67,14 +62,11 @@ end
 
 **Purpose**
 
-Removes hooks created by `liaListenForInventoryChanges`. Useful for cleaning up
-when the panel is removed or no longer needs updates. Calling this on an
-inventory that has no hooks has no effect.
+Removes hooks created by `liaListenForInventoryChanges`. Useful for cleaning up when the panel is removed or no longer needs updates. Calling this on an inventory that has no hooks has no effect. If called with `nil`, all tracked inventories are cleared.
 
 **Parameters**
 
-* `id` (*number|nil*): Inventory ID to stop listening to. Defaults to `nil`,
-  which removes hooks for all tracked inventories.
+* `id` (*number|nil*): Inventory ID to stop listening to. Defaults to `nil`, which removes hooks for all tracked inventories.
 
 **Realm**
 

--- a/gamemode/core/meta/panel.lua
+++ b/gamemode/core/meta/panel.lua
@@ -1,24 +1,5 @@
-﻿local panelMeta = FindMetaTable("Panel")
---[[
-    liaListenForInventoryChanges
+local panelMeta = FindMetaTable("Panel")
 
-    Purpose:
-        Sets up hooks to listen for changes in the given inventory and calls corresponding panel methods when changes occur.
-        Automatically removes hooks when the inventory is deleted or when requested.
-
-    Parameters:
-        inventory (Inventory) - The inventory object to listen for changes on.
-
-    Returns:
-        nil
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Listen for changes on an inventory and update the panel accordingly
-        panel:liaListenForInventoryChanges(inventory)
-]]
 function panelMeta:liaListenForInventoryChanges(inventory)
     assert(inventory, L("noInventorySet"))
     local id = inventory:getID()
@@ -57,29 +38,6 @@ function panelMeta:liaListenForInventoryChanges(inventory)
     table.insert(self.liaToRemoveHooks[id], "ItemDataChanged")
 end
 
---[[
-    liaDeleteInventoryHooks
-
-    Purpose:
-        Removes all hooks associated with inventory changes for the given inventory ID.
-        If no ID is provided, removes all inventory hooks associated with this panel.
-
-    Parameters:
-        id (number, optional) - The inventory ID to remove hooks for. If nil, removes all hooks.
-
-    Returns:
-        nil
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Remove hooks for a specific inventory
-        panel:liaDeleteInventoryHooks(inventoryID)
-
-        -- Remove all inventory hooks for this panel
-        panel:liaDeleteInventoryHooks()
-]]
 function panelMeta:liaDeleteInventoryHooks(id)
     if not self.liaHookID then return end
     if id == nil then
@@ -101,50 +59,11 @@ function panelMeta:liaDeleteInventoryHooks(id)
     self.liaToRemoveHooks[id] = nil
 end
 
---[[
-    SetScaledPos
-
-    Purpose:
-        Sets the position of the panel using scaled screen coordinates for resolution independence.
-
-    Parameters:
-        x (number) - The X position (unscaled).
-        y (number) - The Y position (unscaled).
-
-    Returns:
-        nil
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Set the panel's position to (10, 20) in scaled screen units
-        panel:SetScaledPos(10, 20)
-]]
 function panelMeta:SetScaledPos(x, y)
     self:SetPos(ScreenScale(x), ScreenScaleH(y))
 end
 
---[[
-    SetScaledSize
-
-    Purpose:
-        Sets the size of the panel using scaled screen dimensions for resolution independence.
-
-    Parameters:
-        w (number) - The width (unscaled).
-        h (number) - The height (unscaled).
-
-    Returns:
-        nil
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Set the panel's size to 100x50 in scaled screen units
-        panel:SetScaledSize(100, 50)
-]]
 function panelMeta:SetScaledSize(w, h)
     self:SetSize(ScreenScale(w), ScreenScaleH(h))
 end
+


### PR DESCRIPTION
## Summary
- document panel inventory hook helpers and scaled positioning
- drop outdated panel meta comment blocks

## Testing
- `luac -p gamemode/core/meta/panel.lua`
- `luacheck gamemode/core/meta/panel.lua` *(warnings: accessing undefined variables)*

------
https://chatgpt.com/codex/tasks/task_e_689856ceeadc8327b25ccf3600028d31