### PR TITLE
docs: update keybind library documentation

### DIFF
--- a/documentation/docs/libraries/lia.keybind.md
+++ b/documentation/docs/libraries/lia.keybind.md
@@ -6,14 +6,14 @@ This page describes functions for registering and managing custom keybinds.
 
 ## Overview
 
-The keybind library runs **client-side** and stores user-defined key bindings in `lia.keybind.stored`. Bindings are saved to `data/lilia/keybinds/<gamemode>/<server-ip>.json` and loaded automatically on start. Press and release callbacks are dispatched through `PlayerButtonDown` and `PlayerButtonUp`, and a “Keybinds” page is added to the configuration menu via `PopulateConfigurationButtons`.
+The keybind library runs **client-side** and stores user-defined key bindings in `lia.keybind.stored`. Bindings are saved to `data/lilia/keybinds/<gamemode>/<server-ip>.json` (using the server IP with dots replaced by underscores) and loaded automatically on start. If a legacy `.txt` file exists it is migrated to the new JSON format. Press and release callbacks are dispatched through `PlayerButtonDown` and `PlayerButtonUp`, and a “Keybinds” page is added to the configuration menu via `PopulateConfigurationButtons`. Editing in this menu can be disabled with the `AllowKeybindEditing` configuration option.
 
 Each entry in `lia.keybind.stored` contains:
 
 * `default` (*number*) – key code assigned on registration.
 * `value` (*number*) – current key code (initially the default).
-* `callback` (*function | nil*) – invoked when the key is pressed.
-* `release` (*function | nil*) – invoked when the key is released.
+* `callback` (*function | nil*) – invoked when the key is pressed. The player is passed as the sole argument.
+* `release` (*function | nil*) – invoked when the key is released. The player is passed as the sole argument.
 
 Numeric key codes are also mapped back to their action identifiers for reverse lookup. The library registers some actions by default (e.g. `openInventory` and `adminMode`) but leaves them unbound.
 
@@ -29,8 +29,8 @@ Register a keybind action and optional callbacks. The default key is stored and 
 
 * `k` (*string | number*): Key identifier. A string is matched case-insensitively against the internal key map. Invalid keys abort registration.
 * `d` (*string*): Action identifier.
-* `cb` (*function | nil*): Called when the key is pressed. Optional.
-* `rcb` (*function | nil*): Called when the key is released. Optional.
+* `cb` (*function | nil*): Called when the key is pressed. Receives the player as its only argument. Optional.
+* `rcb` (*function | nil*): Called when the key is released. Receives the player as its only argument. Optional.
 
 **Realm**
 
@@ -48,11 +48,11 @@ local inv
 lia.keybind.add(
     KEY_F1,
     "Open Inventory",
-    function()
+    function(client)
         inv = vgui.Create("liaMenu")
         inv:setActiveTab("Inventory")
     end,
-    function()
+    function(client)
         if IsValid(inv) then
             inv:Close()
         end
@@ -121,7 +121,7 @@ lia.keybind.save()
 
 **Purpose**
 
-Load keybinds from disk. If none exist, defaults registered via `lia.keybind.add` are applied and saved. After loading, numeric indexes are cleared, reverse lookup mappings are rebuilt, and the `InitializedKeybinds` hook fires.
+Load keybinds from disk. Legacy `.txt` files are automatically converted to `.json`. If no keybind file exists, defaults registered via `lia.keybind.add` are applied and saved. After loading, numeric indexes are cleared, reverse lookup mappings are rebuilt, and the `InitializedKeybinds` hook fires.
 
 **Parameters**
 
@@ -145,5 +145,3 @@ end)
 -- Reload keybinds
 lia.keybind.load()
 ```
-
----


### PR DESCRIPTION
## Summary
- Clarify keybind storage path, migration of legacy `.txt` files, and config option for editing
- Document that callbacks and release functions receive the player argument
- Note that `lia.keybind.load` converts old `.txt` files to JSON

## Testing
- `luacheck gamemode/core/libraries/keybind.lua` *(command not found: luacheck)*

------
https://chatgpt.com/codex/tasks/task_e_689856b07dd083278a6f78d5bdd15c1c