### PR TITLE
docs: move config library documentation to markdown

### DIFF
--- a/documentation/docs/libraries/lia.config.md
+++ b/documentation/docs/libraries/lia.config.md
@@ -1,289 +1,172 @@
 # Config Library
 
-This page explains how to add and access configuration settings.
+## lia.config.add
 
----
+**Purpose:** Registers a new configuration variable with the Lilia config system. This function sets up the config's name, default value, type, description, category, and optional callback for when the value changes. The config is stored in `lia.config.stored`.
 
-## Overview
+**Parameters:**
+- `key` (string) - The unique key for the config variable.
+- `name` (string) - The display name for the config variable (localized automatically).
+- `value` (any) - The default value for the config variable.
+- `callback` (function) - (Optional) Function to call when the config value changes.
+- `data` (table) - Table containing additional config properties (type, desc, category, etc). String values such as `desc`, `category`, and entries in an `options` table are localized automatically.
 
-The configuration library provides a centralized system for managing settings across the framework. It supports:
+**Returns:** None.
 
-* **Type-safe values** with automatic detection for strings, numbers, booleans, colors and tables.
-* **Validation rules** such as minimum/maximum ranges and selectable options.
-* **Change callbacks** for reacting to updates at runtime.
-* **Client-server synchronization** so changes propagate to connected players.
-* **Category organization** and description text for use in UI.
-* **Default value management** with persistence to the database.
+**Realm:** Shared.
 
----
-
-### lia.config.add
-
-**Purpose**
-
-Registers a new config option with the given key, display name, default value, and optional callback. A data table describing the option is **required**. If an option with the same key already exists, its current value is kept.
-
-**Parameters**
-
-* `key` (*string*): Unique identifier for the option.
-
-* `name` (*string*): Display name shown in menus. Localized automatically with `L`.
-
-* `value` (*any*): Default stored value.
-
-* `callback` (*function*): Function run when the value changes. Receives `(oldValue, newValue)`. *Optional*.
-
-* `data` (*table*): Table describing the option. Common fields include `desc`, `category`, `type`, `min`, `max`, `decimals`, `options`, and `noNetworking`. `category` defaults to `L("character")` and `noNetworking` defaults to `false`. Additional fields are accepted and stored. Any string values for `desc`, `category`, or within `options` are localized automatically. If `type` is omitted, it is inferred from `value`.
-
-**Realm**
-
-`Shared`
-
-**Returns**
-
-* *nil*: This function does not return a value.
-
-**Example Usage**
-
+**Example Usage:**
 ```lua
--- Register a walk-speed option with limits and a callback
-lia.config.add(
-    "walkSpeed",
-    "walkSpeed",
-    130,
-    function(_, newValue)
-        for _, ply in player.Iterator() do
-            ply:SetWalkSpeed(newValue)
-        end
-    end,
-    {
-        desc = "walkSpeedDesc",
-        category = "movement",
-        type = "Int",
-        min = 50,
-        max = 300
-    }
-)
+-- Add a new integer config variable for maximum players
+lia.config.add("MaxPlayers", "Maximum Players", 32, function(old, new)
+    print("Max players changed from", old, "to", new)
+end, {
+    desc = "The maximum number of players allowed on the server.",
+    category = "server",
+    type = "Int",
+    min = 1,
+    max = 128
+})
 ```
 
----
+## lia.config.setDefault
 
-### lia.config.setDefault
+**Purpose:** Sets the default value for a given config variable. This does not change the current value, only the default.
 
-**Purpose**
+**Parameters:**
+- `key` (string) - The config variable key.
+- `value` (any) - The new default value.
 
-Changes the stored default for an existing config option without affecting its current value or notifying clients. This does not automatically persist the new default; call `lia.config.save()` to commit it.
+**Returns:** None.
 
-**Parameters**
+**Realm:** Shared.
 
-* `key` (*string*): Key identifying the option.
-
-* `value` (*any*): New default value.
-
-**Realm**
-
-`Shared`
-
-**Returns**
-
-* *nil*: This function does not return a value.
-
-**Example Usage**
-
+**Example Usage:**
 ```lua
--- Update the default maximum players
-lia.config.setDefault("maxPlayers", 32)
+-- Change the default walk speed to 150
+lia.config.setDefault("WalkSpeed", 150)
 ```
 
----
+## lia.config.forceSet
 
-### lia.config.forceSet
+**Purpose:** Sets the value of a config variable, bypassing any callbacks or networking, and optionally skips saving to the database.
 
-**Purpose**
+**Parameters:**
+- `key` (string) - The config variable key.
+- `value` (any) - The value to set.
+- `noSave` (boolean) - If true, does not save the config to the database.
 
-Sets a config value directly without running callbacks or networking the update. The value is saved unless `noSave` is `true`. If the key does not exist, the call has no effect.
+**Returns:** None.
 
-**Parameters**
+**Realm:** Shared.
 
-* `key` (*string*): Key identifying the option.
-
-* `value` (*any*): New value to set.
-
-* `noSave` (*boolean*): If `true`, value is not written to disk. *Default*: `false`.
-
-**Realm**
-
-`Shared`
-
-**Returns**
-
-* *nil*: This function does not return a value.
-
-**Example Usage**
-
+**Example Usage:**
 ```lua
-lia.config.forceSet("someSetting", true, true)
+-- Force the money limit to 10000 without saving to the database
+lia.config.forceSet("MoneyLimit", 10000, true)
 ```
 
----
+## lia.config.set
 
-### lia.config.set
+**Purpose:** Sets the value of a config variable, triggers networking to clients (if applicable), calls the callback, and saves the config.
 
-**Purpose**
+**Parameters:**
+- `key` (string) - The config variable key.
+- `value` (any) - The value to set.
 
-Sets a config value and updates `lia.config.stored`. On the server it broadcasts a `cfgSet` net message to clients (unless the option is marked `noNetworking`), runs the change callback with `(oldValue, newValue)`, and saves the result. On the client it only updates the local value. If the key does not exist, nothing happens.
+**Returns:** None.
 
-**Parameters**
+**Realm:** Shared (server triggers networking).
 
-* `key` (*string*): Key identifying the option.
-
-* `value` (*any*): New value to set.
-
-**Realm**
-
-`Shared`
-
-**Returns**
-
-* *nil*: This function does not return a value.
-
-**Example Usage**
-
+**Example Usage:**
 ```lua
-lia.config.set("maxPlayers", 24)
+-- Set the walk speed to 140 and notify all clients
+lia.config.set("WalkSpeed", 140)
 ```
 
----
+## lia.config.get
 
-### lia.config.get
+**Purpose:** Retrieves the value of a config variable. If the value is not set, returns the default or a provided fallback.
 
-**Purpose**
+**Parameters:**
+- `key` (string) - The config variable key.
+- `default` (any) - (Optional) Value to return if the config is not found.
 
-Retrieves the current value of a config entry. If unset, returns the stored default or the provided fallback. Color tables are converted to `Color` objects automatically.
+**Returns:** Any - The current value, the default, or the provided fallback.
 
-**Parameters**
+**Realm:** Shared.
 
-* `key` (*string*): Key identifying the config option.
-
-* `default` (*any*): Value to return if the config is not found.
-
-**Realm**
-
-`Shared`
-
-**Returns**
-
-* *any*: The config value or the default.
-
-**Example Usage**
-
+**Example Usage:**
 ```lua
-local players = lia.config.get("maxPlayers", 64)
+-- Get the current money limit, or 5000 if not set
+local limit = lia.config.get("MoneyLimit", 5000)
 ```
 
----
+## lia.config.load
 
-### lia.config.load
+**Purpose:** Loads all config variables from the database for the current schema/gamemode. If a config is missing, it is inserted with its default value. On the client, requests the config list from the server.
 
-**Purpose**
+**Parameters:** None.
 
-On the server, loads config values from the database for the current schema and inserts any missing entries with their defaults. After loading, the `InitializedConfig` hook is fired. On the client, `lia.config.load` requests the config list from the server.
+**Returns:** None.
 
-**Parameters**
+**Realm:** Server (loads from DB), Client (requests from server).
 
-*None*
-
-**Realm**
-
-`Server` and `Client`
-
-**Returns**
-
-* *nil*: This function does not return a value.
-
-**Example Usage**
-
+**Example Usage:**
 ```lua
+-- Load all config variables at server startup
 lia.config.load()
 ```
 
----
+## lia.config.getChangedValues
 
-### lia.config.getChangedValues
+**Purpose:** Returns a table of all config variables whose value differs from their default.
 
-**Purpose**
+**Parameters:** None.
 
-Returns a table of all config entries whose current value differs from the default.
+**Returns:** table - A table of changed config key-value pairs.
 
-**Parameters**
+**Realm:** Server.
 
-*None*
-
-**Realm**
-
-`Server`
-
-**Returns**
-
-* *table*: Key-value pairs of changed config entries.
-
-**Example Usage**
-
+**Example Usage:**
 ```lua
+-- Get all changed config values for saving
 local changed = lia.config.getChangedValues()
 ```
 
----
+## lia.config.send
 
-### lia.config.send
+**Purpose:** Sends the current changed config values to a specific client or broadcasts to all clients.
 
-**Purpose**
+**Parameters:**
+- `client` (Player) - (Optional) The client to send to. If nil, broadcasts to all.
 
-Sends all changed config values to a client. If no client is provided, the values are broadcast to everyone.
+**Returns:** None.
 
-**Parameters**
+**Realm:** Server.
 
-* `client` (*Player | nil*): Player to receive the config data. If omitted, all clients receive it.
-
-**Realm**
-
-`Server`
-
-**Returns**
-
-* *nil*: This function does not return a value.
-
-**Example Usage**
-
+**Example Usage:**
 ```lua
--- Broadcast current config to every player
+-- Send config to a specific client
+lia.config.send(somePlayer)
+
+-- Broadcast config to all clients
 lia.config.send()
 ```
 
----
+## lia.config.save
 
-### lia.config.save
+**Purpose:** Saves all changed config values to the database for the current schema/gamemode.
 
-**Purpose**
+**Parameters:** None.
 
-Writes all changed config values to the database so they persist across restarts. Existing rows for the current schema are replaced.
+**Returns:** None.
 
-**Parameters**
+**Realm:** Server.
 
-*None*
-
-**Realm**
-
-`Server`
-
-**Returns**
-
-* *nil*: This function does not return a value.
-
-**Example Usage**
-
+**Example Usage:**
 ```lua
+-- Save all config changes to the database
 lia.config.save()
 ```
 
----

--- a/gamemode/core/libraries/config.lua
+++ b/gamemode/core/libraries/config.lua
@@ -1,38 +1,5 @@
 lia.config = lia.config or {}
 lia.config.stored = lia.config.stored or {}
---[[
-    lia.config.add
-
-    Purpose:
-        Registers a new configuration variable with the Lilia config system. This function sets up the config's name, default value,
-        type, description, category, and optional callback for when the value changes. The config is stored in lia.config.stored.
-
-    Parameters:
-        key (string)        - The unique key for the config variable.
-        name (string)       - The display name for the config variable (localized automatically).
-        value (any)         - The default value for the config variable.
-        callback (function) - (Optional) Function to call when the config value changes.
-        data (table)        - Table containing additional config properties (type, desc, category, etc). String values such as
-                              `desc`, `category`, and entries in an `options` table are localized automatically.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Add a new integer config variable for maximum players
-        lia.config.add("MaxPlayers", "Maximum Players", 32, function(old, new)
-            print("Max players changed from", old, "to", new)
-        end, {
-            desc = "The maximum number of players allowed on the server.",
-            category = "server",
-            type = "Int",
-            min = 1,
-            max = 128
-        })
-]]
 function lia.config.add(key, name, value, callback, data)
     assert(isstring(key), L("configKeyString", type(key)))
     assert(istable(data), L("configDataTable", type(data)))
@@ -65,78 +32,17 @@ function lia.config.add(key, name, value, callback, data)
     }
 end
 
---[[
-    lia.config.setDefault
-
-    Purpose:
-        Sets the default value for a given config variable. This does not change the current value, only the default.
-
-    Parameters:
-        key (string)   - The config variable key.
-        value (any)    - The new default value.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Change the default walk speed to 150
-        lia.config.setDefault("WalkSpeed", 150)
-]]
 function lia.config.setDefault(key, value)
     local config = lia.config.stored[key]
     if config then config.default = value end
 end
 
---[[
-    lia.config.forceSet
-
-    Purpose:
-        Sets the value of a config variable, bypassing any callbacks or networking, and optionally skips saving to the database.
-
-    Parameters:
-        key (string)     - The config variable key.
-        value (any)      - The value to set.
-        noSave (boolean) - If true, does not save the config to the database.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Force the money limit to 10000 without saving to the database
-        lia.config.forceSet("MoneyLimit", 10000, true)
-]]
 function lia.config.forceSet(key, value, noSave)
     local config = lia.config.stored[key]
     if config then config.value = value end
     if not noSave then lia.config.save() end
 end
 
---[[
-    lia.config.set
-
-    Purpose:
-        Sets the value of a config variable, triggers networking to clients (if applicable), calls the callback, and saves the config.
-
-    Parameters:
-        key (string)   - The config variable key.
-        value (any)    - The value to set.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared (server triggers networking).
-
-    Example Usage:
-        -- Set the walk speed to 140 and notify all clients
-        lia.config.set("WalkSpeed", 140)
-]]
 function lia.config.set(key, value)
     local config = lia.config.stored[key]
     if config then
@@ -156,26 +62,6 @@ function lia.config.set(key, value)
     end
 end
 
---[[
-    lia.config.get
-
-    Purpose:
-        Retrieves the value of a config variable. If the value is not set, returns the default or a provided fallback.
-
-    Parameters:
-        key (string)     - The config variable key.
-        default (any)    - (Optional) Value to return if the config is not found.
-
-    Returns:
-        any - The current value, the default, or the provided fallback.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Get the current money limit, or 5000 if not set
-        local limit = lia.config.get("MoneyLimit", 5000)
-]]
 function lia.config.get(key, default)
     local config = lia.config.stored[key]
     if config then
@@ -189,26 +75,6 @@ function lia.config.get(key, default)
     return default
 end
 
---[[
-    lia.config.load
-
-    Purpose:
-        Loads all config variables from the database for the current schema/gamemode. If a config is missing, it is inserted with its default value.
-        On the client, requests the config list from the server.
-
-    Parameters:
-        None.
-
-    Returns:
-        None.
-
-    Realm:
-        Server (loads from DB), Client (requests from server).
-
-    Example Usage:
-        -- Load all config variables at server startup
-        lia.config.load()
-]]
 function lia.config.load()
     if SERVER then
         local gamemode = SCHEMA and SCHEMA.folder or engine.ActiveGamemode()
@@ -258,25 +124,6 @@ function lia.config.load()
 end
 
 if SERVER then
-    --[[
-        lia.config.getChangedValues
-
-        Purpose:
-            Returns a table of all config variables whose value differs from their default.
-
-        Parameters:
-            None.
-
-        Returns:
-            table - A table of changed config key-value pairs.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            -- Get all changed config values for saving
-            local changed = lia.config.getChangedValues()
-    ]]
     function lia.config.getChangedValues()
         local data = {}
         for k, v in pairs(lia.config.stored) do
@@ -285,28 +132,6 @@ if SERVER then
         return data
     end
 
-    --[[
-        lia.config.send
-
-        Purpose:
-            Sends the current changed config values to a specific client or broadcasts to all clients.
-
-        Parameters:
-            client (Player) - (Optional) The client to send to. If nil, broadcasts to all.
-
-        Returns:
-            None.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            -- Send config to a specific client
-            lia.config.send(somePlayer)
-
-            -- Broadcast config to all clients
-            lia.config.send()
-    ]]
     function lia.config.send(client)
         net.Start("cfgList")
         net.WriteTable(lia.config.getChangedValues())
@@ -317,25 +142,6 @@ if SERVER then
         end
     end
 
-    --[[
-        lia.config.save
-
-        Purpose:
-            Saves all changed config values to the database for the current schema/gamemode.
-
-        Parameters:
-            None.
-
-        Returns:
-            None.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            -- Save all config changes to the database
-            lia.config.save()
-    ]]
     function lia.config.save()
         local changed = lia.config.getChangedValues()
         local rows = {}


### PR DESCRIPTION
## Summary
- port config library documentation from inline comments into `documentation/docs/libraries/lia.config.md`
- strip now redundant documentation comments from `gamemode/core/libraries/config.lua`

## Testing
- `luac -p gamemode/core/libraries/config.lua`


------
https://chatgpt.com/codex/tasks/task_e_68988bff92c08327aedea00c583e3ffb