### PR TITLE
docs: clarify attributes library behavior

### DIFF
--- a/documentation/docs/libraries/lia.attributes.md
+++ b/documentation/docs/libraries/lia.attributes.md
@@ -9,18 +9,25 @@ This page documents the functions for working with character attributes.
 The attributes library loads attribute definitions from Lua files and provides helpers for initializing them on a character. Each attribute is defined on a global `ATTRIBUTE` table inside its own file. When
 `lia.attribs.loadFromDir` is called, each file is included in the shared realm, the attribute's `name` and `desc` fields are
 replaced with their translated versions (defaulting to `L("unknown")` and `L("noDesc")` when absent), and the definition is stored in `lia.attribs.list`
-using the file name without extension as the key. Files beginning with `sh_` have the prefix removed and the key
-lowercased. If an attribute was already registered, its existing table is reused, allowing definitions to be extended across
-multiple files or reloads. The loader is invoked automatically when a module is initialized, so most schemas simply place their
-attribute files in `schema/attributes/`.
+using the file name without extension as the key. Files beginning with `sh_` have the prefix removed and the remaining name
+lowercased; other filenames are used as-is. If an attribute was already registered, its existing table is reused, allowing
+definitions to be extended across multiple files or reloads. After each file is processed the temporary global `ATTRIBUTE` is
+cleared. The loader is invoked automatically when a module is initialized, so most schemas simply place their attribute files in
+`schema/attributes/`.
 
 For details on each `ATTRIBUTE` field, see the [Attribute Fields documentation](../definitions/attribute.md).
+
+### lia.attribs.list
+
+Table of all registered attribute definitions. Keys are attribute IDs derived from the filenames passed to
+`lia.attribs.loadFromDir`, and values are the attribute tables themselves. The table is populated when attributes are loaded and
+used by other functions such as `lia.attribs.setup`.
 
 ### lia.attribs.loadFromDir
 
 **Purpose**
 
-Loads attribute definitions from each Lua file in the given directory, localizes their `name` and `desc` fields, and registers them in `lia.attribs.list`. Filenames supply the list key—if a file begins with `sh_`, the prefix is stripped and the key is lowercased. If the attribute was previously registered, the existing table is reused. Missing `name` or `desc` fields default to `L("unknown")` and `L("noDesc")`.
+Loads attribute definitions from each `.lua` file in the given directory, includes them in the shared realm, localizes their `name` and `desc` fields, and registers them in `lia.attribs.list`. Filenames supply the list key—if a file begins with `sh_`, the prefix is stripped and the remaining name lowercased; otherwise the filename without extension is used as-is. If the attribute was previously registered, the existing table is reused. Missing `name` or `desc` fields default to `L("unknown")` and `L("noDesc")`.
 
 **Parameters**
 


### PR DESCRIPTION
## Summary
- expand docs for `lia.attribs.loadFromDir` to describe file handling and clearing of the `ATTRIBUTE` global
- document the `lia.attribs.list` registry
- ensure examples and wording match the library implementation

## Testing
- no tests available

------
https://chatgpt.com/codex/tasks/task_e_68988165cc708327bdb0b555cd0895e2