### PR TITLE
chore: sync logger docs and clean code

### DIFF
--- a/documentation/docs/libraries/lia.logger.md
+++ b/documentation/docs/libraries/lia.logger.md
@@ -6,7 +6,7 @@ This page documents the functions for working with Lilia's logging and audit sys
 
 ## Overview
 
-The logger library records structured log entries to the console and to the `logs` SQL table (timestamp, gamemode, category, message, character ID, SteamID). Built‑in log types are defined in `lia.log.types` within `gamemode/core/libraries/logger.lua`; custom types can be registered with `lia.log.addType`.
+The logger library records structured log entries to the console and to the `logs` SQL table. Each entry stores a timestamp (`%Y-%m-%d %H:%M:%S`), the active gamemode, category, message, character ID (when the client has a character) and SteamID. Built‑in log types are defined in `lia.log.types` within `gamemode/core/libraries/logger.lua`; custom types can be registered with `lia.log.addType`.
 
 Each database row stores the timestamp, SteamID and, when applicable, the character ID so that every entry can be associated with a specific player.
 
@@ -54,7 +54,7 @@ lia.log.add(client, "mytype", "a backflip")
 
 **Purpose**
 
-Returns the formatted log string (and its category) for a given type without writing anything. If the type is unknown or the generator function errors, `nil` is returned.
+Returns the formatted log string (and its category) for a given type without writing anything. If the type is unknown or the generator function errors, nothing is returned.
 
 **Parameters**
 
@@ -70,13 +70,15 @@ Returns the formatted log string (and its category) for a given type without wri
 
 **Returns**
 
-* *string*, *string*: Log text and its category, or `nil` if the log type is invalid.
+* *string*, *string*: Log text and its category, or `nil` if the type is invalid or the generator fails.
 
 **Example Usage**
 
 ```lua
-local text, cat = lia.log.getString(client, "mytype", "test")
-print(cat .. ": " .. text)
+local text, cat = lia.log.getString(client, "mytype", "a backflip")
+if text then
+    print(cat .. ": " .. text)
+end
 ```
 
 ---
@@ -85,7 +87,7 @@ print(cat .. ": " .. text)
 
 **Purpose**
 
-Creates a log entry, fires `OnServerLog`, prints to console, and inserts into the `logs` table together with the player's SteamID and character ID (when available). If the log type is unknown or the generator fails, nothing is written. Missing or non-string categories fall back to the localized string for "uncategorized".
+Creates a log entry, fires `OnServerLog`, prints via `lia.printLog`, and inserts into the `logs` table together with the player's SteamID and character ID (when available). The inserted row contains `timestamp`, `gamemode`, `category`, `message`, `charID` and `steamID`. If the log type is unknown or the generator fails, nothing is written. Missing or non-string categories fall back to the localized string for "uncategorized".
 
 **Parameters**
 

--- a/gamemode/core/libraries/logger.lua
+++ b/gamemode/core/libraries/logger.lua
@@ -1,14 +1,3 @@
-﻿--[[
-# Logger Library
-
-This page documents the functions for working with logging and audit systems.
-
----
-
-## Overview
-
-The logger library provides a comprehensive logging system for tracking player actions, server events, and administrative activities within the Lilia framework. It supports categorized logging, localized messages, and provides utilities for recording various types of events such as character actions, combat events, world interactions, and administrative operations.
-]]
 lia.log = lia.log or {}
 lia.log.types = {
     ["charRecognize"] = {
@@ -752,35 +741,9 @@ lia.log.types = {
         func = function(client, charID) return L("logCharUnbanOffline", client:Name(), tostring(charID)) end,
         category = L("admin")
     },
+
 }
 
---[[
-    lia.log.addType
-
-    Purpose:
-        Registers a new log type with a custom formatting function and category.
-        This allows you to extend the logging system with your own log events.
-
-    Parameters:
-        logType (string)   - The unique identifier for the log type.
-        func (function)    - A function that returns the formatted log string. Receives (client, ...).
-        category (string)  - The category name for this log type (used for filtering and display).
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        -- Register a new log type for a custom event
-        lia.log.addType("myCustomEvent", function(client, data)
-            return string.format("%s performed a custom event: %s", client:Name(), data)
-        end, "customCategory")
-
-        -- Later, you can log this event:
-        lia.log.add(somePlayer, "myCustomEvent", "opened the secret door")
-]]
 function lia.log.addType(logType, func, category)
     lia.log.types[logType] = {
         func = func,
@@ -788,31 +751,6 @@ function lia.log.addType(logType, func, category)
     }
 end
 
---[[
-    lia.log.getString
-
-    Purpose:
-        Retrieves the formatted log string and category for a given log type and arguments.
-        This is used internally to generate the final log message before output or storage.
-
-    Parameters:
-        client (Player)    - The player associated with the log event (can be nil for server events).
-        logType (string)   - The log type identifier (must be registered in lia.log.types).
-        ...                - Additional arguments passed to the log formatting function.
-
-    Returns:
-        logString (string) - The formatted log message, or nil if the log type is invalid.
-        category (string)  - The category of the log message, or nil if not found.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        -- Get the log string for a player spawning a prop
-        local logString, category = lia.log.getString(player, "spawned_prop", "models/props_c17/oildrum001.mdl")
-        print(logString) -- e.g., "PlayerName spawned prop: models/props_c17/oildrum001.mdl"
-        print(category)  -- e.g., "World"
-]]
 function lia.log.getString(client, logType, ...)
     local logData = lia.log.types[logType]
     if not logData then return end
@@ -822,34 +760,6 @@ function lia.log.getString(client, logType, ...)
     end
 end
 
---[[
-    lia.log.add
-
-    Purpose:
-        Adds a new log entry to the server log, prints it, and stores it in the database.
-        This is the main function to use when you want to log an event in the system.
-
-    Parameters:
-        client (Player)    - The player associated with the log event (can be nil for server events).
-        logType (string)   - The log type identifier (must be registered in lia.log.types).
-        ...                - Additional arguments passed to the log formatting function.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        -- Log a player picking up money
-        lia.log.add(player, "moneyPickedUp", 100)
-
-        -- Log a player using a command
-        lia.log.add(player, "command", "/roll 100")
-
-        -- Log a server-side event (no player)
-        lia.log.add(nil, "configChange", "maxPlayers", 32, 64)
-]]
 function lia.log.add(client, logType, ...)
     local logString, category = lia.log.getString(client, logType, ...)
     if not isstring(category) then category = L("uncategorized") end


### PR DESCRIPTION
## Summary
- detail logger database fields and clarify getString behaviour
- remove obsolete inline comments from logger library

## Testing
- `luac -p gamemode/core/libraries/logger.lua`
- `luacheck gamemode/core/libraries/logger.lua` *(warnings: accessing undefined globals, long lines)*

------
https://chatgpt.com/codex/tasks/task_e_68988149adf483278e13ed763905db46