### PR TITLE
Reflect damage to cheaters and notify on blocked actions

### DIFF
--- a/gamemode/modules/doors/commands.lua
+++ b/gamemode/modules/doors/commands.lua
@@ -115,6 +115,7 @@ lia.command.add("doorbuy", {
     onRun = function(client)
         if lia.config.get("DisableCheaterActions", true) and client:getNetVar("cheater", false) then
             lia.log.add(client, "cheaterAction", L("buyDoor"):lower())
+            client:notify("Maybe you shouldn't have cheated")
             return
         end
 

--- a/gamemode/modules/doors/libraries/server.lua
+++ b/gamemode/modules/doors/libraries/server.lua
@@ -195,6 +195,7 @@ function MODULE:KeyLock(client, door, time)
     if not IsValid(door) or not IsValid(client) then return end
     if lia.config.get("DisableCheaterActions", true) and client:getNetVar("cheater", false) then
         lia.log.add(client, "cheaterAction", L("cheaterActionLockDoor"))
+        client:notify("Maybe you shouldn't have cheated")
         return
     end
     if hook.Run("CanPlayerLock", client, door) == false then return end
@@ -211,6 +212,7 @@ function MODULE:KeyUnlock(client, door, time)
     if not IsValid(door) or not IsValid(client) then return end
     if lia.config.get("DisableCheaterActions", true) and client:getNetVar("cheater", false) then
         lia.log.add(client, "cheaterAction", L("cheaterActionUnlockDoor"))
+        client:notify("Maybe you shouldn't have cheated")
         return
     end
     if hook.Run("CanPlayerUnlock", client, door) == false then return end
@@ -227,6 +229,7 @@ function MODULE:ToggleLock(client, door, state)
     if not IsValid(door) then return end
     if lia.config.get("DisableCheaterActions", true) and IsValid(client) and client:getNetVar("cheater", false) then
         lia.log.add(client, "cheaterAction", state and L("cheaterActionLockDoor") or L("cheaterActionUnlockDoor"))
+        client:notify("Maybe you shouldn't have cheated")
         return
     end
     if door:isDoor() then

--- a/gamemode/modules/interactionmenu/libraries/server.lua
+++ b/gamemode/modules/interactionmenu/libraries/server.lua
@@ -4,6 +4,7 @@ net.Receive("TransferMoneyFromP2P", function(_, sender)
     local target = net.ReadEntity()
     if lia.config.get("DisableCheaterActions", true) and sender:getNetVar("cheater", false) then
         lia.log.add(sender, "cheaterAction", L("cheaterActionTransferMoney"))
+        sender:notify("Maybe you shouldn't have cheated")
         return
     end
 
@@ -26,6 +27,7 @@ end)
 net.Receive("RunOption", function(_, ply)
     if lia.config.get("DisableCheaterActions", true) and ply:getNetVar("cheater", false) then
         lia.log.add(ply, "cheaterAction", L("cheaterActionUseInteractionMenu"))
+        ply:notify("Maybe you shouldn't have cheated")
         return
     end
 
@@ -38,6 +40,7 @@ end)
 net.Receive("RunLocalOption", function(_, ply)
     if lia.config.get("DisableCheaterActions", true) and ply:getNetVar("cheater", false) then
         lia.log.add(ply, "cheaterAction", L("cheaterActionUseInteractionMenu"))
+        ply:notify("Maybe you shouldn't have cheated")
         return
     end
 

--- a/gamemode/modules/protection/libraries/server.lua
+++ b/gamemode/modules/protection/libraries/server.lua
@@ -12,6 +12,7 @@ end
 
 local function LogCheaterAction(client, action)
     lia.log.add(client, "cheaterAction", action)
+    client:notify("Maybe you shouldn't have cheated")
 end
 
 function MODULE:CanPlayerSwitchChar(client, character)
@@ -53,8 +54,14 @@ function MODULE:EntityTakeDamage(entity, dmgInfo)
 
     local inflictor = dmgInfo:GetInflictor()
     local attacker = dmgInfo:GetAttacker()
-    if IsValid(attacker) and attacker:IsPlayer() and IsCheater(attacker) then
+    if IsValid(attacker) and attacker:IsPlayer() and IsCheater(attacker) and entity ~= attacker then
+        local damage = dmgInfo:GetDamage()
         dmgInfo:SetDamage(0)
+        local refl = DamageInfo()
+        refl:SetDamage(damage)
+        refl:SetAttacker(attacker)
+        refl:SetInflictor(IsValid(inflictor) and inflictor or attacker)
+        attacker:TakeDamageInfo(refl)
         LogCheaterAction(attacker, L("cheaterActionDealDamage"))
         return true
     end


### PR DESCRIPTION
## Summary
- Notify cheaters attempting blocked actions with "Maybe you shouldn't have cheated"
- Reflect any damage they cause back onto themselves

## Testing
- `luacheck gamemode/modules/protection/libraries/server.lua gamemode/modules/doors/commands.lua gamemode/modules/doors/libraries/server.lua gamemode/modules/interactionmenu/libraries/server.lua` *(fails: 423 warnings, 0 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68987f23c060832797cc86d02877c509