### PR TITLE
docs: sync factions library documentation

### DIFF
--- a/documentation/docs/libraries/lia.factions.md
+++ b/documentation/docs/libraries/lia.factions.md
@@ -1,425 +1,377 @@
 # Factions Library
 
-This page covers the faction system helpers.
+This page documents the functions for working with faction management and team systems.
 
 ---
 
 ## Overview
 
-The factions library loads faction definitions and stores them for later lookup. Factions are kept in two tables:
-
-* `lia.faction.teams` — indexed by unique identifier.
-
-* `lia.faction.indices` — indexed by team number.
-
-By default a staff faction is registered and exposed as the global constant `FACTION_STAFF`.
-
-The helpers below let you find factions and iterate over their data. See [Faction Fields](../definitions/faction.md) for the keys stored in each `FACTION` table.
-
----
+The factions library provides a system for managing player factions, teams, and group affiliations within the Lilia framework. It handles faction registration, team setup, model management, and provides utilities for working with faction data. The library supports faction-specific colors, models, and metadata, and integrates with Garry's Mod's team system.
 
 ### lia.faction.register
 
 **Purpose**
 
-Registers a new faction, localises its fields, precaches its models and assigns it a team.
+Registers a new faction with the given unique ID and data table. Handles localization, color, models, and sets up the team. Also precaches all faction models and stores the faction in the global indices and teams tables.
 
 **Parameters**
 
-* `uniqueID` (*string*): Unique identifier for the faction.
-* `data` (*table*): Faction properties. Missing fields default to:
-  * `name` → `"unknown"`
-  * `desc` → `"noDesc"`
-  * `isDefault` → `true`
-  * `color` → `Color(150, 150, 150)`
-  * `models` → citizen model set
-  * `index` → next free index if omitted
-
-**Realm**
-
-`Shared`
+* `uniqueID` (*string*) - The unique identifier for the faction.
+* `data` (*table*) - The data table containing faction properties (name, desc, color, models, etc).
 
 **Returns**
 
-* `number`: Index assigned to the faction.
-* `table`: The registered faction table.
+* `index` (*number*) - The index assigned to the faction.
+* `faction` (*table*) - The faction table that was registered.
 
-**Notes**
+**Realm**
 
-* Uses `data.index` or an existing `FACTION_<UNIQUEID>` constant if provided; otherwise the next free index is used.
-* Registers the faction in `lia.faction.indices` and `lia.faction.teams`.
-* Defines global constant `FACTION_<UNIQUEID>` with the faction's index.
-* Name, description and model lists are localized via `L()` and may be overridden by the hooks `OverrideFactionName`, `OverrideFactionDesc` and `OverrideFactionModels`.
+Shared.
 
 **Example Usage**
 
 ```lua
+-- Register a new faction called "citizen"
 local index, faction = lia.faction.register("citizen", {
     name = "Citizen",
-    desc = "Common populace",
-    isDefault = true,
+    desc = "The common people of the city.",
     color = Color(100, 150, 200),
-    models = {"models/player/group01/male_01.mdl"}
+    isDefault = true,
+    models = {"models/player/group01/male_01.mdl", "models/player/group01/female_01.mdl"}
 })
 ```
-
----
 
 ### lia.faction.loadFromDir
 
 **Purpose**
 
-Loads all Lua faction files from a directory, includes them **shared**, and registers the resulting `FACTION` tables.
-Each file should define a global `FACTION` table describing the faction.
-The filename (minus any leading `sh_`) becomes the faction's unique ID unless `FACTION.uniqueID` is set.
-Missing `name`, `desc`, or `color` fields are replaced with defaults and an error is logged.
-`isDefault` defaults to `true` and a new index is assigned if not provided.
-Models default to the citizen set and are precached. Names, descriptions and models are localized via `L()` and can be overridden via the hooks `OverrideFactionName`, `OverrideFactionDesc` and `OverrideFactionModels`.
-Factions are stored in both lookup tables and `team.SetUp` is called for each.
+Loads all faction definition files from the specified directory, registering them into `lia.faction.teams` and `lia.faction.indices`. Each faction file should define a `FACTION` table. This function ensures the faction's name, description, and color are set and localized, and precaches all models.
 
 **Parameters**
 
-* `directory` (*string*): Path to the folder containing faction files.
-
-**Realm**
-
-`Shared`
+* `directory` (*string*) - The directory path to search for faction files (should be relative to the gamemode).
 
 **Returns**
 
-* *nil*: This function does not return a value.
+* *nil*
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-lia.faction.loadFromDir("path/to/factions")
+-- Load all factions from the "factions" directory
+lia.faction.loadFromDir("gamemode/schema/factions")
 ```
-
----
 
 ### lia.faction.get
 
 **Purpose**
 
-Retrieves a faction table by its index or unique identifier.
+Retrieves a faction table by its index or unique ID.
 
 **Parameters**
 
-* `identifier` (*number | string*): Faction index or unique ID.
-
-**Realm**
-
-`Shared`
+* `identifier` (*number|string*) - The faction index or unique ID.
 
 **Returns**
 
-* *table | nil*: The faction table, or `nil` if not found.
+* `faction` (*table|nil*) - The faction table if found, or nil.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-local faction = lia.faction.get("citizen")
+-- Get the faction table for the "staff" faction
+local staffFaction = lia.faction.get("staff")
+-- Get the faction table by index
+local factionByIndex = lia.faction.get(1)
 ```
-
----
 
 ### lia.faction.getIndex
 
 **Purpose**
 
-Returns the numeric index of a faction given its unique identifier.
+Retrieves the index of a faction by its unique ID.
 
 **Parameters**
 
-* `uniqueID` (*string*): Faction unique ID.
-
-**Realm**
-
-`Shared`
+* `uniqueID` (*string*) - The unique ID of the faction.
 
 **Returns**
 
-* *number | nil*: Index if found, otherwise `nil`.
+* `index` (*number|nil*) - The index of the faction, or nil if not found.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-local index = lia.faction.getIndex("citizen")
+-- Get the index of the "staff" faction
+local staffIndex = lia.faction.getIndex("staff")
 ```
-
----
 
 ### lia.faction.getClasses
 
 **Purpose**
 
-Returns a list of class tables that belong to the specified faction.
+Retrieves all classes associated with a given faction.
 
 **Parameters**
 
-* `faction` (*number | string*): Faction index or unique ID.
-
-**Realm**
-
-`Shared`
+* `faction` (*number|string*) - The faction index or unique ID.
 
 **Returns**
 
-* *table*: Array of class tables.
+* `classes` (*table*) - A table of class tables belonging to the faction.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-local classes = lia.faction.getClasses(FACTION_CITIZEN)
+-- Get all classes for the "staff" faction
+local staffClasses = lia.faction.getClasses("staff")
 ```
-
----
 
 ### lia.faction.getPlayers
 
 **Purpose**
 
-Retrieves all player entities whose characters are in the given faction. Players without a character are ignored.
+Retrieves all players currently in the specified faction.
 
 **Parameters**
 
-* `faction` (*number | string*): Faction index or unique ID.
-
-**Realm**
-
-`Shared`
+* `faction` (*number|string*) - The faction index or unique ID.
 
 **Returns**
 
-* *table*: Array of `Player` entities.
+* `players` (*table*) - A table of player objects in the faction.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-local players = lia.faction.getPlayers(FACTION_CITIZEN)
+-- Get all players in the "staff" faction
+local staffPlayers = lia.faction.getPlayers("staff")
 ```
-
----
 
 ### lia.faction.getPlayerCount
 
 **Purpose**
 
-Counts how many players belong to the specified faction. Players without a character are not counted.
+Counts the number of players currently in the specified faction.
 
 **Parameters**
 
-* `faction` (*number | string*): Faction index or unique ID.
-
-**Realm**
-
-`Shared`
+* `faction` (*number|string*) - The faction index or unique ID.
 
 **Returns**
 
-* *number*: Player count.
+* `count` (*number*) - The number of players in the faction.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-local count = lia.faction.getPlayerCount(FACTION_CITIZEN)
+-- Get the number of players in the "staff" faction
+local staffCount = lia.faction.getPlayerCount("staff")
 ```
-
----
 
 ### lia.faction.isFactionCategory
 
 **Purpose**
 
-Checks whether a faction belongs to a category defined by a list of faction IDs.
+Checks if a given faction is part of a specified category (list of factions).
 
 **Parameters**
 
-* `faction` (*number | string*): Faction index or unique ID.
-* `categoryFactions` (*table*): Array of faction indices or unique IDs in the category.
-
-**Realm**
-
-`Shared`
+* `faction` (*number|string*) - The faction index or unique ID.
+* `categoryFactions` (*table*) - Table of faction indices or unique IDs representing the category.
 
 **Returns**
 
-* *boolean*: `true` if the faction is in the category.
+* `isCategory` (*boolean*) - True if the faction is in the category, false otherwise.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-local isMember = lia.faction.isFactionCategory("citizen", { "citizen", "veteran" })
+-- Check if "staff" is in the admin category
+local isAdmin = lia.faction.isFactionCategory("staff", {"staff", "admin", "superadmin"})
 ```
-
----
 
 ### lia.faction.jobGenerate
 
 **Purpose**
 
-Dynamically creates and registers a new faction (job) with the team system, precaching its models and storing it in the lookup tables.
+Generates and registers a simple faction/job with the specified properties.
 
 **Parameters**
 
-* `index` (*number*): Team index.
-
-* `name` (*string*): Faction name.
-
-* `color` (*Color*): Team colour.
-
-* `default` (*boolean*): Whether this faction is default.
-
-* `models` (*table | nil*): Optional array of model paths or model data. Defaults to the citizen model set.
-
-**Realm**
-
-`Shared`
+* `index` (*number*) - The index to assign to the faction.
+* `name` (*string*) - The name of the faction.
+* `color` (*Color*) - The color of the faction.
+* `default` (*boolean*) - Whether the faction is default.
+* `models` (*table|nil*) - Table of model paths for the faction (optional).
 
 **Returns**
 
-* *table*: The generated faction table. The `desc` field is empty and `uniqueID` defaults to `name`.
+* `FACTION` (*table*) - The created faction table.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-local police = lia.faction.jobGenerate(
-    2,
-    "Police",
-    Color(0, 0, 255),
-    false,
-    { "models/player/police.mdl" }
-)
+-- Generate a new job/faction called "Guard"
+local guardFaction = lia.faction.jobGenerate(2, "Guard", Color(0, 100, 255), false, {"models/player/police.mdl"})
 ```
-
----
 
 ### lia.faction.formatModelData
 
 **Purpose**
 
-Processes all faction model entries and expands any bodygroup data so each model has numeric group indices. Useful for bodygroup customisation.
+Processes and formats the model data for all factions, ensuring bodygroup data is properly set up for each model. This is useful for advanced model customization and bodygroup support.
 
 **Parameters**
 
 *None*
 
-**Realm**
-
-`Shared`
-
 **Returns**
 
-* *nil*: This function does not return a value.
+*None*
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
+-- Format all faction model data after loading factions
 lia.faction.formatModelData()
 ```
-
----
 
 ### lia.faction.getCategories
 
 **Purpose**
 
-Returns a list of model category names for the given faction.
+Retrieves all model categories for a given faction/team name.
 
 **Parameters**
 
-* `teamName` (*string*): Faction unique ID.
-
-**Realm**
-
-`Shared`
+* `teamName` (*string*) - The unique ID of the faction/team.
 
 **Returns**
 
-* *table*: Array of category names (empty if none or the faction doesn't exist).
+* `categories` (*table*) - A table of category names (strings).
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-local categories = lia.faction.getCategories("citizen")
+-- Get all model categories for the "staff" faction
+local categories = lia.faction.getCategories("staff")
 ```
-
----
 
 ### lia.faction.getModelsFromCategory
 
 **Purpose**
 
-Returns the models that belong to a specific category for a faction.
+Retrieves all models from a specific category for a given faction/team.
 
 **Parameters**
 
-* `teamName` (*string*): Faction unique ID.
-
-* `category` (*string*): Category name.
-
-**Realm**
-
-`Shared`
+* `teamName` (*string*) - The unique ID of the faction/team.
+* `category` (*string*) - The category name.
 
 **Returns**
 
-* *table*: Table of model entries (strings or `{path, skin, bodygroups}`) — empty if the faction or category is missing.
+* `models` (*table*) - A table of models in the specified category.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-local models = lia.faction.getModelsFromCategory("citizen", "special")
+-- Get all "male" models for the "citizen" faction
+local maleModels = lia.faction.getModelsFromCategory("citizen", "male")
 ```
-
----
 
 ### lia.faction.getDefaultClass
 
 **Purpose**
 
-Finds the first class marked as default for the given faction.
+Retrieves the default class for a given faction.
 
 **Parameters**
 
-* `id` (*number | string*): Faction index or unique ID.
-
-**Realm**
-
-`Shared`
+* `id` (*number|string*) - The faction index or unique ID.
 
 **Returns**
 
-* *table | nil*: Default class table, or `nil` if none.
+* `defaultClass` (*table|nil*) - The default class table, or nil if not found.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-local defaultClass = lia.faction.getDefaultClass(FACTION_CITIZEN)
+-- Get the default class for the "staff" faction
+local defaultClass = lia.faction.getDefaultClass("staff")
 ```
-
----
 
 ### lia.faction.hasWhitelist
 
 **Purpose**
 
-Client-side check whether the local player is whitelisted for a faction. Default factions always return `true`. For the `FACTION_STAFF` faction the `createStaffCharacter` privilege is required and the player is notified if the privilege is missing. Other factions check `lia.localData.whitelists`.
+Checks if the local player has a whitelist for the specified faction.
 
 **Parameters**
 
-* `faction` (*number | string*): Faction index or unique ID.
-
-**Realm**
-
-`Client`
+* `faction` (*number|string*) - The faction index or unique ID.
 
 **Returns**
 
-* *boolean*: `true` if the faction is default or the player has a whitelist.
+* `hasWhitelist` (*boolean*) - True if the player has a whitelist or the faction is default, false otherwise.
+
+**Realm**
+
+Client.
 
 **Example Usage**
 
 ```lua
-local whitelisted = lia.faction.hasWhitelist(FACTION_CITIZEN)
+-- Check if the local player has access to the "staff" faction
+if lia.faction.hasWhitelist("staff") then
+    print("You are whitelisted for staff!")
+end
 ```

--- a/gamemode/core/libraries/factions.lua
+++ b/gamemode/core/libraries/factions.lua
@@ -1,46 +1,7 @@
-﻿--[[
-# Factions Library
-
-This page documents the functions for working with faction management and team systems.
-
----
-
-## Overview
-
-The factions library provides a system for managing player factions, teams, and group affiliations within the Lilia framework. It handles faction registration, team setup, model management, and provides utilities for working with faction data. The library supports faction-specific colors, models, and metadata, and integrates with Garry's Mod's team system.
-]]
-lia.faction = lia.faction or {}
+﻿lia.faction = lia.faction or {}
 lia.faction.indices = lia.faction.indices or {}
 lia.faction.teams = lia.faction.teams or {}
 local DefaultModels = {"models/player/group01/male_01.mdl", "models/player/group01/male_02.mdl", "models/player/group01/male_03.mdl", "models/player/group01/male_04.mdl", "models/player/group01/male_05.mdl", "models/player/group01/male_06.mdl", "models/player/group01/female_01.mdl", "models/player/group01/female_02.mdl", "models/player/group01/female_03.mdl", "models/player/group01/female_04.mdl", "models/player/group01/female_05.mdl", "models/player/group01/female_06.mdl"}
---[[
-    lia.faction.register
-
-    Purpose:
-        Registers a new faction with the given unique ID and data table. Handles localization, color, models, and sets up the team.
-        Also precaches all faction models and stores the faction in the global indices and teams tables.
-
-    Parameters:
-        uniqueID (string) - The unique identifier for the faction.
-        data (table)      - The data table containing faction properties (name, desc, color, models, etc).
-
-    Returns:
-        index (number)    - The index assigned to the faction.
-        faction (table)   - The faction table that was registered.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Register a new faction called "citizen"
-        local index, faction = lia.faction.register("citizen", {
-            name = "Citizen",
-            desc = "The common people of the city.",
-            color = Color(100, 150, 200),
-            isDefault = true,
-            models = {"models/player/group01/male_01.mdl", "models/player/group01/female_01.mdl"}
-        })
-]]
 function lia.faction.register(uniqueID, data)
     assert(isstring(uniqueID), L("factionUniqueIDString"))
     assert(istable(data), L("factionDataTable"))
@@ -86,27 +47,6 @@ function lia.faction.register(uniqueID, data)
     return faction.index, faction
 end
 
---[[
-    lia.faction.loadFromDir
-
-    Purpose:
-        Loads all faction definition files from the specified directory, registering them into lia.faction.teams and lia.faction.indices.
-        Each faction file should define a FACTION table. This function ensures the faction's name, description, and color are set and localized,
-        and precaches all models.
-
-    Parameters:
-        directory (string) - The directory path to search for faction files (should be relative to the gamemode).
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Load all factions from the "factions" directory
-        lia.faction.loadFromDir("gamemode/schema/factions")
-]]
 function lia.faction.loadFromDir(directory)
     for _, v in ipairs(file.Find(directory .. "/*.lua", "LUA")) do
         local niceName
@@ -162,73 +102,14 @@ function lia.faction.loadFromDir(directory)
     end
 end
 
---[[
-    lia.faction.get
-
-    Purpose:
-        Retrieves a faction table by its index or unique ID.
-
-    Parameters:
-        identifier (number|string) - The faction index or unique ID.
-
-    Returns:
-        faction (table|none) - The faction table if found, or none.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Get the faction table for the "staff" faction
-        local staffFaction = lia.faction.get("staff")
-        -- Get the faction table by index
-        local factionByIndex = lia.faction.get(1)
-]]
 function lia.faction.get(identifier)
     return lia.faction.indices[identifier] or lia.faction.teams[identifier]
 end
 
---[[
-    lia.faction.getIndex
-
-    Purpose:
-        Retrieves the index of a faction by its unique ID.
-
-    Parameters:
-        uniqueID (string) - The unique ID of the faction.
-
-    Returns:
-        index (number|none) - The index of the faction, or nil if not found.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Get the index of the "staff" faction
-        local staffIndex = lia.faction.getIndex("staff")
-]]
 function lia.faction.getIndex(uniqueID)
     return lia.faction.teams[uniqueID] and lia.faction.teams[uniqueID].index
 end
 
---[[
-    lia.faction.getClasses
-
-    Purpose:
-        Retrieves all classes associated with a given faction.
-
-    Parameters:
-        faction (number|string) - The faction index or unique ID.
-
-    Returns:
-        classes (table) - A table of class tables belonging to the faction.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Get all classes for the "staff" faction
-        local staffClasses = lia.faction.getClasses("staff")
-]]
 function lia.faction.getClasses(faction)
     local classes = {}
     for _, class in pairs(lia.class.list) do
@@ -237,25 +118,6 @@ function lia.faction.getClasses(faction)
     return classes
 end
 
---[[
-    lia.faction.getPlayers
-
-    Purpose:
-        Retrieves all players currently in the specified faction.
-
-    Parameters:
-        faction (number|string) - The faction index or unique ID.
-
-    Returns:
-        players (table) - A table of player objects in the faction.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Get all players in the "staff" faction
-        local staffPlayers = lia.faction.getPlayers("staff")
-]]
 function lia.faction.getPlayers(faction)
     local players = {}
     for _, v in player.Iterator() do
@@ -265,25 +127,6 @@ function lia.faction.getPlayers(faction)
     return players
 end
 
---[[
-    lia.faction.getPlayerCount
-
-    Purpose:
-        Counts the number of players currently in the specified faction.
-
-    Parameters:
-        faction (number|string) - The faction index or unique ID.
-
-    Returns:
-        count (number) - The number of players in the faction.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Get the number of players in the "staff" faction
-        local staffCount = lia.faction.getPlayerCount("staff")
-]]
 function lia.faction.getPlayerCount(faction)
     local count = 0
     for _, v in player.Iterator() do
@@ -293,54 +136,11 @@ function lia.faction.getPlayerCount(faction)
     return count
 end
 
---[[
-    lia.faction.isFactionCategory
-
-    Purpose:
-        Checks if a given faction is part of a specified category (list of factions).
-
-    Parameters:
-        faction (number|string)     - The faction index or unique ID.
-        categoryFactions (table)    - Table of faction indices or unique IDs representing the category.
-
-    Returns:
-        isCategory (boolean)        - True if the faction is in the category, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Check if "staff" is in the admin category
-        local isAdmin = lia.faction.isFactionCategory("staff", {"staff", "admin", "superadmin"})
-]]
 function lia.faction.isFactionCategory(faction, categoryFactions)
     if table.HasValue(categoryFactions, faction) then return true end
     return false
 end
 
---[[
-    lia.faction.jobGenerate
-
-    Purpose:
-        Generates and registers a simple faction/job with the specified properties.
-
-    Parameters:
-        index (number)         - The index to assign to the faction.
-        name (string)          - The name of the faction.
-        color (Color)          - The color of the faction.
-        default (boolean)      - Whether the faction is default.
-        models (table|none)     - Table of model paths for the faction (optional).
-
-    Returns:
-        FACTION (table)        - The created faction table.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Generate a new job/faction called "Guard"
-        local guardFaction = lia.faction.jobGenerate(2, "Guard", Color(0, 100, 255), false, {"models/player/police.mdl"})
-]]
 function lia.faction.jobGenerate(index, name, color, default, models)
     local FACTION = {}
     FACTION.index = index
@@ -406,26 +206,6 @@ local function formatModelDataEntry(name, faction, modelIndex, modelData, catego
     end
 end
 
---[[
-    lia.faction.formatModelData
-
-    Purpose:
-        Processes and formats the model data for all factions, ensuring bodygroup data is properly set up for each model.
-        This is useful for advanced model customization and bodygroup support.
-
-    Parameters:
-        None.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Format all faction model data after loading factions
-        lia.faction.formatModelData()
-]]
 function lia.faction.formatModelData()
     for name, faction in pairs(lia.faction.teams) do
         if faction.models then
@@ -442,25 +222,6 @@ function lia.faction.formatModelData()
     end
 end
 
---[[
-    lia.faction.getCategories
-
-    Purpose:
-        Retrieves all model categories for a given faction/team name.
-
-    Parameters:
-        teamName (string) - The unique ID of the faction/team.
-
-    Returns:
-        categories (table) - A table of category names (strings).
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Get all model categories for the "staff" faction
-        local categories = lia.faction.getCategories("staff")
-]]
 function lia.faction.getCategories(teamName)
     local categories = {}
     local faction = lia.faction.teams[teamName]
@@ -472,26 +233,6 @@ function lia.faction.getCategories(teamName)
     return categories
 end
 
---[[
-    lia.faction.getModelsFromCategory
-
-    Purpose:
-        Retrieves all models from a specific category for a given faction/team.
-
-    Parameters:
-        teamName (string)   - The unique ID of the faction/team.
-        category (string)   - The category name.
-
-    Returns:
-        models (table)      - A table of models in the specified category.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Get all "male" models for the "citizen" faction
-        local maleModels = lia.faction.getModelsFromCategory("citizen", "male")
-]]
 function lia.faction.getModelsFromCategory(teamName, category)
     local models = {}
     local faction = lia.faction.teams[teamName]
@@ -503,25 +244,6 @@ function lia.faction.getModelsFromCategory(teamName, category)
     return models
 end
 
---[[
-    lia.faction.getDefaultClass
-
-    Purpose:
-        Retrieves the default class for a given faction.
-
-    Parameters:
-        id (number|string) - The faction index or unique ID.
-
-    Returns:
-        defaultClass (table|none) - The default class table, or nil if not found.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Get the default class for the "staff" faction
-        local defaultClass = lia.faction.getDefaultClass("staff")
-]]
 function lia.faction.getDefaultClass(id)
     local defaultClass = nil
     for _, class in ipairs(lia.class.list) do
@@ -543,35 +265,14 @@ FACTION_STAFF = lia.faction.register("staff", {
 })
 
 if CLIENT then
-    --[[
-        lia.faction.hasWhitelist
-
-        Purpose:
-            Checks if the local player has a whitelist for the specified faction.
-
-        Parameters:
-            faction (number|string) - The faction index or unique ID.
-
-        Returns:
-            hasWhitelist (boolean)  - True if the player has a whitelist or the faction is default, false otherwise.
-
-        Realm:
-            Client.
-
-        Example Usage:
-            -- Check if the local player has access to the "staff" faction
-            if lia.faction.hasWhitelist("staff") then
-                print("You are whitelisted for staff!")
-            end
-    ]]
     function lia.faction.hasWhitelist(faction)
         local data = lia.faction.indices[faction]
         if data then
             if data.isDefault then return true end
-            
+
             if faction == FACTION_STAFF then
                 local hasPriv = LocalPlayer():hasPrivilege("createStaffCharacter")
-                
+
                 if not (lia.administrator.privileges and lia.administrator.privileges["createStaffCharacter"]) then
                     lia.information(L("privilegeNotExist", "createStaffCharacter"))
                     if IsValid(LocalPlayer()) and LocalPlayer().notifyLocalized then


### PR DESCRIPTION
## Summary
- Replace `lia.factions` library docs with content from code comments
- Drop in-file documentation blocks from `factions.lua`

## Testing
- `luacheck gamemode/core/libraries/factions.lua` *(154 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68988bfa6a788327a62bd39adb6397d4