### PR TITLE
docs: revise menu library to match implementation

### DIFF
--- a/documentation/docs/libraries/lia.menu.md
+++ b/documentation/docs/libraries/lia.menu.md
@@ -6,7 +6,7 @@ Client-side helpers for simple world-space context menus.
 
 ## Overview
 
-The menu library offers convenience functions for building simple context menus. Menus are defined by label/callback pairs and automatically appear at the player's crosshair or follow a specified entity. Active menus are stored in `lia.menu.list` on the client. Menus fade out and are removed if the player moves more than **96 units** away or the attached entity becomes invalid.
+The menu library offers convenience functions for building simple context menus. Menus are defined by label/callback pairs and automatically appear at the player's crosshair or follow a specified entity. Active menus are stored in `lia.menu.list` on the client. Menus fade when the player looks away and are removed if the player moves more than **96 units** away or the attached entity becomes invalid.
 
 ### Menu-entry fields
 
@@ -15,8 +15,8 @@ Each entry in `lia.menu.list` is a table containing:
 * `position` (*Vector*) – World position where the menu is drawn.
 * `entity` (*Entity | nil*) – Entity the menu follows, if attached.
 * `items` (*table*) – Sorted array of `{ label, callback }` pairs.
-* `width` (*number*) – Pixel width used for rendering.
-* `height` (*number*) – Combined pixel height of all rows.
+* `width` (*number*) – Pixel width based on the longest label plus 24px padding.
+* `height` (*number*) – Total height of all rows (each row is 28px).
 * `onRemove` (*function | nil*) – Executed when the menu is removed.
 * `alpha` (*number*) – Internal fade alpha used while drawing.
 * `displayed` (*boolean | nil*) – Internal flag used for fade-in logic.
@@ -64,7 +64,7 @@ end)
 
 **Purpose**
 
-Draws every active menu on the player's HUD and handles fade-in/fade-out. Menus are removed if the player is too far or the attached entity becomes invalid.
+Draws each active menu and handles fade-in/fade-out. Menus fade when the player looks away and are removed if the player moves too far or the attached entity becomes invalid.
 
 **Parameters**
 
@@ -90,7 +90,7 @@ hook.Add("HUDPaintBackground", "DrawMenus", lia.menu.drawAll)
 
 **Purpose**
 
-Returns the ID and callback of the menu item currently under the cursor.
+Returns the ID and callback of the menu item currently under the player's crosshair.
 
 **Parameters**
 
@@ -130,7 +130,7 @@ Removes the menu with the given ID and runs its callback (if present).
 **Parameters**
 
 * `id` (*number*): Identifier returned by `lia.menu.add`.
-* `callback` (*function | nil*): Function executed after removal.
+* `cb` (*function | nil*): Function executed after removal.
 
 **Realm**
 
@@ -138,7 +138,7 @@ Removes the menu with the given ID and runs its callback (if present).
 
 **Returns**
 
-* *boolean*: `true` if a callback executed.
+* *boolean*: `true` if `cb` executed, otherwise `false`.
 
 **Example Usage**
 


### PR DESCRIPTION
## Summary
- clarify menu entry sizing and fade behavior
- document crosshair-based selection and `cb` callback parameter

## Testing
- `luacheck gamemode/core/libraries/menu.lua` *(fails: expected '=' near 'end')*

------
https://chatgpt.com/codex/tasks/task_e_6898814156dc8327903da701c1d0f69e