### PR TITLE
docs: update languages library

### DIFF
--- a/documentation/docs/libraries/lia.languages.md
+++ b/documentation/docs/libraries/lia.languages.md
@@ -1,12 +1,12 @@
 # Languages Library
 
-This page explains how translations and phrases are loaded.
+This page documents translation loading and retrieval.
 
 ---
 
 ## Overview
 
-The languages library loads localisation files from directories, resolves phrase keys to translated text, and supports runtime language switching. Language files live in `languages/<langname>.lua` inside schemas or modules; each file defines a `LANGUAGE` table of phrases. Loaded phrases are cached in `lia.lang.stored`, while display names defined through a global `NAME` variable are kept in `lia.lang.names`. During start-up the framework automatically loads its bundled translations from `lilia/gamemode/languages` and then fires the `OnLocalizationLoaded` hook.
+The languages library loads localisation files from directories, resolves phrase keys to translated text, and supports runtime language switching. Language files live in `languages/<identifier>.lua` inside schemas or modules; each file defines a global `LANGUAGE` table of phrases and may define a global `NAME` for display. Loaded phrases are cached in `lia.lang.stored`, while display names are kept in `lia.lang.names`. During start-up the framework automatically loads its bundled translations from `lilia/gamemode/languages` and then fires the `OnLocalizationLoaded` hook.
 
 ---
 
@@ -14,7 +14,7 @@ The languages library loads localisation files from directories, resolves phrase
 
 **Purpose**
 
-Loads every Lua language file in a directory and merges their `LANGUAGE` tables into the cache. Keys and values are coerced to strings and an optional global `NAME` is stored in `lia.lang.names`.
+Loads every `.lua` language file in a directory and merges its `LANGUAGE` table into the cache. File names prefixed with `sh_` have the prefix removed and the remainder lowercased to form the language identifier. Keys and values from `LANGUAGE` are coerced to strings before merging, existing phrases are overwritten, and an optional global `NAME` is stored in `lia.lang.names`. Files that do not define `LANGUAGE` are ignored. After processing each file the globals `LANGUAGE` and `NAME` are cleared.
 
 **Parameters**
 
@@ -41,13 +41,12 @@ lia.lang.loadFromDir(SCHEMA.folder .. "/languages")
 
 **Purpose**
 
-Adds or merges key-value pairs into an existing language table. Keys and values are converted to strings and existing entries are overwritten.
+Adds or merges key–value pairs into a language table. The language name is lowercased and a new table is created if it does not already exist. Keys and values are converted to strings and existing entries are overwritten.
 
 **Parameters**
 
 * `name` (*string*): Language identifier to update.
-
-* `tbl` (*table*): Key-value pairs to insert or override.
+* `tbl` (*table*): Key–value pairs to insert or override.
 
 **Realm**
 
@@ -73,7 +72,7 @@ lia.lang.AddTable("english", {
 
 **Purpose**
 
-Returns a sorted list of the identifiers for all loaded languages with their first letter capitalised.
+Returns an alphabetically sorted list of the identifiers for all loaded languages with their first letter capitalised. Display names stored in `lia.lang.names` are not used.
 
 **Parameters**
 
@@ -101,13 +100,12 @@ end
 
 **Purpose**
 
-Returns the translated phrase for a key in the active language, using `string.format` with any additional arguments. Missing translations return the key itself. If fewer arguments are supplied than `%s` placeholders, the extras default to empty strings. The active language defaults to `"english"` when not configured.
+Returns the translated phrase for a key in the active language, formatting it with `string.format`. The active language is read from `lia.config.get("Language", "english")` if available; otherwise it defaults to `"english"`. Translations are looked up in `lia.lang.stored` using a lowercase language identifier and the key as provided. If no translation exists the key itself is returned. All additional arguments are converted to strings. The function counts the number of `%s` placeholders in the translation: missing arguments are replaced with empty strings, while extra arguments are ignored by `string.format`.
 
 **Parameters**
 
 * `key` (*string*): Localisation key.
-
-* …: Values interpolated via `string.format`.
+* `...` (*string*): Values interpolated via `string.format`.
 
 **Realm**
 
@@ -121,6 +119,10 @@ Returns the translated phrase for a key in the active language, using `string.fo
 
 ```lua
 print(L("vendorShowAll"))
+print(L("unknownKey")) -- missing translation returns "unknownKey"
+
+-- assuming LANGUAGE.greeting = "Hello %s %s"
+print(L("greeting", "John")) -- outputs "Hello John "
 ```
 
 ---


### PR DESCRIPTION
## Summary
- document language file loading and caching
- clarify language table merging and retrieval
- describe `L` helper formatting edge cases

## Testing
- `luacheck gamemode/core/libraries/languages.lua` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689856b31c3883278e3ba7a653ad6f4c