### PR TITLE
Clarify GridInv add parameters

### DIFF
--- a/documentation/docs/meta/gridinv.md
+++ b/documentation/docs/meta/gridinv.md
@@ -466,9 +466,9 @@ non-stackable item simply spawns one instance.
 
 * `itemTypeOrItem` (`Item|string`): Item instance or unique ID to add.
 
-* `xOrQuantity` (`number`): X slot or stack quantity (optional, defaults to `1`).
+* `xOrQuantity` (`number`): X slot or stack quantity. When used as a quantity this defaults to `1` (optional).
 
-* `yOrData` (`number|table`): Y slot or data table (optional).
+* `yOrData` (`number|table`): Y slot or data table. Supplying a table treats the second argument as a quantity.
 
 * `noReplicate` (`boolean`): Skip networking new items to clients (defaults to `false`).
 


### PR DESCRIPTION
## Summary
- Clarify how `GridInv:add` interprets positional versus quantity arguments and data tables
- Ensure documentation aligns with the current Lua implementation

## Testing
- `luacheck gamemode/modules/inventory/gridinv.lua` (50 warnings, 0 errors)


------
https://chatgpt.com/codex/tasks/task_e_689856917030832793e7ffff771794b1