### PR TITLE
docs: update fonts library documentation

### DIFF
--- a/documentation/docs/libraries/lia.fonts.md
+++ b/documentation/docs/libraries/lia.fonts.md
@@ -13,9 +13,18 @@ Registered fonts rely on two config options:
 * `Font` – Core UI font family. Default: `PoppinsMedium`.
 * `GenericFont` – Secondary UI font family. Default: `PoppinsMedium`.
 
-Changing either option emits the `RefreshFonts` hook, which runs `lia.font.refresh` to rebuild every stored font.
+Changing either option emits the `RefreshFonts` hook, which runs `lia.font.refresh` to rebuild every stored font. Afterward the `PostLoadFonts` hook fires with the current UI and generic font names. Register custom fonts inside that hook so they persist across refreshes.
 
-Fonts are refreshed whenever `lia.font.refresh` runs; afterward, the `PostLoadFonts` hook fires with the current UI and generic font names. Register custom fonts inside that hook so they persist across refreshes.
+### Configuration
+
+Two configuration entries are provided by this library:
+
+| Name         | Default         | Type  | Description                                      |
+|--------------|-----------------|-------|--------------------------------------------------|
+| `Font`       | `PoppinsMedium` | Table | Primary UI font family. Options come from `lia.font.getAvailableFonts()`. Changing this value triggers a font refresh. |
+| `GenericFont`| `PoppinsMedium` | Table | Secondary UI font family. Options come from `lia.font.getAvailableFonts()`. Changing this value triggers a font refresh. |
+
+Both callbacks simply run `hook.Run("RefreshFonts")` on the client, ensuring fonts rebuild whenever these settings change.
 
 ---
 
@@ -23,7 +32,7 @@ Fonts are refreshed whenever `lia.font.refresh` runs; afterward, the `PostLoadFo
 
 **Purpose**
 
-Creates and stores a font via `surface.CreateFont`. Arguments must be a string name and a table of font properties; otherwise an error is raised. Each call caches the definition so the font can be regenerated later.
+Creates and stores a font via `surface.CreateFont`. Arguments must be a string name and a table of font properties; otherwise `lia.error(L("invalidFont"))` is invoked and the call aborts. Each call caches the definition so the font can be regenerated later.
 
 **Parameters**
 
@@ -123,7 +132,7 @@ The base gamemode registers the following fonts for use in menus and panels:
 
 **Purpose**
 
-Returns an alphabetically sorted list of all cached font identifiers. If no fonts have been registered, an empty table is returned.
+Returns an alphabetically sorted array of keys from `lia.font.stored`. If no fonts have been registered, an empty table is returned.
 
 **Parameters**
 
@@ -152,7 +161,7 @@ end
 
 **Purpose**
 
-Clears and re-creates every stored font definition. The library hooks this function to both `OnScreenSizeChanged` and the custom `RefreshFonts` event, so it runs when the resolution changes or when the `Font`/`GenericFont` configs update. After recreating the fonts, it triggers the `PostLoadFonts` hook with the active `currentFont` and `genericFont`.
+Wipes `lia.font.stored` and re-creates each cached font via `surface.CreateFont`. The library hooks this function to both `OnScreenSizeChanged` and the custom `RefreshFonts` event, so it runs when the resolution changes or when the `Font`/`GenericFont` configs update. After recreating the fonts, it triggers `PostLoadFonts` with the active `currentFont` and `genericFont` names.
 
 **Parameters**
 


### PR DESCRIPTION
## Summary
- document `Font` and `GenericFont` config options in fonts library
- clarify `lia.font.register`, `lia.font.getAvailableFonts`, and `lia.font.refresh`

## Testing
- `luacheck gamemode/core/libraries/fonts.lua` (233 warnings, 0 errors)


------
https://chatgpt.com/codex/tasks/task_e_689856a869988327895184ff4b2ea840