### PR TITLE
docs: sync character library

### DIFF
--- a/documentation/docs/libraries/lia.character.md
+++ b/documentation/docs/libraries/lia.character.md
@@ -19,8 +19,8 @@ Retrieves a character object by ID. If the character is not loaded, it is loaded
 **Parameters**
 
 * `charID` (*number*): Character identifier.
-* `client` (*Player*): Owning player (server only).
-* `callback` (*function*): Function executed once the character is available.
+* `client` (*Player*): Owning player (server only, optional).
+* `callback` (*function*): Function executed once the character is available (optional).
 
 **Realm**
 
@@ -306,7 +306,7 @@ local ply = lia.char.getOwnerByID(1)
 
 **Purpose**
 
-Retrieves a character object by SteamID or SteamID64.
+Retrieves a character object by SteamID or SteamID64 from currently connected players.
 
 **Parameters**
 
@@ -390,9 +390,9 @@ Inserts a new character into the database, creates a default inventory, and fire
 
 **Parameters**
 
-* `data` (*table*): Character creation data.
+* `data` (*table*): Character creation data. Requires `name`, `model`, and `steamID`. `money` defaults to `lia.config.get("DefaultMoney")`, and `faction` defaults to `L("unknown")` when omitted.
 
-* `callback` (*function*): Callback receiving the new character ID.
+* `callback` (*function*): Optional function receiving the new character ID.
 
 **Realm**
 
@@ -478,13 +478,13 @@ lia.char.cleanUpForPlayer(client)
 
 **Purpose**
 
-Deletes a character by ID, cleans up, and notifies players via hooks.
+Deletes a character by ID, cleans up, and notifies players via hooks. If no `client` is provided, any player using the character is removed from it.
 
 **Parameters**
 
 * `id` (*number*): Character ID to delete.
 
-* `client` (*Player*): Player entity reference.
+* `client` (*Player*): Player entity to remove from the character (optional).
 
 **Realm**
 
@@ -727,3 +727,4 @@ end)
 ```
 
 ---
+

--- a/gamemode/core/libraries/character.lua
+++ b/gamemode/core/libraries/character.lua
@@ -1,30 +1,3 @@
---[[
-# Character Library
-
-This page documents the functions for working with character data and management.
-
----
-
-## Overview
-
-The character library provides functions for creating, managing, and manipulating character data within the Lilia framework. It handles character creation, loading, saving, and provides various utility functions for working with character variables and metadata. Characters are the core data structure that represents a player's in-game identity and progress.
-
-The library features include:
-- **Character Lifecycle Management**: Complete creation, loading, saving, and deletion of character data
-- **Variable System**: Dynamic character variables with hooks for change detection and validation
-- **Database Integration**: Automatic persistence of character data with optimized query handling
-- **Multi-Character Support**: Players can have multiple characters with independent data and progression
-- **Character Validation**: Built-in validation for character data integrity and consistency
-- **Hook System**: Extensive hook system for custom character logic and data manipulation
-- **Networking**: Efficient client-server synchronization of character data and changes
-- **Memory Management**: Optimized memory usage with lazy loading and caching strategies
-- **Error Handling**: Robust error handling for database failures and data corruption
-- **Performance Optimization**: Efficient query patterns and data structure management
-- **Cross-Realm Support**: Works seamlessly on both client and server sides
-- **Plugin Integration**: Easy integration with external character-related addons and systems
-
-The character system is the foundation of the role-playing experience in Lilia, providing a flexible and extensible framework for character progression, customization, and data management. It supports complex character attributes, relationships, and persistent data across server sessions.
-]]
 local characterMeta = lia.meta.character or {}
 lia.char = lia.char or {}
 lia.char.loaded = lia.char.loaded or {}
@@ -44,26 +17,6 @@ if SERVER and #lia.char.names < 1 then
     end)
 end
 
---[[
-    lia.char.getCharacter
-
-    Purpose:
-        Retrieves a character object by ID. If the character is not
-        currently loaded it will be loaded from the server first.
-
-    Parameters:
-        charID (number) - Identifier of the character to fetch.
-        client (Player) - Optional player who owns the character
-                          (used server side).
-        callback (function) - Optional function called once the
-                              character is available.
-
-    Returns:
-        character (table) - The character object if already loaded,
-                            otherwise nil. When nil is returned the
-                            callback will be invoked once loading is
-                            complete.
-]]
 if SERVER then
     function lia.char.getCharacter(charID, client, callback)
         local character = lia.char.loaded[charID]
@@ -115,34 +68,6 @@ function lia.char.removeCharacter(id)
 end
 
 
---[[
-    lia.char.new
-
-    Purpose:
-        Creates a new character object with the provided data, ID, client, and SteamID.
-        Initializes all registered character variables with their default values if not provided in data.
-
-    Parameters:
-        data (table)      - Table containing character variable values.
-        id (number)       - The unique ID for the character.
-        client (Player)   - The player entity associated with the character.
-        steamID (string)  - The SteamID of the player (optional if client is valid).
-
-    Returns:
-        character (table) - The newly created character object.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local charData = {
-            name = "John Doe",
-            desc = "A mysterious wanderer.",
-            model = "models/player/kleiner.mdl",
-            faction = "Citizen"
-        }
-        local newChar = lia.char.new(charData, 1234, somePlayer, somePlayer:SteamID())
-]]
 function lia.char.new(data, id, client, steamID)
     local character = setmetatable({
         vars = {}
@@ -170,62 +95,11 @@ function lia.char.new(data, id, client, steamID)
     return character
 end
 
---[[
-    lia.char.hookVar
-
-    Purpose:
-        Registers a hook function to be called when a specific character variable changes.
-
-    Parameters:
-        varName (string)  - The name of the character variable to hook.
-        hookName (string) - The unique name for this hook.
-        func (function)   - The function to call when the variable changes.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        lia.char.hookVar("money", "OnMoneyChanged", function(character, oldValue, newValue)
-            print("Money changed from", oldValue, "to", newValue)
-        end)
-]]
 function lia.char.hookVar(varName, hookName, func)
     lia.char.varHooks[varName] = lia.char.varHooks[varName] or {}
     lia.char.varHooks[varName][hookName] = func
 end
 
---[[
-    lia.char.registerVar
-
-    Purpose:
-        Registers a new character variable with the system, defining its behavior, default value, and networking.
-
-    Parameters:
-        key (string)  - The variable's unique key.
-        data (table)  - Table describing the variable's properties (default, onSet, onGet, etc).
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        lia.char.registerVar("karma", {
-            field = "karma",
-            fieldType = "integer",
-            default = 0,
-            onSet = function(character, value)
-                character.vars.karma = value
-            end,
-            onGet = function(character, default)
-                return character.vars.karma or default or 0
-            end
-        })
-]]
 function lia.char.registerVar(key, data)
     lia.char.vars[key] = data
     data.index = data.index or table.Count(lia.char.vars)
@@ -668,29 +542,6 @@ lia.char.registerVar("banned", {
     noDisplay = true
 })
 
---[[
-    lia.char.getCharData
-
-    Purpose:
-        Retrieves character-specific data from the database for a given character ID.
-        If a key is provided, returns only that key's value; otherwise, returns all data as a table.
-
-    Parameters:
-        charID (number or string) - The character's unique ID.
-        key (string)              - (Optional) The specific data key to retrieve.
-
-    Returns:
-        value (any) or data (table) - The value for the key, or a table of all key-value pairs.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Get all custom data for character ID 1234
-        local allData = lia.char.getCharData(1234)
-        -- Get only the "reputation" value for character ID 1234
-        local rep = lia.char.getCharData(1234, "reputation")
-]]
 function lia.char.getCharData(charID, key)
     local charIDsafe = tonumber(charID)
     if not charIDsafe then return end
@@ -707,29 +558,6 @@ function lia.char.getCharData(charID, key)
     return data
 end
 
---[[
-    lia.char.getCharDataRaw
-
-    Purpose:
-        Retrieves raw character data from the database for a given character ID.
-        If a key is provided, returns only that key's value; otherwise, returns all data as a table.
-
-    Parameters:
-        charID (number or string) - The character's unique ID.
-        key (string)              - (Optional) The specific data key to retrieve.
-
-    Returns:
-        value (any) or data (table) - The value for the key, or a table of all key-value pairs.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Get all raw data for character ID 5678
-        local allRaw = lia.char.getCharDataRaw(5678)
-        -- Get only the "notes" value for character ID 5678
-        local notes = lia.char.getCharDataRaw(5678, "notes")
-]]
 function lia.char.getCharDataRaw(charID, key)
     local charIDsafe = tonumber(charID)
     if not charIDsafe then return end
@@ -751,27 +579,6 @@ function lia.char.getCharDataRaw(charID, key)
     return data
 end
 
---[[
-    lia.char.getOwnerByID
-
-    Purpose:
-        Finds and returns the player entity that owns a character with the given ID.
-
-    Parameters:
-        ID (number or string) - The character's unique ID.
-
-    Returns:
-        client (Player) - The player entity who owns the character, or nil if not found.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local owner = lia.char.getOwnerByID(1234)
-        if owner then
-            print("Character 1234 belongs to", owner:Nick())
-        end
-]]
 function lia.char.getOwnerByID(ID)
     ID = tonumber(ID)
     for client, character in pairs(lia.char.getAll()) do
@@ -779,27 +586,6 @@ function lia.char.getOwnerByID(ID)
     end
 end
 
---[[
-    lia.char.getBySteamID
-
-    Purpose:
-        Retrieves the character object associated with a given SteamID.
-
-    Parameters:
-        steamID (string) - The SteamID or SteamID64 of the player.
-
-    Returns:
-        character (table) - The character object, or nil if not found.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local char = lia.char.getBySteamID("STEAM_0:1:12345678")
-        if char then
-            print("Found character:", char:getName())
-        end
-]]
 function lia.char.getBySteamID(steamID)
     if not isstring(steamID) or steamID == "" then return end
     local lookupID = steamID
@@ -809,26 +595,6 @@ function lia.char.getBySteamID(steamID)
     end
 end
 
---[[
-    lia.char.getAll
-
-    Purpose:
-        Returns a table of all currently loaded characters, indexed by their player entity.
-
-    Parameters:
-        None.
-
-    Returns:
-        charTable (table) - Table of [Player] = character pairs.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        for client, char in pairs(lia.char.getAll()) do
-            print(client:Nick(), "has character", char:getName())
-        end
-]]
 function lia.char.getAll()
     local charTable = {}
     for _, client in player.Iterator() do
@@ -837,25 +603,6 @@ function lia.char.getAll()
     return charTable
 end
 
---[[
-    lia.char.GetTeamColor
-
-    Purpose:
-        Returns the color associated with a player's character's class, or their team color if not available.
-
-    Parameters:
-        client (Player) - The player entity.
-
-    Returns:
-        color (Color) - The color for the character's class or team.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local color = lia.char.GetTeamColor(somePlayer)
-        chat.AddText(color, somePlayer:Nick() .. " says hello!")
-]]
 function lia.char.GetTeamColor(client)
     local char = client:getChar()
     if not char then return team.GetColor(client:Team()) end
@@ -867,36 +614,7 @@ function lia.char.GetTeamColor(client)
 end
 
 if SERVER then
-    --[[
-        lia.char.create
-
-        Purpose:
-            Creates a new character in the database and initializes its inventory and data.
-            Calls the callback with the new character's ID when finished.
-
-        Parameters:
-            data (table)      - Table containing character creation data (name, desc, model, etc).
-            callback (function) - Function to call with the new character's ID.
-
-        Returns:
-            None.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            local data = {
-                name = "Jane Doe",
-                desc = "A brave explorer.",
-                model = "models/player/alyx.mdl",
-                steamID = somePlayer:SteamID(),
-                faction = "Citizen"
-            }
-            lia.char.create(data, function(charID)
-                print("Created character with ID:", charID)
-            end)
-    ]]
-    function lia.char.create(data, callback)
+        function lia.char.create(data, callback)
         local timeStamp = os.date("%Y-%m-%d %H:%M:%S", os.time())
         data.money = data.money or lia.config.get("DefaultMoney")
         local gamemode = SCHEMA and SCHEMA.folder or "lilia"
@@ -937,30 +655,7 @@ if SERVER then
         end)
     end
 
-    --[[
-        lia.char.restore
-
-        Purpose:
-            Restores all characters for a given client from the database, loading their inventories and data.
-            Calls the callback with a table of character IDs when finished.
-
-        Parameters:
-            client (Player)     - The player entity whose characters to restore.
-            callback (function) - Function to call with the table of character IDs.
-            id (number)         - (Optional) Only restore the character with this ID.
-
-        Returns:
-            None.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            lia.char.restore(somePlayer, function(charIDs)
-                print("Restored characters:", table.concat(charIDs, ", "))
-            end)
-    ]]
-    function lia.char.restore(client, callback, id)
+        function lia.char.restore(client, callback, id)
         local steamID = client:SteamID()
         local fields = {"id"}
         for _, var in pairs(lia.char.vars) do
@@ -1060,25 +755,7 @@ if SERVER then
         end)
     end
 
-    --[[
-        lia.char.cleanUpForPlayer
-
-        Purpose:
-            Cleans up all character data and inventories for a given player, removing them from memory.
-
-        Parameters:
-            client (Player) - The player entity whose characters to clean up.
-
-        Returns:
-            None.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            lia.char.cleanUpForPlayer(somePlayer)
-    ]]
-    function lia.char.cleanUpForPlayer(client)
+        function lia.char.cleanUpForPlayer(client)
         for _, charID in pairs(client.liaCharList or {}) do
             if lia.char.loaded[charID] then
                 lia.char.unloadCharacter(charID)
@@ -1098,30 +775,7 @@ if SERVER then
         end
     end
 
-    --[[
-        lia.char.delete
-
-        Purpose:
-            Deletes a character from the database and cleans up all associated data and inventories.
-            Optionally removes the player from their character if a client is provided.
-
-        Parameters:
-            id (number)      - The unique ID of the character to delete.
-            client (Player)  - (Optional) The player entity to remove from the character.
-
-        Returns:
-            None.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            -- Delete character with ID 1234 and remove the player from it
-            lia.char.delete(1234, somePlayer)
-            -- Delete character with ID 5678 (no player specified)
-            lia.char.delete(5678)
-    ]]
-    function lia.char.delete(id, client)
+        function lia.char.delete(id, client)
         assert(isnumber(id), L("idMustBeNumber"))
         if IsValid(client) then
             removePlayer(client)
@@ -1155,31 +809,7 @@ if SERVER then
         hook.Run("OnCharDelete", client, id)
     end
 
-    --[[
-        lia.char.setCharData
-
-        Purpose:
-            Sets or removes a custom data key-value pair for a character in the database.
-            Also updates the in-memory character if loaded.
-
-        Parameters:
-            charID (number or string) - The character's unique ID.
-            key (string)              - The data key to set.
-            val (any)                 - The value to set. If nil, the key is removed.
-
-        Returns:
-            true (boolean) - Returns true on success.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            -- Set a custom "reputation" value for character 1234
-            lia.char.setCharData(1234, "reputation", 50)
-            -- Remove the "notes" key from character 1234
-            lia.char.setCharData(1234, "notes", nil)
-    ]]
-    function lia.char.setCharData(charID, key, val)
+        function lia.char.setCharData(charID, key, val)
         local charIDsafe = tonumber(charID)
         if not charIDsafe or not key then return end
         if val == nil then
@@ -1197,26 +827,7 @@ if SERVER then
         return true
     end
 
-    --[[
-        lia.char.setCharName
-
-        Purpose:
-            Sets the name of a character in the database and updates the in-memory character if loaded.
-
-        Parameters:
-            charID (number or string) - The character's unique ID.
-            name (string)             - The new name to set.
-
-        Returns:
-            true (boolean) or false - Returns true on success, false on failure.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            lia.char.setCharName(1234, "New Name")
-    ]]
-    function lia.char.setCharName(charID, name)
+        function lia.char.setCharName(charID, name)
         local charIDsafe = tonumber(charID)
         if not name or not charID then return end
         local promise = lia.db.updateTable({
@@ -1233,31 +844,7 @@ if SERVER then
         return true
     end
 
-    --[[
-        lia.char.setCharModel
-
-        Purpose:
-            Sets the model and bodygroups of a character in the database and updates the in-memory character if loaded.
-
-        Parameters:
-            charID (number or string) - The character's unique ID.
-            model (string)            - The new model to set.
-            bg (table)                - (Optional) Table of bodygroup data.
-
-        Returns:
-            true (boolean) or false - Returns true on success, false on failure.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            -- Set model and bodygroups for character 1234
-            lia.char.setCharModel(1234, "models/player/barney.mdl", {
-                {id = 1, value = 2},
-                {id = 2, value = 0}
-            })
-    ]]
-    function lia.char.setCharModel(charID, model, bg)
+        function lia.char.setCharModel(charID, model, bg)
         local charIDsafe = tonumber(charID)
         if not model or not charID then return end
         local promise = lia.db.updateTable({
@@ -1290,57 +877,14 @@ if SERVER then
         return true
     end
 
-    --[[
-        lia.char.getCharBanned
-
-        Purpose:
-            Retrieves the banned status of a character from the database.
-
-        Parameters:
-            charID (number or string) - The character's unique ID.
-
-        Returns:
-            banned (number) - 0 if not banned, or the ban value.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            local banned = lia.char.getCharBanned(1234)
-            if banned > 0 then
-                print("Character 1234 is banned!")
-            end
-    ]]
-    function lia.char.getCharBanned(charID)
+        function lia.char.getCharBanned(charID)
         local charIDsafe = tonumber(charID)
         if not charIDsafe then return end
         local result = sql.Query("SELECT banned FROM lia_characters WHERE id = " .. charIDsafe .. " LIMIT 1")
         if istable(result) and result[1] then return tonumber(result[1].banned) or 0 end
     end
 
-    --[[
-        lia.char.setCharBanned
-
-        Purpose:
-            Sets the banned status of a character in the database and updates the in-memory character if loaded.
-
-        Parameters:
-            charID (number or string) - The character's unique ID.
-            value (number or string)  - The ban value to set (0 for unbanned).
-
-        Returns:
-            true (boolean) or false - Returns true on success, false on failure.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            -- Ban character 1234
-            lia.char.setCharBanned(1234, 1)
-            -- Unban character 1234
-            lia.char.setCharBanned(1234, 0)
-    ]]
-    function lia.char.setCharBanned(charID, value)
+        function lia.char.setCharBanned(charID, value)
         local charIDsafe = tonumber(charID)
         if not charIDsafe then return end
         value = tonumber(value) or 0
@@ -1358,19 +902,7 @@ if SERVER then
         return true
     end
 
-    --[[
-        lia.char.unloadCharacter
-        
-        Purpose:
-            Unloads a single character from memory, saving it first and cleaning up its inventories.
-            
-        Parameters:
-            charID (number) - The character ID to unload.
-            
-        Returns:
-            boolean - True if unloaded successfully, false if character wasn't loaded.
-    ]]
-    function lia.char.unloadCharacter(charID)
+        function lia.char.unloadCharacter(charID)
         local character = lia.char.loaded[charID]
         if not character then return false end
 
@@ -1405,20 +937,7 @@ if SERVER then
         return true
     end
     
-    --[[
-        lia.char.unloadUnusedCharacters
-        
-        Purpose:
-            Unloads all characters for a client except the specified active character.
-            
-        Parameters:
-            client (Player) - The player whose unused characters should be unloaded.
-            activeCharID (number) - The character ID to keep loaded.
-            
-        Returns:
-            number - Count of characters unloaded.
-    ]]
-    function lia.char.unloadUnusedCharacters(client, activeCharID)
+        function lia.char.unloadUnusedCharacters(client, activeCharID)
         local unloadedCount = 0
 
         for _, charID in pairs(client.liaCharList or {}) do
@@ -1430,21 +949,7 @@ if SERVER then
         return unloadedCount
     end
 
-    --[[
-        lia.char.loadSingleCharacter
-        
-        Purpose:
-            Loads a single character by ID for a specific client if it's not already loaded.
-            
-        Parameters:
-            charID (number) - The character ID to load.
-            client (Player) - The player who owns the character.
-            callback (function) - Optional callback function called when loading is complete.
-            
-        Returns:
-            None.
-    ]]
-    function lia.char.loadSingleCharacter(charID, client, callback)
+        function lia.char.loadSingleCharacter(charID, client, callback)
         
         if lia.char.loaded[charID] then
             if callback then callback(lia.char.loaded[charID]) end


### PR DESCRIPTION
## Summary
- document optional parameters and defaults for lia.char APIs
- drop in-source comment blocks from character library

## Testing
- `luacheck gamemode/core/libraries/character.lua` *(fails: expected '=' near 'end')*

------
https://chatgpt.com/codex/tasks/task_e_689856bca8908327a94c7a98fc264c4b