### PR TITLE
docs: sync entity docs and remove inline comments

### DIFF
--- a/documentation/docs/meta/entity.md
+++ b/documentation/docs/meta/entity.md
@@ -4,13 +4,6 @@ Entities in Garry's Mod may represent props, items, and interactive objects.
 
 This reference describes utility functions added to entity metatables for easier classification and management.
 
----
-
-## Overview
-
-The entity-meta library extends Garry's Mod entities with helpers for detection, door access, persistence, and networked variables.
-Using these functions ensures consistent behavior when handling game objects across Lilia.
-
 > **Note**
 > Every helper verifies that the entity is valid before proceeding. If the entity is invalid, the function returns a default value or performs no action.
 
@@ -19,26 +12,21 @@ Using these functions ensures consistent behavior when handling game objects acr
 ### isProp
 
 **Purpose**
-
 Checks if the entity is a physics prop.
 
 **Parameters**
-
-* None
+- None
 
 **Returns**
-
-* `boolean`: `true` when the entity's class is `prop_physics`.
+- boolean - True if the entity is a physics prop, false otherwise.
 
 **Realm**
-
-`Shared`
+Shared.
 
 **Example Usage**
-
 ```lua
-if ent:isProp() then
-    ent:TakeDamage(50)
+if entity:isProp() then
+print("This is a prop!")
 end
 ```
 
@@ -47,26 +35,21 @@ end
 ### isItem
 
 **Purpose**
-
-Checks if the entity is an item entity (`lia_item`).
+Checks if the entity is an item entity.
 
 **Parameters**
-
-* None
+- None
 
 **Returns**
-
-* `boolean`: `true` if the entity represents an item.
+- boolean - True if the entity is an item, false otherwise.
 
 **Realm**
-
-`Shared`
+Shared.
 
 **Example Usage**
-
 ```lua
-if ent:isItem() then
-    lia.item.pickup(client, ent)
+if entity:isItem() then
+print("This is an item!")
 end
 ```
 
@@ -75,26 +58,21 @@ end
 ### isMoney
 
 **Purpose**
-
-Checks if the entity is a money entity (`lia_money`).
+Checks if the entity is a money entity.
 
 **Parameters**
-
-* None
+- None
 
 **Returns**
-
-* `boolean`: `true` if the entity represents money.
+- boolean - True if the entity is money, false otherwise.
 
 **Realm**
-
-`Shared`
+Shared.
 
 **Example Usage**
-
 ```lua
-if ent:isMoney() then
-    char:addMoney(ent:getAmount())
+if entity:isMoney() then
+print("This is money!")
 end
 ```
 
@@ -103,26 +81,21 @@ end
 ### isSimfphysCar
 
 **Purpose**
-
-Determines whether this entity is a simfphys or LVS vehicle.
+Checks if the entity is a simfphys or LVS vehicle.
 
 **Parameters**
-
-* None
+- None
 
 **Returns**
-
-* `boolean`: `true` if the entity's class or base matches known simfphys classes or it contains the `IsSimfphyscar`/`LVS` flag.
+- boolean - True if the entity is a simfphys or LVS vehicle, false otherwise.
 
 **Realm**
-
-`Shared`
+Shared.
 
 **Example Usage**
-
 ```lua
-if ent:isSimfphysCar() then
-    print("Simfphys vehicle detected")
+if entity:isSimfphysCar() then
+print("This is a simfphys/LVS car!")
 end
 ```
 
@@ -131,26 +104,21 @@ end
 ### isLiliaPersistent
 
 **Purpose**
-
-Checks if the entity should persist across sessions in Lilia.
+Checks if the entity is persistent in the Lilia framework.
 
 **Parameters**
-
-* None
+- None
 
 **Returns**
-
-* `boolean`: `true` if `GetPersistent()` returns `true` or the entity has `IsLeonNPC` or `IsPersistent` flags.
+- boolean - True if the entity is persistent, false otherwise.
 
 **Realm**
-
-`Shared`
+Shared.
 
 **Example Usage**
-
 ```lua
-if ent:isLiliaPersistent() then
-    -- Entity will be saved between map resets
+if entity:isLiliaPersistent() then
+print("This entity is persistent!")
 end
 ```
 
@@ -159,27 +127,22 @@ end
 ### checkDoorAccess
 
 **Purpose**
-
-Checks whether `client` has at least the given access level on the door. The hook `CanPlayerAccessDoor` is consulted first, then the door's `liaAccess` table.
+Checks if the given client has the specified access level to the door entity.
 
 **Parameters**
-
-* `client` (`Player`): Player to check.
-* `access` (`number`, optional): Access level to test, defaults to `DOOR_GUEST`.
+- client (Player) - The player to check access for.
+- access (number) - The access level to check (optional, defaults to DOOR_GUEST).
 
 **Returns**
-
-* `boolean`: `true` if the player may access the door.
+- boolean - True if the client has access, false otherwise.
 
 **Realm**
-
-`Shared`
+Shared.
 
 **Example Usage**
-
 ```lua
-if not door:checkDoorAccess(client, DOOR_GUEST) then
-    client:notifyLocalized("doorLocked")
+if door:checkDoorAccess(client, DOOR_OWNER) then
+print("Client can access the door!")
 end
 ```
 
@@ -188,25 +151,17 @@ end
 ### keysOwn
 
 **Purpose**
-
-If the entity is a vehicle, assigns ownership to the provided player using CPPI and sets the `owner` and `ownerName` network variables.
+Assigns ownership of the vehicle entity to the given client.
 
 **Parameters**
-
-* `client` (`Player`): New owner.
-
-**Returns**
-
-* `nil`: This function does not return a value.
+- client (Player) - The player to set as the owner.
 
 **Realm**
-
-`Shared`
+Shared.
 
 **Example Usage**
-
 ```lua
-car:keysOwn(client)
+vehicle:keysOwn(client)
 ```
 
 ---
@@ -214,25 +169,17 @@ car:keysOwn(client)
 ### keysLock
 
 **Purpose**
-
-If the entity is a vehicle, locks it by firing the `lock` input.
+Locks the vehicle entity.
 
 **Parameters**
-
-* None
-
-**Returns**
-
-* `nil`: This function does not return a value.
+- None
 
 **Realm**
-
-`Shared`
+Shared.
 
 **Example Usage**
-
 ```lua
-car:keysLock()
+vehicle:keysLock()
 ```
 
 ---
@@ -240,25 +187,17 @@ car:keysLock()
 ### keysUnLock
 
 **Purpose**
-
-If the entity is a vehicle, unlocks it by firing the `unlock` input.
+Unlocks the vehicle entity.
 
 **Parameters**
-
-* None
-
-**Returns**
-
-* `nil`: This function does not return a value.
+- None
 
 **Realm**
-
-`Shared`
+Shared.
 
 **Example Usage**
-
 ```lua
-car:keysUnLock()
+vehicle:keysUnLock()
 ```
 
 ---
@@ -266,28 +205,21 @@ car:keysUnLock()
 ### getDoorOwner
 
 **Purpose**
-
-Returns the result of `CPPIGetOwner()` when the entity is a vehicle that supports CPPI.
+Returns the owner of the vehicle entity if available.
 
 **Parameters**
-
-* None
+- None
 
 **Returns**
-
-* `Player|nil`: The owner of the vehicle, or `nil` if unavailable.
+- Player or nil - The owner of the vehicle, or nil if not available.
 
 **Realm**
-
-`Shared`
+Shared.
 
 **Example Usage**
-
 ```lua
-local owner = car:getDoorOwner()
-if owner then
-    print("Owned by", owner:Name())
-end
+local owner = vehicle:getDoorOwner()
+if owner then print("Owner found!") end
 ```
 
 ---
@@ -295,26 +227,21 @@ end
 ### isLocked
 
 **Purpose**
-
-Checks the `locked` network variable and returns its boolean state.
+Checks if the entity is locked according to its networked variable.
 
 **Parameters**
-
-* None
+- None
 
 **Returns**
-
-* `boolean`: `true` if the entity is locked.
+- boolean - True if locked, false otherwise.
 
 **Realm**
-
-`Shared`
+Shared.
 
 **Example Usage**
-
 ```lua
-if door:isLocked() then
-    DrawLockedIcon(door)
+if entity:isLocked() then
+print("Entity is locked!")
 end
 ```
 
@@ -323,26 +250,21 @@ end
 ### isDoorLocked
 
 **Purpose**
-
-Checks `GetInternalVariable("m_bLocked")` or the fallback `locked` field for door entities.
+Checks if the door entity is locked according to its internal variable or fallback.
 
 **Parameters**
-
-* None
+- None
 
 **Returns**
-
-* `boolean`: `true` if the door reports itself as locked.
+- boolean - True if locked, false otherwise.
 
 **Realm**
-
-`Shared`
+Shared.
 
 **Example Usage**
-
 ```lua
 if door:isDoorLocked() then
-    door:EmitSound("doors/door_locked2.wav")
+print("Door is locked!")
 end
 ```
 
@@ -351,26 +273,20 @@ end
 ### getEntItemDropPos
 
 **Purpose**
-
-Calculates a safe drop position in front of the entity's eyes.
+Calculates the position and angle where an item should be dropped from the entity.
 
 **Parameters**
-
-* `offset` (`number`, optional): Distance to trace forward. Defaults to `64` units.
+- offset (number) - The distance from the entity to drop the item (optional, defaults to 64).
 
 **Returns**
-
-* `Vector`, `Angle`: The drop position and surface normal angle. Returns `(0, 0, 0)` and `Angle(0, 0, 0)` if the entity is invalid.
+- Vector, Angle - The position and angle for item drop.
 
 **Realm**
-
-`Shared`
+Shared.
 
 **Example Usage**
-
 ```lua
-local pos, ang = ent:getEntItemDropPos(16)
-lia.item.spawn("item_water", pos, ang)
+local pos, ang = entity:getEntItemDropPos(128)
 ```
 
 ---
@@ -378,27 +294,22 @@ lia.item.spawn("item_water", pos, ang)
 ### isNearEntity
 
 **Purpose**
-
-Checks for another entity within a radius. If `otherEntity` is supplied, only that entity will satisfy the check; otherwise any entity of the same class will.
+Checks if another entity is within a certain radius of this entity.
 
 **Parameters**
-
-* `radius` (`number`, optional): Search radius in units. Defaults to `96`.
-* `otherEntity` (`Entity`, optional): Specific entity to look for.
+- radius (number) - The radius to check within (optional, defaults to 96).
+- otherEntity (Entity) - The entity to check proximity to.
 
 **Returns**
-
-* `boolean`: `true` if a matching entity is nearby. Always `true` when `otherEntity` is the entity itself.
+- boolean - True if the other entity is near, false otherwise.
 
 **Realm**
-
-`Shared`
+Shared.
 
 **Example Usage**
-
 ```lua
-if ent:isNearEntity(128, otherChest) then
-    client:notifyLocalized("chestTooClose")
+if entity:isNearEntity(128, otherEntity) then
+print("Other entity is nearby!")
 end
 ```
 
@@ -407,28 +318,21 @@ end
 ### GetCreator
 
 **Purpose**
-
-Returns the player stored in the `creator` network variable.
+Returns the creator of the entity from its networked variable.
 
 **Parameters**
-
-* None
+- None
 
 **Returns**
-
-* `Player|nil`: Creator player if stored.
+- Player or nil - The creator of the entity, or nil if not set.
 
 **Realm**
-
-`Shared`
+Shared.
 
 **Example Usage**
-
 ```lua
-local creator = ent:GetCreator()
-if IsValid(creator) then
-    creator:notifyLocalized("propRemoved")
-end
+local creator = entity:GetCreator()
+if creator then print("Creator found!") end
 ```
 
 ---
@@ -436,25 +340,17 @@ end
 ### SetCreator
 
 **Purpose**
-
-Stores the creator player in the entity's `creator` network variable for later retrieval.
+Sets the creator of the entity in its networked variable.
 
 **Parameters**
-
-* `client` (`Player`): Creator of the entity.
-
-**Returns**
-
-* `nil`: This function does not return a value.
+- client (Player) - The player to set as the creator.
 
 **Realm**
-
-`Server`
+Server.
 
 **Example Usage**
-
 ```lua
-ent:SetCreator(client)
+entity:SetCreator(client)
 ```
 
 ---
@@ -462,26 +358,18 @@ ent:SetCreator(client)
 ### sendNetVar
 
 **Purpose**
-
-Serializes the value stored in `lia.net[self][key]` and sends it to a specific player or broadcasts it to all clients.
+Sends a networked variable to a specific receiver or broadcasts it.
 
 **Parameters**
-
-* `key` (`string`): Identifier of the variable.
-* `receiver` (`Player|nil`, optional): Player to send to. Broadcasts if omitted.
-
-**Returns**
-
-* `nil`: This function does not return a value.
+- key (string) - The key of the variable to send.
+- receiver (Player) - The player to send the variable to (optional).
 
 **Realm**
-
-`Server`
+Server.
 
 **Example Usage**
-
 ```lua
-ent:sendNetVar("doorState")
+entity:sendNetVar("locked", client)
 ```
 
 ---
@@ -489,25 +377,17 @@ ent:sendNetVar("doorState")
 ### clearNetVars
 
 **Purpose**
-
-Removes all entries from `lia.net[self]` and sends an `nDel` message to clients to clear their copies.
+Clears all networked variables for the entity and notifies clients.
 
 **Parameters**
-
-* `receiver` (`Player|nil`, optional): Receiver to notify. Broadcasts if omitted.
-
-**Returns**
-
-* `nil`: This function does not return a value.
+- receiver (Player) - The player to send the clear notification to (optional).
 
 **Realm**
-
-`Server`
+Server.
 
 **Example Usage**
-
 ```lua
-ent:clearNetVars(client)
+entity:clearNetVars(client)
 ```
 
 ---
@@ -515,25 +395,17 @@ ent:clearNetVars(client)
 ### removeDoorAccessData
 
 **Purpose**
-
-Clears the door's access data, notifies each affected player, and resets `liaAccess` and `DTEntity(0)`.
+Removes all door access data for the entity and notifies clients.
 
 **Parameters**
-
-* None
-
-**Returns**
-
-* `nil`: This function does not return a value.
+- None
 
 **Realm**
-
-`Server`
+Server.
 
 **Example Usage**
-
 ```lua
-ent:removeDoorAccessData()
+door:removeDoorAccessData()
 ```
 
 ---
@@ -541,25 +413,17 @@ ent:removeDoorAccessData()
 ### setLocked
 
 **Purpose**
-
-Sets the networked `locked` state of the entity using `setNetVar`.
+Sets the locked state of the entity.
 
 **Parameters**
-
-* `state` (`boolean`): New locked state.
-
-**Returns**
-
-* `nil`: This function does not return a value.
+- state (boolean) - The locked state to set.
 
 **Realm**
-
-`Server`
+Server.
 
 **Example Usage**
-
 ```lua
-door:setLocked(true)
+entity:setLocked(true)
 ```
 
 ---
@@ -567,82 +431,62 @@ door:setLocked(true)
 ### setKeysNonOwnable
 
 **Purpose**
-
-Marks the entity as non-ownable by setting the `noSell` network variable, preventing players from purchasing it.
+Sets whether the entity is non-ownable.
 
 **Parameters**
-
-* `state` (`boolean`): Whether the entity should be non-ownable.
-
-**Returns**
-
-* `nil`: This function does not return a value.
+- state (boolean) - The non-ownable state to set.
 
 **Realm**
-
-`Server`
+Server.
 
 **Example Usage**
-
 ```lua
-ent:setKeysNonOwnable(true)
+entity:setKeysNonOwnable(true)
 ```
 
 ---
 
-### isDoor *(Server)*
+### isDoor
 
 **Purpose**
-
-Checks if the entity's class name begins with one of the prefixes `prop_door`, `func_door`, `func_door_rotating`, or `door_`.
+Checks if the entity is a door.
 
 **Parameters**
-
-* None
+- None
 
 **Returns**
-
-* `boolean`: `true` if the entity is recognized as a door.
+- boolean - True if the entity is a door, false otherwise.
 
 **Realm**
-
-`Server`
+Server.
 
 **Example Usage**
-
 ```lua
-if ent:isDoor() then
-    print("This is a door!")
+if entity:isDoor() then
+print("This is a door!")
 end
 ```
 
 ---
 
-### getDoorPartner *(Server)*
+### getDoorPartner
 
 **Purpose**
-
-Returns the door entity linked as this one's partner via `liaPartner`. This function simply returns the stored value and does not perform a search.
+Returns the partner door entity if available.
 
 **Parameters**
-
-* None
+- None
 
 **Returns**
-
-* `Entity|nil`: Partner door entity.
+- Entity or nil - The partner door entity, or nil if not set.
 
 **Realm**
-
-`Server`
+Server.
 
 **Example Usage**
-
 ```lua
-local partner = ent:getDoorPartner()
-if IsValid(partner) then
-    partner:setLocked(false)
-end
+local partner = door:getDoorPartner()
+if partner then print("Partner door found!") end
 ```
 
 ---
@@ -650,134 +494,108 @@ end
 ### setNetVar
 
 **Purpose**
-
-Updates a networked variable and notifies recipients. Unsupported types are ignored via `checkBadType`. Triggers the `NetVarChanged` hook when the value changes.
+Sets a networked variable for the entity and notifies clients.
 
 **Parameters**
-
-* `key` (`string`): Variable name.
-* `value` (`any`): Value to store.
-* `receiver` (`Player|nil`, optional): Player to send the update to. Broadcasts if omitted.
-
-**Returns**
-
-* `nil`: This function does not return a value.
+- key (string) - The key of the variable.
+- value (any) - The value to set.
+- receiver (Player) - The player to send the update to (optional).
 
 **Realm**
-
-`Server`
+Server.
 
 **Example Usage**
-
 ```lua
-ent:setNetVar("locked", true)
+entity:setNetVar("locked", true)
 ```
 
 ---
 
-### getNetVar *(Server)*
+### getNetVar
 
 **Purpose**
-
-Retrieves a stored networked variable from `lia.net[self]` or returns the provided default.
+Gets a networked variable for the entity.
 
 **Parameters**
-
-* `key` (`string`): Variable name.
-* `default` (`any`): Value returned if the variable is not set.
+- key (string) - The key of the variable.
+- default (any) - The default value to return if not set.
 
 **Returns**
-
-* `any`: Stored value or the provided default.
+- any - The value of the networked variable, or the default if not set.
 
 **Realm**
-
-`Server`
+Server.
 
 **Example Usage**
-
 ```lua
-local locked = ent:getNetVar("locked", false)
+local locked = entity:getNetVar("locked", false)
 ```
 
-### isDoor *(Client)*
+---
+
+### isDoor
 
 **Purpose**
-
-Client-side check using `self:GetClass():find("door")` to see if the entity's class name contains "door".
+Checks if the entity is a door.
 
 **Parameters**
-
-* None
+- None
 
 **Returns**
-
-* `boolean`: `true` if the class name contains "door".
+- boolean - True if the entity is a door, false otherwise.
 
 **Realm**
-
-`Client`
+Client.
 
 **Example Usage**
-
 ```lua
-if ent:isDoor() then
-    print("Door detected on client")
+if entity:isDoor() then
+print("This is a door!")
 end
 ```
 
 ---
 
-### getDoorPartner *(Client)*
+### getDoorPartner
 
 **Purpose**
-
-Returns `GetOwner()` or a cached `liaDoorOwner` if it is a valid door; otherwise searches for a `prop_door_rotating` owned by this entity and caches the result.
+Returns the partner door entity if available.
 
 **Parameters**
-
-* None
+- None
 
 **Returns**
-
-* `Entity|nil`: The partner door entity, if found.
+- Entity or nil - The partner door entity, or nil if not set.
 
 **Realm**
-
-`Client`
+Client.
 
 **Example Usage**
-
 ```lua
-local partner = ent:getDoorPartner()
-if IsValid(partner) then
-    partner:SetColor(Color(0, 255, 0))
-end
+local partner = door:getDoorPartner()
+if partner then print("Partner door found!") end
 ```
 
 ---
 
-### getNetVar *(Client)*
+### getNetVar
 
 **Purpose**
-
-Retrieves a networked variable for this entity from `lia.net[self:EntIndex()]` on the client.
+Gets a networked variable for the entity.
 
 **Parameters**
-
-* `key` (`string`): Variable name.
-* `default` (`any`): Value returned if the variable is not set.
+- key (string) - The key of the variable.
+- default (any) - The default value to return if not set.
 
 **Returns**
-
-* `any`: Stored value or the provided default.
+- any - The value of the networked variable, or the default if not set.
 
 **Realm**
-
-`Client`
+Client.
 
 **Example Usage**
-
 ```lua
-local locked = ent:getNetVar("locked", false)
+local locked = entity:getNetVar("locked", false)
 ```
+
+---

--- a/gamemode/core/meta/entity.lua
+++ b/gamemode/core/meta/entity.lua
@@ -7,138 +7,32 @@ local validClasses = {
     ["prop_vehicle_prisoner_pod"] = true,
 }
 
---[[
-    isProp
-
-    Purpose:
-        Checks if the entity is a physics prop.
-
-    Returns:
-        boolean - True if the entity is a physics prop, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if entity:isProp() then
-            print("This is a prop!")
-        end
-]]
 function entityMeta:isProp()
     if not IsValid(self) then return false end
     return self:GetClass() == "prop_physics"
 end
 
---[[
-    isItem
-
-    Purpose:
-        Checks if the entity is an item entity.
-
-    Returns:
-        boolean - True if the entity is an item, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if entity:isItem() then
-            print("This is an item!")
-        end
-]]
 function entityMeta:isItem()
     if not IsValid(self) then return false end
     return self:GetClass() == "lia_item"
 end
 
---[[
-    isMoney
-
-    Purpose:
-        Checks if the entity is a money entity.
-
-    Returns:
-        boolean - True if the entity is money, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if entity:isMoney() then
-            print("This is money!")
-        end
-]]
 function entityMeta:isMoney()
     if not IsValid(self) then return false end
     return self:GetClass() == "lia_money"
 end
 
---[[
-    isSimfphysCar
-
-    Purpose:
-        Checks if the entity is a simfphys or LVS vehicle.
-
-    Returns:
-        boolean - True if the entity is a simfphys or LVS vehicle, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if entity:isSimfphysCar() then
-            print("This is a simfphys/LVS car!")
-        end
-]]
 function entityMeta:isSimfphysCar()
     if not IsValid(self) then return false end
     return validClasses[self:GetClass()] or self.IsSimfphyscar or self.LVS or validClasses[self.Base]
 end
 
---[[
-    isLiliaPersistent
-
-    Purpose:
-        Checks if the entity is persistent in the Lilia framework.
-
-    Returns:
-        boolean - True if the entity is persistent, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if entity:isLiliaPersistent() then
-            print("This entity is persistent!")
-        end
-]]
 function entityMeta:isLiliaPersistent()
     if not IsValid(self) then return false end
     if self.GetPersistent and self:GetPersistent() then return true end
     return self.IsLeonNPC or self.IsPersistent
 end
 
---[[
-    checkDoorAccess
-
-    Purpose:
-        Checks if the given client has the specified access level to the door entity.
-
-    Parameters:
-        client (Player) - The player to check access for.
-        access (number) - The access level to check (optional, defaults to DOOR_GUEST).
-
-    Returns:
-        boolean - True if the client has access, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if door:checkDoorAccess(client, DOOR_OWNER) then
-            print("Client can access the door!")
-        end
-]]
 function entityMeta:checkDoorAccess(client, access)
     if not IsValid(self) then return false end
     if not self:isDoor() then return false end
@@ -148,21 +42,6 @@ function entityMeta:checkDoorAccess(client, access)
     return false
 end
 
---[[
-    keysOwn
-
-    Purpose:
-        Assigns ownership of the vehicle entity to the given client.
-
-    Parameters:
-        client (Player) - The player to set as the owner.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        vehicle:keysOwn(client)
-]]
 function entityMeta:keysOwn(client)
     if not IsValid(self) then return end
     if self:IsVehicle() then
@@ -173,123 +52,31 @@ function entityMeta:keysOwn(client)
     end
 end
 
---[[
-    keysLock
-
-    Purpose:
-        Locks the vehicle entity.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        vehicle:keysLock()
-]]
 function entityMeta:keysLock()
     if not IsValid(self) then return end
     if self:IsVehicle() then self:Fire("lock") end
 end
 
---[[
-    keysUnLock
-
-    Purpose:
-        Unlocks the vehicle entity.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        vehicle:keysUnLock()
-]]
 function entityMeta:keysUnLock()
     if not IsValid(self) then return end
     if self:IsVehicle() then self:Fire("unlock") end
 end
 
---[[
-    getDoorOwner
-
-    Purpose:
-        Returns the owner of the vehicle entity if available.
-
-    Returns:
-        Player or nil - The owner of the vehicle, or nil if not available.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local owner = vehicle:getDoorOwner()
-        if owner then print("Owner found!") end
-]]
 function entityMeta:getDoorOwner()
     if not IsValid(self) then return nil end
     if self:IsVehicle() and self.CPPIGetOwner then return self:CPPIGetOwner() end
 end
 
---[[
-    isLocked
-
-    Purpose:
-        Checks if the entity is locked according to its networked variable.
-
-    Returns:
-        boolean - True if locked, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if entity:isLocked() then
-            print("Entity is locked!")
-        end
-]]
 function entityMeta:isLocked()
     if not IsValid(self) then return false end
     return self:getNetVar("locked", false)
 end
 
---[[
-    isDoorLocked
-
-    Purpose:
-        Checks if the door entity is locked according to its internal variable or fallback.
-
-    Returns:
-        boolean - True if locked, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if door:isDoorLocked() then
-            print("Door is locked!")
-        end
-]]
 function entityMeta:isDoorLocked()
     if not IsValid(self) then return false end
     return self:GetInternalVariable("m_bLocked") or self.locked or false
 end
 
---[[
-    getEntItemDropPos
-
-    Purpose:
-        Calculates the position and angle where an item should be dropped from the entity.
-
-    Parameters:
-        offset (number) - The distance from the entity to drop the item (optional, defaults to 64).
-
-    Returns:
-        Vector, Angle - The position and angle for item drop.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local pos, ang = entity:getEntItemDropPos(128)
-]]
 function entityMeta:getEntItemDropPos(offset)
     if not IsValid(self) then return Vector(0, 0, 0), Angle(0, 0, 0) end
     if not offset then offset = 64 end
@@ -302,27 +89,6 @@ function entityMeta:getEntItemDropPos(offset)
     return trResult.HitPos + trResult.HitNormal * 5, trResult.HitNormal:Angle()
 end
 
---[[
-    isNearEntity
-
-    Purpose:
-        Checks if another entity is within a certain radius of this entity.
-
-    Parameters:
-        radius (number) - The radius to check within (optional, defaults to 96).
-        otherEntity (Entity) - The entity to check proximity to.
-
-    Returns:
-        boolean - True if the other entity is near, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if entity:isNearEntity(128, otherEntity) then
-            print("Other entity is nearby!")
-        end
-]]
 function entityMeta:isNearEntity(radius, otherEntity)
     if not IsValid(self) then return false end
     if otherEntity == self then return true end
@@ -334,64 +100,16 @@ function entityMeta:isNearEntity(radius, otherEntity)
     return false
 end
 
---[[
-    GetCreator
-
-    Purpose:
-        Returns the creator of the entity from its networked variable.
-
-    Returns:
-        Player or nil - The creator of the entity, or nil if not set.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local creator = entity:GetCreator()
-        if creator then print("Creator found!") end
-]]
 function entityMeta:GetCreator()
     if not IsValid(self) then return nil end
     return self:getNetVar("creator", nil)
 end
 
 if SERVER then
-    --[[
-        SetCreator
-
-        Purpose:
-            Sets the creator of the entity in its networked variable.
-
-        Parameters:
-            client (Player) - The player to set as the creator.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            entity:SetCreator(client)
-    ]]
     function entityMeta:SetCreator(client)
         if not IsValid(self) then return end
         self:setNetVar("creator", client)
     end
-
-    --[[
-        sendNetVar
-
-        Purpose:
-            Sends a networked variable to a specific receiver or broadcasts it.
-
-        Parameters:
-            key (string) - The key of the variable to send.
-            receiver (Player) - The player to send the variable to (optional).
-
-        Realm:
-            Server.
-
-        Example Usage:
-            entity:sendNetVar("locked", client)
-    ]]
     function entityMeta:sendNetVar(key, receiver)
         if not IsValid(self) then return end
         net.Start("nVar")
@@ -404,22 +122,6 @@ if SERVER then
             net.Broadcast()
         end
     end
-
-    --[[
-        clearNetVars
-
-        Purpose:
-            Clears all networked variables for the entity and notifies clients.
-
-        Parameters:
-            receiver (Player) - The player to send the clear notification to (optional).
-
-        Realm:
-            Server.
-
-        Example Usage:
-            entity:clearNetVars(client)
-    ]]
     function entityMeta:clearNetVars(receiver)
         if not IsValid(self) then return end
         lia.net[self] = nil
@@ -431,19 +133,6 @@ if SERVER then
             net.Broadcast()
         end
     end
-
-    --[[
-        removeDoorAccessData
-
-        Purpose:
-            Removes all door access data for the entity and notifies clients.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            door:removeDoorAccessData()
-    ]]
     function entityMeta:removeDoorAccessData()
         if IsValid(self) then
             for k, _ in pairs(self.liaAccess or {}) do
@@ -455,64 +144,14 @@ if SERVER then
             self:SetDTEntity(0, nil)
         end
     end
-
-    --[[
-        setLocked
-
-        Purpose:
-            Sets the locked state of the entity.
-
-        Parameters:
-            state (boolean) - The locked state to set.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            entity:setLocked(true)
-    ]]
     function entityMeta:setLocked(state)
         if not IsValid(self) then return end
         self:setNetVar("locked", state)
     end
-
-    --[[
-        setKeysNonOwnable
-
-        Purpose:
-            Sets whether the entity is non-ownable.
-
-        Parameters:
-            state (boolean) - The non-ownable state to set.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            entity:setKeysNonOwnable(true)
-    ]]
     function entityMeta:setKeysNonOwnable(state)
         if not IsValid(self) then return end
         self:setNetVar("noSell", state)
     end
-
-    --[[
-        isDoor
-
-        Purpose:
-            Checks if the entity is a door.
-
-        Returns:
-            boolean - True if the entity is a door, false otherwise.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            if entity:isDoor() then
-                print("This is a door!")
-            end
-    ]]
     function entityMeta:isDoor()
         if not IsValid(self) then return false end
         local class = self:GetClass():lower()
@@ -522,44 +161,9 @@ if SERVER then
         end
         return false
     end
-
-    --[[
-        getDoorPartner
-
-        Purpose:
-            Returns the partner door entity if available.
-
-        Returns:
-            Entity or nil - The partner door entity, or nil if not set.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            local partner = door:getDoorPartner()
-            if partner then print("Partner door found!") end
-    ]]
     function entityMeta:getDoorPartner()
         return self.liaPartner
     end
-
-    --[[
-        setNetVar
-
-        Purpose:
-            Sets a networked variable for the entity and notifies clients.
-
-        Parameters:
-            key (string) - The key of the variable.
-            value (any) - The value to set.
-            receiver (Player) - The player to send the update to (optional).
-
-        Realm:
-            Server.
-
-        Example Usage:
-            entity:setNetVar("locked", true)
-    ]]
     function entityMeta:setNetVar(key, value, receiver)
         if not IsValid(self) then return end
         if checkBadType(key, value) then return end
@@ -569,26 +173,6 @@ if SERVER then
         self:sendNetVar(key, receiver)
         hook.Run("NetVarChanged", self, key, oldValue, value)
     end
-
-    --[[
-        getNetVar
-
-        Purpose:
-            Gets a networked variable for the entity.
-
-        Parameters:
-            key (string) - The key of the variable.
-            default (any) - The default value to return if not set.
-
-        Returns:
-            any - The value of the networked variable, or the default if not set.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            local locked = entity:getNetVar("locked", false)
-    ]]
     function entityMeta:getNetVar(key, default)
         if not IsValid(self) then return default end
         if lia.net[self] and lia.net[self][key] ~= nil then return lia.net[self][key] end
@@ -597,44 +181,10 @@ if SERVER then
 
     playerMeta.getLocalVar = entityMeta.getNetVar
 else
-    --[[
-        isDoor
-
-        Purpose:
-            Checks if the entity is a door.
-
-        Returns:
-            boolean - True if the entity is a door, false otherwise.
-
-        Realm:
-            Client.
-
-        Example Usage:
-            if entity:isDoor() then
-                print("This is a door!")
-            end
-    ]]
     function entityMeta:isDoor()
         if not IsValid(self) then return false end
         return self:GetClass():find("door")
     end
-
-    --[[
-        getDoorPartner
-
-        Purpose:
-            Returns the partner door entity if available.
-
-        Returns:
-            Entity or nil - The partner door entity, or nil if not set.
-
-        Realm:
-            Client.
-
-        Example Usage:
-            local partner = door:getDoorPartner()
-            if partner then print("Partner door found!") end
-    ]]
     function entityMeta:getDoorPartner()
         if not IsValid(self) then return nil end
         local owner = self:GetOwner() or self.liaDoorOwner
@@ -646,26 +196,6 @@ else
             end
         end
     end
-
-    --[[
-        getNetVar
-
-        Purpose:
-            Gets a networked variable for the entity.
-
-        Parameters:
-            key (string) - The key of the variable.
-            default (any) - The default value to return if not set.
-
-        Returns:
-            any - The value of the networked variable, or the default if not set.
-
-        Realm:
-            Client.
-
-        Example Usage:
-            local locked = entity:getNetVar("locked", false)
-    ]]
     function entityMeta:getNetVar(key, default)
         if not IsValid(self) then return default end
         local index = self:EntIndex()


### PR DESCRIPTION
## Summary
- regenerate entity meta docs from Lua comments
- remove inline documentation blocks from entity meta

## Testing
- `luacheck gamemode/core/meta/entity.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68988c277f208327b3109ed98fc8c65c