### PR TITLE
doc: migrate item library comments

### DIFF
--- a/documentation/docs/libraries/lia.item.md
+++ b/documentation/docs/libraries/lia.item.md
@@ -179,24 +179,33 @@ print(size.width, size.height)
 
 **Purpose**
 
-Retrieves an item definition by its identifier, checking both `lia.item.base` and `lia.item.list`.
+Retrieves an item definition table by its identifier, searching both base and regular item lists.
+
 
 **Parameters**
 
 * `identifier` (*string*): The unique identifier of the item.
 
-**Realm**
 
-`Shared`
 
 **Returns**
 
-* *table | nil*: The item table if found, otherwise `nil`.
+* *table or nil*: The item definition table if found, otherwise none.
+
+
+
+**Realm**
+
+`Shared.`
+
 
 **Example Usage**
 
 ```lua
-local itemDef = lia.item.get("testItem")
+local itemDef = lia.item.get("weapon_ak47")
+if itemDef then
+print("AK47 item found:", itemDef.name)
+end
 ```
 
 ---
@@ -205,29 +214,34 @@ local itemDef = lia.item.get("testItem")
 
 **Purpose**
 
-Retrieves an item instance by its numeric item ID and reports whether it is in an inventory, the world, or unknown.
+Retrieves an instanced item by its unique item ID, along with its location (inventory or world).
+
 
 **Parameters**
 
-* `itemID` (*number*): Numeric item ID.
+* `itemID` (*number*): The unique ID of the item instance.
 
-**Realm**
 
-`Shared`
 
 **Returns**
 
-* `table | nil`: `{ item = <item>, location = <string> }` when found.
-* `string | nil`: error message when not found.
+* *table or nil, string*: Table containing the item and its location, or nil and an error message.
+
+
+
+**Realm**
+
+`Shared.`
+
 
 **Example Usage**
 
 ```lua
-local result, err = lia.item.getItemByID(42)
+local result, err = lia.item.getItemByID(1234)
 if result then
-    print("Item location:", result.location)
+print("Item found in location:", result.location)
 else
-    print("Error:", err)
+print("Error:", err)
 end
 ```
 
@@ -237,29 +251,34 @@ end
 
 **Purpose**
 
-Returns the item instance table itself without location information.
+Retrieves an instanced item object by its unique item ID.
+
 
 **Parameters**
 
-* `itemID` (*number*): Numeric item ID.
+* `itemID` (*number*): The unique ID of the item instance.
 
-**Realm**
 
-`Shared`
 
 **Returns**
 
-* `table | nil`: Item instance when found.
-* `string | nil`: error message when not found.
+* *table or nil, string*: The item instance table if found, or nil and an error message.
+
+
+
+**Realm**
+
+`Shared.`
+
 
 **Example Usage**
 
 ```lua
-local inst, err = lia.item.getInstancedItemByID(42)
-if inst then
-    print("Got item:", inst.name)
+local item, err = lia.item.getInstancedItemByID(5678)
+if item then
+print("Item name:", item.name)
 else
-    print("Error:", err)
+print("Error:", err)
 end
 ```
 
@@ -269,29 +288,34 @@ end
 
 **Purpose**
 
-Retrieves the `data` table of an item instance by its ID.
+Retrieves the data table of an instanced item by its unique item ID.
+
 
 **Parameters**
 
-* `itemID` (*number*): Numeric item ID.
+* `itemID` (*number*): The unique ID of the item instance.
 
-**Realm**
 
-`Shared`
 
 **Returns**
 
-* `table | nil`: Data table when found.
-* `string | nil`: error message when not found.
+* *table or nil, string*: The data table of the item if found, or nil and an error message.
+
+
+
+**Realm**
+
+`Shared.`
+
 
 **Example Usage**
 
 ```lua
-local data, err = lia.item.getItemDataByID(42)
+local data, err = lia.item.getItemDataByID(4321)
 if data then
-    print("Item data found.")
+PrintTable(data)
 else
-    print("Error:", err)
+print("Error:", err)
 end
 ```
 
@@ -301,28 +325,32 @@ end
 
 **Purpose**
 
-Generates a `uniqueID` from a file path and registers the item via `lia.item.register`. Used when loading items from directories.
+Loads an item definition file and registers it as a base or regular item, depending on parameters.
+
 
 **Parameters**
 
-* `path` (*string*): Path to the Lua file.
+* `path` (*string*): The file path to the item definition.
+* `baseID` (*string*): The base item ID to inherit from (optional).
+* `isBaseItem` (*bool*): Whether this is a base item definition (optional).
 
-* `baseID` (*string*): Base item unique ID to inherit from. *Optional*.
 
-* `isBaseItem` (*boolean*): Register as a base item. *Optional*.
-
-**Realm**
-
-`Shared`
 
 **Returns**
 
-* *nil*: This function does not return a value.
+* None.
+
+
+
+**Realm**
+
+`Shared.`
+
 
 **Example Usage**
 
 ```lua
-lia.item.load("lilia/gamemode/items/base/outfit.lua", nil, true)
+lia.item.load("lilia/gamemode/items/weapons/sh_ak47.lua", "base_weapons")
 ```
 
 ---
@@ -331,25 +359,31 @@ lia.item.load("lilia/gamemode/items/base/outfit.lua", nil, true)
 
 **Purpose**
 
-Checks whether an object is recognised as an item.
+Checks if the given object is an item instance.
+
 
 **Parameters**
 
-* `object` (*any*): Object to test.
+* `object` (*any*): The object to check.
 
-**Realm**
 
-`Shared`
 
 **Returns**
 
-* *boolean*: `true` if the object is an item.
+* *boolean*: True if the object is an item, false otherwise.
+
+
+
+**Realm**
+
+`Shared.`
+
 
 **Example Usage**
 
 ```lua
-if lia.item.isItem(myObject) then
-    print("It's an item!")
+if lia.item.isItem(myItem) then
+print("This is a valid item instance.")
 end
 ```
 
@@ -359,26 +393,32 @@ end
 
 **Purpose**
 
-Returns an inventory table by its ID from `lia.inventory.instances`.
+Retrieves an inventory instance by its ID.
+
 
 **Parameters**
 
-* `invID` (*number*): Inventory ID.
+* `invID` (*number*): The unique ID of the inventory.
 
-**Realm**
 
-`Shared`
 
 **Returns**
 
-* *table | nil*: Inventory or `nil`.
+* *table or nil*: The inventory instance if found, otherwise none.
+
+
+
+**Realm**
+
+`Shared.`
+
 
 **Example Usage**
 
 ```lua
-local inv = lia.item.getInv(5)
+local inv = lia.item.getInv(1001)
 if inv then
-    print("Got inventory with ID 5")
+print("Inventory found with size:", inv:getSize())
 end
 ```
 
@@ -388,32 +428,35 @@ end
 
 **Purpose**
 
-Registers a new item or base item. Sets up its metatable, merges data from the specified base, and optionally includes the file.
+Registers a new item definition, either as a base or regular item, and sets up its metatable and properties.
+
 
 **Parameters**
 
-* `uniqueID` (*string*): Item unique ID.
+* `uniqueID` (*string*): The unique identifier for the item.
+* `baseID` (*string*): The base item ID to inherit from (optional).
+* `isBaseItem` (*bool*): Whether this is a base item (optional).
+* `path` (*string*): The file path to the item definition (optional).
+* `luaGenerated` (*bool*): If true, the item is generated in Lua and not loaded from file (optional).
 
-* `baseID` (*string*): Base item ID. *Optional*.
 
-* `isBaseItem` (*boolean*): Register as a base item. *Optional*.
-
-* `path` (*string*): Optional file path.
-
-* `luaGenerated` (*boolean*): `true` if generated in code.
-
-**Realm**
-
-`Shared`
 
 **Returns**
 
-* *table*: The registered item table.
+* *table*: The registered item definition.
+
+
+
+**Realm**
+
+`Shared.`
+
 
 **Example Usage**
 
 ```lua
-lia.item.register("special_item", "base_item", false, "path/to/item.lua")
+local myItem = lia.item.register("custom_pistol", "base_weapons", false, "lilia/gamemode/items/weapons/sh_custom_pistol.lua")
+print("Registered item:", myItem.uniqueID)
 ```
 
 ---
@@ -422,23 +465,31 @@ lia.item.register("special_item", "base_item", false, "path/to/item.lua")
 
 **Purpose**
 
-Loads item Lua files from a directory. Base items load first, then sub-folders (prefixed `base_`), then loose files. Fires the `InitializedItems` hook after completion.
+Loads all item definition files from the specified directory, including base items and category folders.
+Registers each item using lia.item.load and triggers the "InitializedItems" hook after loading.
+
 
 **Parameters**
 
-* `directory` (*string*): Directory path.
+* `directory` (*string*): The directory path to search for item files (should be relative to the gamemode).
 
-**Realm**
 
-`Shared`
 
 **Returns**
 
-* *nil*: This function does not return a value.
+* None.
+
+
+
+**Realm**
+
+`Shared.`
+
 
 **Example Usage**
 
 ```lua
+-- Load all items from the "lilia/gamemode/items" directory
 lia.item.loadFromDir("lilia/gamemode/items")
 ```
 
@@ -448,27 +499,32 @@ lia.item.loadFromDir("lilia/gamemode/items")
 
 **Purpose**
 
-Creates an item instance from a registered definition and stores it in `lia.item.instances`. Re-using an ID for the same uniqueID returns the existing instance.
+Creates a new instanced item from a registered item definition and assigns it a unique ID.
+
 
 **Parameters**
 
-* `uniqueID` (*string*): Item definition ID.
+* `uniqueID` (*string*): The unique identifier of the item definition.
+* `id` (*number*): The unique instance ID for the item.
 
-* `id` (*number*): Numeric instance ID.
 
-**Realm**
-
-`Shared`
 
 **Returns**
 
-* *table*: Newly created (or existing) item instance.
+* *table*: The new item instance.
+
+
+
+**Realm**
+
+`Shared.`
+
 
 **Example Usage**
 
 ```lua
-local item = lia.item.new("testItem", 101)
-print(item.id) -- 101
+local item = lia.item.new("weapon_ak47", 1234)
+print("Created item instance with ID:", item.id)
 ```
 
 ---
@@ -477,28 +533,32 @@ print(item.id) -- 101
 
 **Purpose**
 
-Registers an inventory type with fixed width and height.
+Registers a new inventory type with specified width and height, extending the GridInv metatable.
+
 
 **Parameters**
 
-* `invType` (*string*): Inventory type name.
+* `invType` (*string*): The unique identifier for the inventory type.
+* `w` (*number*): The width of the inventory grid.
+* `h` (*number*): The height of the inventory grid.
 
-* `w` (*number*): Width.
 
-* `h` (*number*): Height.
-
-**Realm**
-
-`Shared`
 
 **Returns**
 
-* *nil*: This function does not return a value.
+* None.
+
+
+
+**Realm**
+
+`Shared.`
+
 
 **Example Usage**
 
 ```lua
-lia.item.registerInv("smallInv", 4, 4)
+lia.item.registerInv("backpack", 4, 4)
 ```
 
 ---
@@ -507,29 +567,33 @@ lia.item.registerInv("smallInv", 4, 4)
 
 **Purpose**
 
-Asynchronously creates a new inventory of a given type for a character owner and synchronises it to them when online.
+Creates a new inventory instance of a given type for a specified owner, and calls a callback when ready.
+
 
 **Parameters**
 
-* `owner` (*number*): Character ID.
+* `owner` (*number*): The character ID of the owner.
+* `invType` (*string*): The inventory type identifier.
+* `callback` (*function*): Function to call with the created inventory (optional).
 
-* `invType` (*string*): Registered inventory type.
 
-* `callback` (*function*): Receives the new inventory. *Optional*.
-
-**Realm**
-
-`Server`
 
 **Returns**
 
-* *nil*: Uses a deferred internally.
+* None.
+
+
+
+**Realm**
+
+`Shared.`
+
 
 **Example Usage**
 
 ```lua
-lia.item.newInv(10, "smallInv", function(inv)
-    print("New inventory created:", inv.id)
+lia.item.newInv(1, "backpack", function(inv)
+print("New backpack inventory created for char 1:", inv.id)
 end)
 ```
 
@@ -539,29 +603,33 @@ end)
 
 **Purpose**
 
-Creates a `GridInv` instance with given size and ID, caching it in `lia.inventory.instances`.
+Creates a new inventory instance with specified width, height, and ID, and registers it globally.
+
 
 **Parameters**
 
-* `w` (*number*): Width.
+* `w` (*number*): The width of the inventory grid.
+* `h` (*number*): The height of the inventory grid.
+* `id` (*number*): The unique ID for the inventory instance.
 
-* `h` (*number*): Height.
 
-* `id` (*number*): Inventory ID.
-
-**Realm**
-
-`Shared`
 
 **Returns**
 
-* *table*: The created inventory.
+* *table*: The created inventory instance.
+
+
+
+**Realm**
+
+`Shared.`
+
 
 **Example Usage**
 
 ```lua
-local inv = lia.item.createInv(6, 6, 200)
-print("Inventory ID:", inv.id)
+local inv = lia.item.createInv(3, 3, 2001)
+print("Created inventory with ID:", inv.id)
 ```
 
 ---
@@ -570,28 +638,34 @@ print("Inventory ID:", inv.id)
 
 **Purpose**
 
-Overrides properties used when automatically generating weapon items from scripted weapons.
+Adds or updates a weapon override for a specific weapon class, customizing its item properties.
+
 
 **Parameters**
 
-* `className` (*string*): Weapon class.
+* `className` (*string*): The weapon class name.
+* `data` (*table*): Table of override properties (e.g., name, desc, model, etc).
 
-* `data` (*table*): Keys such as `name`, `desc`, `category`, `model`, `class`, `width`, `height`, `weaponCategory`.
 
-**Realm**
-
-`Shared`
 
 **Returns**
 
-* *nil*: This function does not return a value.
+* None.
+
+
+
+**Realm**
+
+`Shared.`
+
 
 **Example Usage**
 
 ```lua
-lia.item.addWeaponOverride("weapon_pistol", {
-    name = "Old Pistol",
-    model = "models/weapons/w_pist_deagle.mdl"
+lia.item.addWeaponOverride("weapon_custom", {
+name = "Custom Blaster",
+desc = "A unique blaster weapon.",
+model = "models/weapons/w_blaster.mdl"
 })
 ```
 
@@ -601,24 +675,30 @@ lia.item.addWeaponOverride("weapon_pistol", {
 
 **Purpose**
 
-Prevents a weapon class from being auto-generated as an item.
+Adds a weapon class to the blacklist, preventing it from being auto-generated as an item.
+
 
 **Parameters**
 
-* `className` (*string*): Weapon class.
+* `className` (*string*): The weapon class name to blacklist.
 
-**Realm**
 
-`Shared`
 
 **Returns**
 
-* *nil*: This function does not return a value.
+* None.
+
+
+
+**Realm**
+
+`Shared.`
+
 
 **Example Usage**
 
 ```lua
-lia.item.addWeaponToBlacklist("weapon_physgun")
+lia.item.addWeaponToBlacklist("weapon_physcannon")
 ```
 
 ---
@@ -627,23 +707,31 @@ lia.item.addWeaponToBlacklist("weapon_physgun")
 
 **Purpose**
 
-Registers item definitions for all scripted weapons that are not blacklisted. Called automatically after modules initialise.
+Automatically generates item definitions for all weapons found in the game's weapon list,
+except those blacklisted or with "_base" in their class name. Applies any registered overrides.
+
 
 **Parameters**
 
-* *None*
+* None.
 
-**Realm**
 
-`Shared`
 
 **Returns**
 
-* *nil*: This function does not return a value.
+* None.
+
+
+
+**Realm**
+
+`Shared.`
+
 
 **Example Usage**
 
 ```lua
+-- Generate all weapon items (usually called automatically)
 lia.item.generateWeapons()
 ```
 
@@ -653,37 +741,39 @@ lia.item.generateWeapons()
 
 **Purpose**
 
-Sets a key/value pair in an item’s `data` table by ID, optionally saving, notifying receivers, or skipping entity checks.
+Sets a specific data key-value pair for an instanced item by its ID, optionally syncing to receivers.
+
 
 **Parameters**
 
-* `itemID` (*number*): Item ID.
+* `itemID` (*number*): The unique ID of the item instance.
+* `key` (*string*): The data key to set.
+* `value` (*any*): The value to assign.
+* `receivers` (*table*): List of players to sync to (optional).
+* `noSave` (*bool*): If true, do not save to database (optional).
+* `noCheckEntity` (*bool*): If true, skip entity checks (optional).
 
-* `key` (*string*): Data key.
 
-* `value` (*any*): New value.
-
-* `receivers` (*table*): Player list to receive update. *Optional*.
-
-* `noSave` (*boolean*): Do not immediately save when `true`.
-
-* `noCheckEntity` (*boolean*): Skip entity validity check.
-
-**Realm**
-
-`Server`
 
 **Returns**
 
-* *boolean*: `true` on success, `false` otherwise.
-* `string | nil`: Error message when unsuccessful.
+* *boolean, string*: True on success, or false and an error message.
+
+
+
+**Realm**
+
+`Server.`
+
 
 **Example Usage**
 
 ```lua
-local ok, err = lia.item.setItemDataByID(50, "durability", 90)
-if not ok then
-    print("Error:", err)
+local success, err = lia.item.setItemDataByID(1234, "durability", 80)
+if success then
+print("Durability updated!")
+else
+print("Error:", err)
 end
 ```
 
@@ -693,35 +783,36 @@ end
 
 **Purpose**
 
-Creates a new item in the database (optionally assigning it to an inventory) and returns it via a deferred.
+Creates a new item instance in the database and in memory, optionally calling a callback when ready.
+
 
 **Parameters**
 
-* `index` (*number | string*): Inventory ID or uniqueID if uniqueID omitted.
+* `index` (*number|string*): Inventory ID or uniqueID (see usage).
+* `uniqueID` (*string*): The unique identifier of the item definition.
+* `itemData` (*table*): Table of item data (optional).
+* `x` (*number*): X position in inventory (optional).
+* `y` (*number*): Y position in inventory (optional).
+* `callback` (*function*): Function to call with the created item (optional).
 
-* `uniqueID` (*string*): Item uniqueID when `index` is invID.
 
-* `itemData` (*table*): Data to store. *Optional*.
-
-* `x` (*number*): Grid X. *Optional*.
-
-* `y` (*number*): Grid Y. *Optional*.
-
-* `callback` (*function*): Receives the item. *Optional*.
-
-**Realm**
-
-`Server`
 
 **Returns**
 
-* *deferred*: Resolves to the new item.
+* *deferred*: A deferred object that resolves to the created item.
+
+
+
+**Realm**
+
+`Server.`
+
 
 **Example Usage**
 
 ```lua
-lia.item.instance("testItem", { quality = 1 }):next(function(item)
-    print("Item created:", item.id)
+lia.item.instance(0, "weapon_ak47", {durability = 100}, 1, 1, function(item)
+print("Spawned AK47 item with ID:", item.id)
 end)
 ```
 
@@ -731,24 +822,30 @@ end)
 
 **Purpose**
 
-Deletes an item from memory and the database.
+Deletes an item instance by its ID, removing it from memory and the database.
+
 
 **Parameters**
 
-* `id` (*number*): Item ID.
+* `id` (*number*): The unique ID of the item instance.
 
-**Realm**
 
-`Server`
 
 **Returns**
 
-* *nil*: This function does not return a value.
+* None.
+
+
+
+**Realm**
+
+`Server.`
+
 
 **Example Usage**
 
 ```lua
-lia.item.deleteByID(42)
+lia.item.deleteByID(1234)
 ```
 
 ---
@@ -757,24 +854,30 @@ lia.item.deleteByID(42)
 
 **Purpose**
 
-Loads one or multiple items from the database by ID and builds instances in memory.
+Loads one or more item instances from the database by their IDs and restores them in memory.
+
 
 **Parameters**
 
-* `itemIndex` (*number | table*): Single ID or table of IDs.
+* `itemIndex` (*number|table*): A single item ID or a table of item IDs.
 
-**Realm**
 
-`Server`
 
 **Returns**
 
-* *nil*: Runs asynchronously.
+* None.
+
+
+
+**Realm**
+
+`Server.`
+
 
 **Example Usage**
 
 ```lua
-lia.item.loadItemByID({ 10, 11, 12 })
+lia.item.loadItemByID({1001, 1002, 1003})
 ```
 
 ---
@@ -783,33 +886,35 @@ lia.item.loadItemByID({ 10, 11, 12 })
 
 **Purpose**
 
-Creates a new item instance and spawns a matching entity at a position/angle in the world.
+Spawns a new item instance in the world at a given position and angle, optionally calling a callback.
+
 
 **Parameters**
 
-* `uniqueID` (*string*): Item definition ID.
+* `uniqueID` (*string*): The unique identifier of the item definition.
+* `position` (*Vector*): The world position to spawn the item at.
+* `callback` (*function*): Function to call with the spawned item (optional).
+* `angles` (*Angle*): The angles to spawn the item with (optional).
+* `data` (*table*): Table of item data (optional).
 
-* `position` (*Vector*): World position.
 
-* `callback` (*function*): Receives the spawned item. *Optional*.
-
-* `angles` (*Angle*): Spawn angles. *Optional*.
-
-* `data` (*table*): Additional item data. *Optional*.
-
-**Realm**
-
-`Server`
 
 **Returns**
 
-* *deferred | nil*: Deferred when no callback, else `nil`.
+* *deferred*: A deferred object that resolves to the spawned item.
+
+
+
+**Realm**
+
+`Server.`
+
 
 **Example Usage**
 
 ```lua
-lia.item.spawn("testItem", vector_origin, function(item)
-    print("Spawned", item.uniqueID, "at", item.entity:GetPos())
+lia.item.spawn("weapon_ak47", Vector(0,0,0), function(item)
+print("Spawned AK47 at origin with ID:", item.id)
 end)
 ```
 
@@ -819,31 +924,34 @@ end)
 
 **Purpose**
 
-Loads an inventory by ID, sets its dimensions, and optionally triggers a callback.
+Restores an inventory by its ID, setting its width and height, and calls a callback when ready.
+
 
 **Parameters**
 
-* `invID` (*number*): Inventory ID.
+* `invID` (*number*): The unique ID of the inventory.
+* `w` (*number*): The width to set.
+* `h` (*number*): The height to set.
+* `callback` (*function*): Function to call with the restored inventory (optional).
 
-* `w` (*number*): Width.
 
-* `h` (*number*): Height.
-
-* `callback` (*function*): Called once loaded. *Optional*.
-
-**Realm**
-
-`Server`
 
 **Returns**
 
-* *nil*: Runs asynchronously.
+* None.
+
+
+
+**Realm**
+
+`Server.`
+
 
 **Example Usage**
 
 ```lua
-lia.item.restoreInv(101, 5, 5, function(inv)
-    print("Restored inventory 101")
+lia.item.restoreInv(1001, 4, 4, function(inv)
+print("Restored inventory with size:", inv:getSize())
 end)
 ```
 

--- a/gamemode/core/libraries/item.lua
+++ b/gamemode/core/libraries/item.lua
@@ -1,4 +1,4 @@
-﻿lia.item = lia.item or {}
+lia.item = lia.item or {}
 lia.item.base = lia.item.base or {}
 lia.item.list = lia.item.list or {}
 lia.item.instances = lia.item.instances or {}
@@ -177,54 +177,9 @@ local DefaultFunctions = {
 
 lia.meta.item.width = 1
 lia.meta.item.height = 1
---[[
-    lia.item.get
-
-    Purpose:
-        Retrieves an item definition table by its identifier, searching both base and regular item lists.
-
-    Parameters:
-        identifier (string) - The unique identifier of the item.
-
-    Returns:
-        table or nil - The item definition table if found, otherwise none.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local itemDef = lia.item.get("weapon_ak47")
-        if itemDef then
-            print("AK47 item found:", itemDef.name)
-        end
-]]
 function lia.item.get(identifier)
     return lia.item.base[identifier] or lia.item.list[identifier]
 end
-
---[[
-    lia.item.getItemByID
-
-    Purpose:
-        Retrieves an instanced item by its unique item ID, along with its location (inventory or world).
-
-    Parameters:
-        itemID (number) - The unique ID of the item instance.
-
-    Returns:
-        table or nil, string - Table containing the item and its location, or nil and an error message.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local result, err = lia.item.getItemByID(1234)
-        if result then
-            print("Item found in location:", result.location)
-        else
-            print("Error:", err)
-        end
-]]
 function lia.item.getItemByID(itemID)
     assert(isnumber(itemID), L("itemIDNumberRequired"))
     local item = lia.item.instances[itemID]
@@ -241,87 +196,18 @@ function lia.item.getItemByID(itemID)
         location = location
     }
 end
-
---[[
-    lia.item.getInstancedItemByID
-
-    Purpose:
-        Retrieves an instanced item object by its unique item ID.
-
-    Parameters:
-        itemID (number) - The unique ID of the item instance.
-
-    Returns:
-        table or nil, string - The item instance table if found, or nil and an error message.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local item, err = lia.item.getInstancedItemByID(5678)
-        if item then
-            print("Item name:", item.name)
-        else
-            print("Error:", err)
-        end
-]]
 function lia.item.getInstancedItemByID(itemID)
     assert(isnumber(itemID), L("itemIDNumberRequired"))
     local item = lia.item.instances[itemID]
     if not item then return nil, L("itemNotFound") end
     return item
 end
-
---[[
-    lia.item.getItemDataByID
-
-    Purpose:
-        Retrieves the data table of an instanced item by its unique item ID.
-
-    Parameters:
-        itemID (number) - The unique ID of the item instance.
-
-    Returns:
-        table or nil, string - The data table of the item if found, or nil and an error message.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local data, err = lia.item.getItemDataByID(4321)
-        if data then
-            PrintTable(data)
-        else
-            print("Error:", err)
-        end
-]]
 function lia.item.getItemDataByID(itemID)
     assert(isnumber(itemID), L("itemIDNumberRequired"))
     local item = lia.item.instances[itemID]
     if not item then return nil, L("itemNotFound") end
     return item.data
 end
-
---[[
-    lia.item.load
-
-    Purpose:
-        Loads an item definition file and registers it as a base or regular item, depending on parameters.
-
-    Parameters:
-        path (string)      - The file path to the item definition.
-        baseID (string)    - The base item ID to inherit from (optional).
-        isBaseItem (bool)  - Whether this is a base item definition (optional).
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        lia.item.load("lilia/gamemode/items/weapons/sh_ak47.lua", "base_weapons")
-]]
 function lia.item.load(path, baseID, isBaseItem)
     local uniqueID = path:match("sh_([_%w]+)%.lua") or path:match("([_%w]+)%.lua")
     if uniqueID then
@@ -334,79 +220,12 @@ function lia.item.load(path, baseID, isBaseItem)
         lia.error("[Lilia] " .. L("invalidItemNaming", path) .. "\n")
     end
 end
-
---[[
-    lia.item.isItem
-
-    Purpose:
-        Checks if the given object is an item instance.
-
-    Parameters:
-        object (any) - The object to check.
-
-    Returns:
-        boolean - True if the object is an item, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if lia.item.isItem(myItem) then
-            print("This is a valid item instance.")
-        end
-]]
 function lia.item.isItem(object)
     return istable(object) and object.isItem
 end
-
---[[
-    lia.item.getInv
-
-    Purpose:
-        Retrieves an inventory instance by its ID.
-
-    Parameters:
-        invID (number) - The unique ID of the inventory.
-
-    Returns:
-        table or nil - The inventory instance if found, otherwise none.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local inv = lia.item.getInv(1001)
-        if inv then
-            print("Inventory found with size:", inv:getSize())
-        end
-]]
 function lia.item.getInv(invID)
     return lia.inventory.instances[invID]
 end
-
---[[
-    lia.item.register
-
-    Purpose:
-        Registers a new item definition, either as a base or regular item, and sets up its metatable and properties.
-
-    Parameters:
-        uniqueID (string)     - The unique identifier for the item.
-        baseID (string)       - The base item ID to inherit from (optional).
-        isBaseItem (bool)     - Whether this is a base item (optional).
-        path (string)         - The file path to the item definition (optional).
-        luaGenerated (bool)   - If true, the item is generated in Lua and not loaded from file (optional).
-
-    Returns:
-        table - The registered item definition.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local myItem = lia.item.register("custom_pistol", "base_weapons", false, "lilia/gamemode/items/weapons/sh_custom_pistol.lua")
-        print("Registered item:", myItem.uniqueID)
-]]
 function lia.item.register(uniqueID, baseID, isBaseItem, path, luaGenerated)
     assert(isstring(uniqueID), L("itemUniqueIDString"))
     local baseTable = lia.item.base[baseID] or lia.meta.item
@@ -472,27 +291,6 @@ function lia.item.register(uniqueID, baseID, isBaseItem, path, luaGenerated)
     ITEM = nil
     return targetTable[itemType]
 end
-
---[[
-    lia.item.loadFromDir
-
-    Purpose:
-        Loads all item definition files from the specified directory, including base items and category folders.
-        Registers each item using lia.item.load and triggers the "InitializedItems" hook after loading.
-
-    Parameters:
-        directory (string) - The directory path to search for item files (should be relative to the gamemode).
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Load all items from the "lilia/gamemode/items" directory
-        lia.item.loadFromDir("lilia/gamemode/items")
-]]
 function lia.item.loadFromDir(directory)
     local files, folders
     files = file.Find(directory .. "/base/*.lua", "LUA")
@@ -514,27 +312,6 @@ function lia.item.loadFromDir(directory)
 
     hook.Run("InitializedItems")
 end
-
---[[
-    lia.item.new
-
-    Purpose:
-        Creates a new instanced item from a registered item definition and assigns it a unique ID.
-
-    Parameters:
-        uniqueID (string) - The unique identifier of the item definition.
-        id (number)       - The unique instance ID for the item.
-
-    Returns:
-        table - The new item instance.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local item = lia.item.new("weapon_ak47", 1234)
-        print("Created item instance with ID:", item.id)
-]]
 function lia.item.new(uniqueID, id)
     id = id and tonumber(id) or id
     assert(isnumber(id), L("itemNonNumberID"))
@@ -556,27 +333,6 @@ function lia.item.new(uniqueID, id)
         error("[Lilia] " .. L("unknownItem", tostring(uniqueID)) .. "\n")
     end
 end
-
---[[
-    lia.item.registerInv
-
-    Purpose:
-        Registers a new inventory type with specified width and height, extending the GridInv metatable.
-
-    Parameters:
-        invType (string) - The unique identifier for the inventory type.
-        w (number)       - The width of the inventory grid.
-        h (number)       - The height of the inventory grid.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        lia.item.registerInv("backpack", 4, 4)
-]]
 function lia.item.registerInv(invType, w, h)
     local GridInv = FindMetaTable("GridInv")
     assert(GridInv, L("gridInvNotFound"))
@@ -592,29 +348,6 @@ function lia.item.registerInv(invType, w, h)
 
     inventory:register(invType)
 end
-
---[[
-    lia.item.newInv
-
-    Purpose:
-        Creates a new inventory instance of a given type for a specified owner, and calls a callback when ready.
-
-    Parameters:
-        owner (number)         - The character ID of the owner.
-        invType (string)       - The inventory type identifier.
-        callback (function)    - Function to call with the created inventory (optional).
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        lia.item.newInv(1, "backpack", function(inv)
-            print("New backpack inventory created for char 1:", inv.id)
-        end)
-]]
 function lia.item.newInv(owner, invType, callback)
     lia.inventory.instance(invType, {
         char = owner
@@ -632,28 +365,6 @@ function lia.item.newInv(owner, invType, callback)
         if callback then callback(inventory) end
     end)
 end
-
---[[
-    lia.item.createInv
-
-    Purpose:
-        Creates a new inventory instance with specified width, height, and ID, and registers it globally.
-
-    Parameters:
-        w (number)   - The width of the inventory grid.
-        h (number)   - The height of the inventory grid.
-        id (number)  - The unique ID for the inventory instance.
-
-    Returns:
-        table - The created inventory instance.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local inv = lia.item.createInv(3, 3, 2001)
-        print("Created inventory with ID:", inv.id)
-]]
 function lia.item.createInv(w, h, id)
     local GridInv = FindMetaTable("GridInv")
     assert(GridInv, L("gridInvNotFound"))
@@ -748,76 +459,12 @@ lia.item.holdTypeSizeMapping = {
         height = 1
     }
 }
-
---[[
-    lia.item.addWeaponOverride
-
-    Purpose:
-        Adds or updates a weapon override for a specific weapon class, customizing its item properties.
-
-    Parameters:
-        className (string) - The weapon class name.
-        data (table)       - Table of override properties (e.g., name, desc, model, etc).
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        lia.item.addWeaponOverride("weapon_custom", {
-            name = "Custom Blaster",
-            desc = "A unique blaster weapon.",
-            model = "models/weapons/w_blaster.mdl"
-        })
-]]
 function lia.item.addWeaponOverride(className, data)
     lia.item.WeaponOverrides[className] = data
 end
-
---[[
-    lia.item.addWeaponToBlacklist
-
-    Purpose:
-        Adds a weapon class to the blacklist, preventing it from being auto-generated as an item.
-
-    Parameters:
-        className (string) - The weapon class name to blacklist.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        lia.item.addWeaponToBlacklist("weapon_physcannon")
-]]
 function lia.item.addWeaponToBlacklist(className)
     lia.item.WeaponsBlackList[className] = true
 end
-
---[[
-    lia.item.generateWeapons
-
-    Purpose:
-        Automatically generates item definitions for all weapons found in the game's weapon list,
-        except those blacklisted or with "_base" in their class name. Applies any registered overrides.
-
-    Parameters:
-        None.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Generate all weapon items (usually called automatically)
-        lia.item.generateWeapons()
-]]
 function lia.item.generateWeapons()
     for _, wep in ipairs(weapons.GetList()) do
         local className = wep.ClassName
@@ -844,34 +491,6 @@ function lia.item.generateWeapons()
 end
 
 if SERVER then
-    --[[
-        lia.item.setItemDataByID
-
-        Purpose:
-            Sets a specific data key-value pair for an instanced item by its ID, optionally syncing to receivers.
-
-        Parameters:
-            itemID (number)      - The unique ID of the item instance.
-            key (string)         - The data key to set.
-            value (any)          - The value to assign.
-            receivers (table)    - List of players to sync to (optional).
-            noSave (bool)        - If true, do not save to database (optional).
-            noCheckEntity (bool) - If true, skip entity checks (optional).
-
-        Returns:
-            boolean, string - True on success, or false and an error message.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            local success, err = lia.item.setItemDataByID(1234, "durability", 80)
-            if success then
-                print("Durability updated!")
-            else
-                print("Error:", err)
-            end
-    ]]
     function lia.item.setItemDataByID(itemID, key, value, receivers, noSave, noCheckEntity)
         assert(isnumber(itemID), L("itemIDNumberRequired"))
         assert(isstring(key), L("itemKeyString"))
@@ -880,32 +499,6 @@ if SERVER then
         item:setData(key, value, receivers, noSave, noCheckEntity)
         return true
     end
-
-    --[[
-        lia.item.instance
-
-        Purpose:
-            Creates a new item instance in the database and in memory, optionally calling a callback when ready.
-
-        Parameters:
-            index (number|string)   - Inventory ID or uniqueID (see usage).
-            uniqueID (string)       - The unique identifier of the item definition.
-            itemData (table)        - Table of item data (optional).
-            x (number)              - X position in inventory (optional).
-            y (number)              - Y position in inventory (optional).
-            callback (function)     - Function to call with the created item (optional).
-
-        Returns:
-            deferred - A deferred object that resolves to the created item.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            lia.item.instance(0, "weapon_ak47", {durability = 100}, 1, 1, function(item)
-                print("Spawned AK47 item with ID:", item.id)
-            end)
-    ]]
     function lia.item.instance(index, uniqueID, itemData, x, y, callback)
         if isstring(index) and (istable(uniqueID) or itemData == nil and x == nil) then
             itemData = uniqueID
@@ -959,25 +552,6 @@ if SERVER then
         end
         return d
     end
-
-    --[[
-        lia.item.deleteByID
-
-        Purpose:
-            Deletes an item instance by its ID, removing it from memory and the database.
-
-        Parameters:
-            id (number) - The unique ID of the item instance.
-
-        Returns:
-            None.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            lia.item.deleteByID(1234)
-    ]]
     function lia.item.deleteByID(id)
         if lia.item.instances[id] then
             lia.item.instances[id]:delete()
@@ -985,25 +559,6 @@ if SERVER then
             lia.db.delete("items", "_itemID = " .. id)
         end
     end
-
-    --[[
-        lia.item.loadItemByID
-
-        Purpose:
-            Loads one or more item instances from the database by their IDs and restores them in memory.
-
-        Parameters:
-            itemIndex (number|table) - A single item ID or a table of item IDs.
-
-        Returns:
-            None.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            lia.item.loadItemByID({1001, 1002, 1003})
-    ]]
     function lia.item.loadItemByID(itemIndex)
         local range
         if istable(itemIndex) then
@@ -1032,31 +587,6 @@ if SERVER then
             end
         end)
     end
-
-    --[[
-        lia.item.spawn
-
-        Purpose:
-            Spawns a new item instance in the world at a given position and angle, optionally calling a callback.
-
-        Parameters:
-            uniqueID (string)      - The unique identifier of the item definition.
-            position (Vector)      - The world position to spawn the item at.
-            callback (function)    - Function to call with the spawned item (optional).
-            angles (Angle)         - The angles to spawn the item with (optional).
-            data (table)           - Table of item data (optional).
-
-        Returns:
-            deferred - A deferred object that resolves to the spawned item.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            lia.item.spawn("weapon_ak47", Vector(0,0,0), function(item)
-                print("Spawned AK47 at origin with ID:", item.id)
-            end)
-    ]]
     function lia.item.spawn(uniqueID, position, callback, angles, data)
         local d
         if not isfunction(callback) then
@@ -1075,30 +605,6 @@ if SERVER then
         end)
         return d
     end
-
-    --[[
-        lia.item.restoreInv
-
-        Purpose:
-            Restores an inventory by its ID, setting its width and height, and calls a callback when ready.
-
-        Parameters:
-            invID (number)      - The unique ID of the inventory.
-            w (number)          - The width to set.
-            h (number)          - The height to set.
-            callback (function) - Function to call with the restored inventory (optional).
-
-        Returns:
-            None.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            lia.item.restoreInv(1001, 4, 4, function(inv)
-                print("Restored inventory with size:", inv:getSize())
-            end)
-    ]]
     function lia.item.restoreInv(invID, w, h, callback)
         lia.inventory.loadByID(invID):next(function(inventory)
             if not inventory then return end


### PR DESCRIPTION
## Summary
- migrate item library comment blocks into `lia.item` documentation
- strip inline documentation from `item.lua`

## Testing
- `luacheck gamemode/core/libraries/item.lua` *(fails: expected '=' near 'end')*
- `cd documentation && mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68988c1009388327b7240d4f150facd9