### PR TITLE
docs: update classes library

### DIFF
--- a/documentation/docs/libraries/lia.classes.md
+++ b/documentation/docs/libraries/lia.classes.md
@@ -16,8 +16,8 @@ See [Class Fields](../definitions/class.md) for configurable `CLASS` properties 
 
 **Purpose**
 
-Registers a new class or updates an existing one with matching `uniqueID`.  
-Sets default values for missing fields and validates the faction.
+Registers a new class or updates an existing one with matching `uniqueID`.
+Applies default values and validates that the provided faction exists.
 
 **Parameters**
 
@@ -31,6 +31,11 @@ Sets default values for missing fields and validates the faction.
 **Returns**
 
 * *table | nil*: The registered class table, or `nil` if the faction is invalid.
+
+**Edge Cases**
+
+* Sets defaults of `name` to `L("unknown")`, `desc` to `L("noDesc")`, `limit` to `0`, and `OnCanBe` to a function returning `true` when those fields are missing.
+* Logs an error and returns `nil` when `faction` is missing or not a valid team.
 
 **Example Usage**
 
@@ -51,13 +56,18 @@ local class = lia.class.register("overwatch", {
 
 **Purpose**
 
-Loads all Lua files within the supplied directory. Each file should define a `CLASS` table inserted into `lia.class.list` with an automatic index.  
-Skips files whose `uniqueID` already exists and requires each class to have a valid `faction`.  
+Loads every `.lua` file within the supplied directory. Each file should define a `CLASS` table inserted into `lia.class.list` with an automatic index.
+Skips files whose `uniqueID` already exists and requires each class to have a valid `faction`.
 Defaults `name` to `L("unknown")`, `desc` to `L("noDesc")`, `limit` to `0`, and `OnCanBe` to a function returning `true`.
+Files prefixed with `sh_` have the prefix stripped when determining `uniqueID`.
 
 **Parameters**
 
 * `directory` (*string*): Folder path containing class Lua files, typically `"schema/classes"` in a schema.
+
+**Edge Cases**
+
+* After inclusion, the temporary global `CLASS` is cleared to avoid leaking state.
 
 **Realm**
 
@@ -80,7 +90,7 @@ lia.class.loadFromDir("schema/classes")
 
 **Purpose**
 
-Checks faction and limit rules. It also runs the `CanPlayerJoinClass` gamemode hook and the class’s `OnCanBe` method to determine if the client may join. This function does not automatically enforce class whitelists.
+Validates faction membership, current class, and population limits before calling the `CanPlayerJoinClass` gamemode hook and the class’s `OnCanBe` method. This function does not automatically enforce class whitelists.
 
 **Parameters**
 
@@ -94,7 +104,7 @@ Checks faction and limit rules. It also runs the `CanPlayerJoinClass` gamemode h
 
 **Returns**
 
-* *boolean*, *string?*: `false` and a reason when denied; on success, returns the class’s `isDefault` flag (defaults to `false`).
+* *boolean | nil*, *string?*: `false` and a localized reason when basic checks fail. If either the hook or `OnCanBe` returns `false`, this function simply returns `false`. On success, returns the class’s `isDefault` flag (`true` for default classes, otherwise `nil`).
 
 **Example Usage**
 
@@ -115,7 +125,7 @@ Retrieves the class table associated with the given identifier.
 
 **Parameters**
 
-* `identifier` (*number|string*): Class index or uniqueID.
+* `identifier` (*number*): Class index to look up.
 
 **Realm**
 
@@ -130,8 +140,6 @@ Retrieves the class table associated with the given identifier.
 ```lua
 -- Retrieve the class table for the engineer class by index
 local classData = lia.class.get(CLASS_ENGINEER)
--- or by uniqueID
-local classData2 = lia.class.get("engineer")
 ```
 
 ---
@@ -152,7 +160,7 @@ Returns an array of players whose characters belong to the given class.
 
 **Returns**
 
-* *table*: List of player objects.
+* *table*: List of player objects. Returns an empty table when no players are in the class.
 
 **Example Usage**
 
@@ -180,7 +188,7 @@ Counts the number of players currently in the specified class.
 
 **Returns**
 
-* *number*: Player count.
+* *number*: Player count (returns `0` if none).
 
 **Example Usage**
 
@@ -255,7 +263,7 @@ Returns all classes the specified client is eligible to join by calling `lia.cla
 
 **Parameters**
 
-* `client` (*Player?*): Player to check. Defaults to `LocalPlayer()` when called on the client.  
+* `client` (*Player?*): Player to check. Defaults to `LocalPlayer()` when called on the client.
   If invalid or omitted on the server, an empty table is returned.
 
 **Realm**
@@ -264,7 +272,7 @@ Returns all classes the specified client is eligible to join by calling `lia.cla
 
 **Returns**
 
-* *table*: List of class tables the client can join.
+* *table*: List of class tables the client can join. Returns an empty table if the client is invalid.
 
 **Example Usage**
 


### PR DESCRIPTION
## Summary
- clarify default field handling and faction validation for `lia.class.register`
- document `sh_` prefix handling and cleanup in `lia.class.loadFromDir`
- refine `lia.class.canBe` return semantics and restrict `lia.class.get` to numeric indices
- note empty-table returns for `getPlayers`, `getPlayerCount`, and `retrieveJoinable`

## Testing
- `luacheck gamemode/core/libraries/classes.lua` *(fails: expected '=' near 'end')*


------
https://chatgpt.com/codex/tasks/task_e_689881532c00832798d865487c088955