### PR TITLE
docs: clarify item meta function details

### DIFF
--- a/documentation/docs/meta/item.md
+++ b/documentation/docs/meta/item.md
@@ -268,7 +268,9 @@ model:SetSkin(item:getSkin())
 
 **Purpose**
 
-Returns the calculated purchase price for the item.
+Returns the calculated purchase price for the item. If `calcPrice` is defined on
+the item, its result is used. Falls back to the stored `price` and defaults to
+`0` when undefined.
 
 **Parameters**
 
@@ -280,7 +282,7 @@ Returns the calculated purchase price for the item.
 
 **Returns**
 
-* `number`: The price value.
+* `number`: Final price value.
 
 **Example Usage**
 
@@ -315,7 +317,8 @@ Invokes an item method with the given player and entity context.
 
 **Returns**
 
-* `any`: Results returned by the called function.
+* `any|nil`: Return values from the called method or `nil` if it doesn't
+  exist.
 
 **Example Usage**
 
@@ -624,7 +627,7 @@ item:setQuantity(1, nil, true)
 
 Returns the display name of this item.
 
-On the client this value is localized.
+The same value is available on both the server and client.
 
 **Parameters**
 


### PR DESCRIPTION
## Summary
- clarify `item:getName` docs
- expand `item:getPrice` behavior and defaults
- note return value when calling missing methods

## Testing
- `luacheck gamemode/core/meta/item.lua`
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68985694ba94832786caed0ad32a8130