### PR TITLE
docs: migrate item meta comments to docs

### DIFF
--- a/documentation/docs/meta/item.md
+++ b/documentation/docs/meta/item.md
@@ -20,25 +20,25 @@ These helpers enable consistent interaction across trading, crafting, and interf
 
 **Purpose**
 
-Checks whether this item instance is rotated within the inventory grid.
+Checks if the item is currently rotated.
 
 **Parameters**
 
 * None
 
-**Realm**
-
-`Shared`
-
 **Returns**
 
-* `boolean`: `true` if the item is rotated.
+* boolean - True if the item is rotated, false otherwise.
+
+**Realm**
+
+`Shared.`
 
 **Example Usage**
 
 ```lua
 if item:isRotated() then
-    print("Rotated item")
+print("The item is rotated!")
 end
 ```
 
@@ -48,24 +48,25 @@ end
 
 **Purpose**
 
-Returns the width of the item, accounting for rotation.
+Returns the width of the item, taking into account its rotation.
 
 **Parameters**
 
 * None
 
-**Realm**
-
-`Shared`
-
 **Returns**
 
-* `number`: Width in grid units.
+* number - The width of the item.
+
+**Realm**
+
+`Shared.`
 
 **Example Usage**
 
 ```lua
-local w = item:getWidth()
+local width = item:getWidth()
+print("Item width: " .. width)
 ```
 
 ---
@@ -74,24 +75,25 @@ local w = item:getWidth()
 
 **Purpose**
 
-Returns the height of the item, accounting for rotation.
+Returns the height of the item, taking into account its rotation.
 
 **Parameters**
 
 * None
 
-**Realm**
-
-`Shared`
-
 **Returns**
 
-* `number`: Height in grid units.
+* number - The height of the item.
+
+**Realm**
+
+`Shared.`
 
 **Example Usage**
 
 ```lua
-local h = item:getHeight()
+local height = item:getHeight()
+print("Item height: " .. height)
 ```
 
 ---
@@ -100,27 +102,24 @@ local h = item:getHeight()
 
 **Purpose**
 
-Retrieves how many of this item the stack represents.
-
-If the item has not yet been instanced (`id` equals `0`), this returns the `maxQuantity` defined on the base item.
+Returns the current quantity of the item.
 
 **Parameters**
 
 * None
 
-**Realm**
-
-`Shared`
-
 **Returns**
 
-* `number`: Quantity contained in this item instance.
+* number - The quantity of the item.
+
+**Realm**
+
+`Shared.`
 
 **Example Usage**
 
 ```lua
--- Give the player ammo equal to the stack quantity
-player:GiveAmmo(item:getQuantity(), "pistol")
+print("You have " .. item:getQuantity() .. " of this item.")
 ```
 
 ---
@@ -129,26 +128,25 @@ player:GiveAmmo(item:getQuantity(), "pistol")
 
 **Purpose**
 
-Compares this item instance to another by ID.
+Checks if this item is equal to another item by comparing their IDs.
 
 **Parameters**
 
-* `other` (Item): The other item to compare with.
-
-**Realm**
-
-`Shared`
+* other (Item) - The other item to compare.
 
 **Returns**
 
-* `boolean`: True if both items share the same ID.
+* boolean - True if the items are equal, false otherwise.
+
+**Realm**
+
+`Shared.`
 
 **Example Usage**
 
 ```lua
--- Check if the held item matches the inventory slot
-if item:eq(slotItem) then
-    print("Same item instance")
+if item:eq(otherItem) then
+print("These items are the same instance.")
 end
 ```
 
@@ -158,25 +156,24 @@ end
 
 **Purpose**
 
-Returns a printable representation of this item.
+Returns a string representation of the item.
 
 **Parameters**
 
 * None
 
-**Realm**
-
-`Shared`
-
 **Returns**
 
-* `string`: Identifier in the form `"item[uniqueID][id]"`.
+* string - The string representation of the item.
+
+**Realm**
+
+`Shared.`
 
 **Example Usage**
 
 ```lua
--- Log the item identifier during saving
-print("Saving " .. item:tostring())
+print(item:tostring())
 ```
 
 ---
@@ -185,25 +182,24 @@ print("Saving " .. item:tostring())
 
 **Purpose**
 
-Retrieves the unique identifier of this item.
+Returns the ID of the item.
 
 **Parameters**
 
 * None
 
-**Realm**
-
-`Shared`
-
 **Returns**
 
-* `number`: Item database ID.
+* number - The ID of the item.
+
+**Realm**
+
+`Shared.`
 
 **Example Usage**
 
 ```lua
--- Use the ID when updating the database
-lia.db.updateItem(item:getID(), {price = 50})
+print("Item ID: " .. item:getID())
 ```
 
 ---
@@ -212,27 +208,24 @@ lia.db.updateItem(item:getID(), {price = 50})
 
 **Purpose**
 
-Returns the model path associated with this item.
+Returns the model of the item.
 
 **Parameters**
 
 * None
 
-**Realm**
-
-`Shared`
-
 **Returns**
 
-* `string`: Model path.
+* string - The model path of the item.
+
+**Realm**
+
+`Shared.`
 
 **Example Usage**
 
 ```lua
--- Spawn the item's model as a world prop
-local prop = ents.Create("prop_physics")
-prop:SetModel(item:getModel())
-prop:Spawn()
+print("Model path: " .. item:getModel())
 ```
 
 ---
@@ -241,25 +234,24 @@ prop:Spawn()
 
 **Purpose**
 
-Retrieves the skin index this item uses.
+Returns the skin index of the item.
 
 **Parameters**
 
 * None
 
-**Realm**
-
-`Shared`
-
 **Returns**
 
-* `number`: Skin ID applied to the model.
+* number - The skin index.
+
+**Realm**
+
+`Shared.`
 
 **Example Usage**
 
 ```lua
--- Apply the correct skin when displaying the item
-model:SetSkin(item:getSkin())
+print("Skin index: " .. tostring(item:getSkin()))
 ```
 
 ---
@@ -268,29 +260,24 @@ model:SetSkin(item:getSkin())
 
 **Purpose**
 
-Returns the calculated purchase price for the item. If `calcPrice` is defined on
-the item, its result is used. Falls back to the stored `price` and defaults to
-`0` when undefined.
+Returns the price of the item, using a custom calculation if available.
 
 **Parameters**
 
 * None
 
-**Realm**
-
-`Shared`
-
 **Returns**
 
-* `number`: Final price value.
+* number - The price of the item.
+
+**Realm**
+
+`Shared.`
 
 **Example Usage**
 
 ```lua
--- Charge the player the item's price before giving it
-if char:hasMoney(item:getPrice()) then
-    char:takeMoney(item:getPrice())
-end
+print("Item price: " .. item:getPrice())
 ```
 
 ---
@@ -299,35 +286,27 @@ end
 
 **Purpose**
 
-Invokes an item method with the given player and entity context.
+Calls a method on the item, temporarily setting the player and entity context.
 
 **Parameters**
 
-* `method` (string): Method name to run.
-
-* `client` (Player|nil): The player performing the action.
-
-* `entity` (Entity|nil): Entity representing this item or `nil` when none.
-
-* `...`: Additional arguments passed to the method.
-
-**Realm**
-
-`Shared`
+* method (string) - The method name to call.
+* client (Player) - The player context.
+* entity (Entity) - The entity context.
+* ... - Additional arguments to pass to the method.
 
 **Returns**
 
-* `any|nil`: Return values from the called method or `nil` if it doesn't
-  exist.
+* ... - The return values of the called method.
+
+**Realm**
+
+`Shared.`
 
 **Example Usage**
 
 ```lua
--- Invoke a custom repair function and check the result
-local success = item:call("repair", client, entity, targetItem)
-if success then
-    client:notify("Repaired!")
-end
+item:call("onUse", client, entity, arg1, arg2)
 ```
 
 ---
@@ -336,27 +315,26 @@ end
 
 **Purpose**
 
-Attempts to find the player currently owning this item.
+Returns the player who owns this item.
 
 **Parameters**
 
 * None
 
-**Realm**
-
-`Shared`
-
 **Returns**
 
-* `Player|nil`: The owner if available.
+* Player - The owner of the item, or nil if not found.
+
+**Realm**
+
+`Shared.`
 
 **Example Usage**
 
 ```lua
--- Notify whoever currently owns the item
 local owner = item:getOwner()
-if IsValid(owner) then
-    owner:notifyLocalized("itemGlows")
+if owner then
+print("Item owner: " .. owner:Name())
 end
 ```
 
@@ -366,27 +344,25 @@ end
 
 **Purpose**
 
-Retrieves a piece of persistent data stored on the item.
+Returns the value of a data key for this item, checking both local and entity data.
 
 **Parameters**
 
-* `key` (string): Data key to read.
-
-* `default` (any): Value to return when the key is absent.
-
-**Realm**
-
-`Shared`
+* key (string) - The data key to retrieve.
+* default (any) - The default value if the key is not found.
 
 **Returns**
 
-* `any`: Stored value or default.
+* any - The value of the data key, or the default.
+
+**Realm**
+
+`Shared.`
 
 **Example Usage**
 
 ```lua
--- Retrieve a custom paint color stored on the item
-local color = item:getData("paintColor", Color(255, 255, 255))
+local durability = item:getData("durability", 100)
 ```
 
 ---
@@ -395,24 +371,23 @@ local color = item:getData("paintColor", Color(255, 255, 255))
 
 **Purpose**
 
-Returns a merged table of this item's stored data and any networked values on its entity.
+Returns a table containing all data for this item, including entity data.
 
 **Parameters**
 
 * None
 
-**Realm**
-
-`Shared`
-
 **Returns**
 
-* `table`: Key/value table of all data fields.
+* table - A table of all data for the item.
+
+**Realm**
+
+`Shared.`
 
 **Example Usage**
 
 ```lua
--- Print all stored data for debugging
 PrintTable(item:getAllData())
 ```
 
@@ -422,27 +397,25 @@ PrintTable(item:getAllData())
 
 **Purpose**
 
-Registers a hook callback for this item instance.
+Registers a hook function for a specific event on this item.
 
 **Parameters**
 
-* `name` (string): Hook identifier.
-
-* `func` (function): Function to call.
-
-**Realm**
-
-`Shared`
+* name (string) - The name of the hook/event.
+* func (function) - The function to call.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+* None
+
+**Realm**
+
+`Shared.`
 
 **Example Usage**
 
 ```lua
--- Run code when the item is used
-item:hook("use", function(ply) ply:ChatPrint("Used!") end)
+item:hook("onUse", function(self, data) print("Used!") end)
 ```
 
 ---
@@ -451,27 +424,25 @@ item:hook("use", function(ply) ply:ChatPrint("Used!") end)
 
 **Purpose**
 
-Registers a post-hook callback for this item.
+Registers a post-hook function for a specific event on this item.
 
 **Parameters**
 
-* `name` (string): Hook identifier.
-
-* `func` (function): Function invoked after the main hook.
-
-**Realm**
-
-`Shared`
+* name (string) - The name of the post-hook/event.
+* func (function) - The function to call.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+* None
+
+**Realm**
+
+`Shared.`
 
 **Example Usage**
 
 ```lua
--- Give a pistol after the item is picked up
-item:postHook("pickup", function(ply) ply:Give("weapon_pistol") end)
+item:postHook("onUse", function(self, result, data) print("Post-use!") end)
 ```
 
 ---
@@ -480,26 +451,24 @@ item:postHook("pickup", function(ply) ply:Give("weapon_pistol") end)
 
 **Purpose**
 
-Called when the item table is first registered.
+Called when the item is registered. Precaches the model if set.
 
 **Parameters**
 
 * None
 
-**Realm**
-
-`Shared`
-
 **Returns**
 
-* `nil`: This function does not return a value.
+* None
+
+**Realm**
+
+`Shared.`
 
 **Example Usage**
 
 ```lua
-function ITEM:onRegistered()
-    print("Registered item " .. self.uniqueID)
-end
+-- Called automatically when the item is registered.
 ```
 
 ---
@@ -508,24 +477,23 @@ end
 
 **Purpose**
 
-Prints a simple representation of the item to the console.
+Prints information about the item to the console.
 
 **Parameters**
 
-* `detail` (boolean): Include position details when true.
-
-**Realm**
-
-`Shared`
+* detail (boolean) - Whether to print detailed information.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+* None
+
+**Realm**
+
+`Shared.`
 
 **Example Usage**
 
 ```lua
--- Output item info while debugging spawn issues
 item:print(true)
 ```
 
@@ -535,88 +503,24 @@ item:print(true)
 
 **Purpose**
 
-Debug helper that prints all stored item data.
+Prints all data associated with the item to the console.
 
 **Parameters**
 
 * None
 
-**Realm**
-
-`Shared`
-
 **Returns**
 
-* `nil`: This function does not return a value.
+* None
+
+**Realm**
+
+`Shared.`
 
 **Example Usage**
 
 ```lua
--- Dump all stored data to the console
 item:printData()
-```
-
----
-
-### addQuantity
-
-**Purpose**
-
-Increases the stored quantity for this item instance.
-
-**Parameters**
-
-* `quantity` (number): Amount to add.
-
-* `receivers` (Player|table|nil): Who to network the change to (defaults to the owner).
-
-* `noCheckEntity` (boolean): Skip entity network update (default `false`).
-
-**Realm**
-
-`Server`
-
-**Returns**
-
-* `nil`: This function does not return a value.
-
-**Example Usage**
-
-```lua
--- Combine stacks from a loot drop and notify the owner
-item:addQuantity(5, {player})
-player:notifyLocalized("item_added", item.name, 5)
-```
-
----
-
-### setQuantity
-
-**Purpose**
-
-Sets the current stack quantity and replicates the change.
-
-**Parameters**
-
-* `quantity` (number): New amount to store.
-
-* `receivers` (Player|table|nil): Recipients to send updates to (defaults to the owner).
-
-* `noCheckEntity` (boolean): Skip entity updates when `true` (default `false`).
-
-**Realm**
-
-`Server`
-
-**Returns**
-
-* `nil`: This function does not return a value.
-
-**Example Usage**
-
-```lua
--- Set quantity to 1 after splitting the stack
-item:setQuantity(1, nil, true)
 ```
 
 ---
@@ -625,27 +529,24 @@ item:setQuantity(1, nil, true)
 
 **Purpose**
 
-Returns the display name of this item.
-
-The same value is available on both the server and client.
+Returns the name of the item.
 
 **Parameters**
 
 * None
 
-**Realm**
-
-`Shared`
-
 **Returns**
 
-* `string`: Item name.
+* string - The name of the item.
+
+**Realm**
+
+`Server.`
 
 **Example Usage**
 
 ```lua
--- Inform the player which item they found
-client:ChatPrint(string.format("Picked up: %s", item:getName()))
+print(item:getName())
 ```
 
 ---
@@ -654,53 +555,24 @@ client:ChatPrint(string.format("Picked up: %s", item:getName()))
 
 **Purpose**
 
-Retrieves the description text for this item.
+Returns the description of the item.
 
 **Parameters**
 
 * None
 
-**Realm**
-
-`Shared`
-
 **Returns**
 
-* `string`: Item description.
+* string - The description of the item.
+
+**Realm**
+
+`Server.`
 
 **Example Usage**
 
 ```lua
--- Display a tooltip describing the item
-tooltip:AddRowAfter("name", "desc"):SetText(item:getDesc())
-```
-
----
-
-### getCategory
-
-**Purpose**
-
-Returns the item's category, localized when available.
-
-If no category is defined, it defaults to the localized string for `"misc"`.
-
-**Parameters**
-
-* None
-
-**Realm**
-
-`Shared`
-
-**Returns**
-
-* `string`: Localized category name.
-
-**Example Usage**
-
-```lua
-print("Category:", item:getCategory())
+print(item:getDesc())
 ```
 
 ---
@@ -709,27 +581,24 @@ print("Category:", item:getCategory())
 
 **Purpose**
 
-Removes this item from its inventory without deleting it when `preserveItem` is true.
+Removes the item from its inventory.
 
 **Parameters**
 
-* `preserveItem` (boolean): Keep the item saved in the database (default `false`).
-
-**Realm**
-
-`Server`
+* preserveItem (boolean) - Whether to preserve the item instance.
 
 **Returns**
 
-* `Deferred`: Resolves when the item has been removed.
+* Deferred - A deferred object that resolves when removal is complete.
+
+**Realm**
+
+`Server.`
 
 **Example Usage**
 
 ```lua
--- Unequip and drop the item while keeping it saved
-item:removeFromInventory(true):next(function()
-    client:ChatPrint("Item unequipped")
-end)
+item:removeFromInventory(true):next(function() print("Removed!") end)
 ```
 
 ---
@@ -738,27 +607,24 @@ end)
 
 **Purpose**
 
-Deletes this item from the database after destroying it.
+Deletes the item from the database and calls onRemoved.
 
 **Parameters**
 
 * None
 
-**Realm**
-
-`Server`
-
 **Returns**
 
-* `Deferred`: Resolves when deletion completes.
+* Deferred - A deferred object that resolves when deletion is complete.
+
+**Realm**
+
+`Server.`
 
 **Example Usage**
 
 ```lua
--- Permanently remove the item from the database
-item:delete():next(function()
-    print("Item purged")
-end)
+item:delete():next(function() print("Deleted!") end)
 ```
 
 ---
@@ -767,27 +633,24 @@ end)
 
 **Purpose**
 
-Destroys the item's entity then removes and deletes it from its inventory.
+Removes the item from the world and inventory, then deletes it.
 
 **Parameters**
 
 * None
 
-**Realm**
-
-`Server`
-
 **Returns**
 
-* `Deferred`: Resolves when the item has been removed.
+* Deferred - A deferred object that resolves when removal is complete.
+
+**Realm**
+
+`Server.`
 
 **Example Usage**
 
 ```lua
--- Remove the item from the world and database
-item:remove():next(function()
-    print("Removed and deleted")
-end)
+item:remove():next(function() print("Item fully removed!") end)
 ```
 
 ---
@@ -796,24 +659,23 @@ end)
 
 **Purpose**
 
-Broadcasts deletion of this item and removes it from memory.
+Destroys the item instance and notifies clients.
 
 **Parameters**
 
 * None
 
-**Realm**
-
-`Server`
-
 **Returns**
 
-* `nil`: This function does not return a value.
+* None
+
+**Realm**
+
+`Server.`
 
 **Example Usage**
 
 ```lua
--- Instantly delete the item across the network
 item:destroy()
 ```
 
@@ -823,26 +685,24 @@ item:destroy()
 
 **Purpose**
 
-Callback executed after the item is destroyed.
+Called when the item is disposed.
 
 **Parameters**
 
 * None
 
-**Realm**
-
-`Server`
-
 **Returns**
 
-* `nil`: This function does not return a value.
+* None
+
+**Realm**
+
+`Server.`
 
 **Example Usage**
 
 ```lua
-function ITEM:onDisposed()
-    print(self:getName() .. " was cleaned up")
-end
+-- Override in your item definition if needed.
 ```
 
 ---
@@ -851,28 +711,25 @@ end
 
 **Purpose**
 
-Finds the entity spawned for this item, if any.
+Returns the entity associated with this item.
 
 **Parameters**
 
 * None
 
-**Realm**
-
-`Server`
-
 **Returns**
 
-* `Entity|nil`: The world entity representing the item.
+* Entity - The entity, or nil if not found.
+
+**Realm**
+
+`Server.`
 
 **Example Usage**
 
 ```lua
--- Grab the world entity to modify it
 local ent = item:getEntity()
-if IsValid(ent) then
-    ent:SetColor(Color(255, 0, 0))
-end
+if ent then print("Entity found!") end
 ```
 
 ---
@@ -881,32 +738,25 @@ end
 
 **Purpose**
 
-Creates a world entity for this item at the specified position.
-
-If no angle is provided it will spawn upright using `angle_zero`.
+Spawns the item as an entity in the world.
 
 **Parameters**
 
-* `position` (Vector|table|Player): Drop position, player, or table convertible to a vector.
-
-* `angles` (Angle|table|nil): Orientation for the entity (default `angle_zero`).
-
-**Realm**
-
-`Server`
+* position (Vector or table or Player) - The position or player to drop at.
+* angles (Angle or table) - The angles to spawn with.
 
 **Returns**
 
-* `Entity|nil`: The created entity if successful.
+* Entity - The spawned entity, or nil if failed.
+
+**Realm**
+
+`Server.`
 
 **Example Usage**
 
 ```lua
--- Drop the item at the player's feet with a random yaw
-local ent = item:spawn(client:getItemDropPos(), Angle(0, math.random(0, 360), 0))
-if IsValid(ent) then
-    ent:SetOwner(client)
-end
+local ent = item:spawn(Vector(0,0,0))
 ```
 
 ---
@@ -915,29 +765,25 @@ end
 
 **Purpose**
 
-Moves the item to another inventory, optionally bypassing access checks.
+Transfers the item to a new inventory.
 
 **Parameters**
 
-* `newInventory` (Inventory): Destination inventory.
-
-* `bBypass` (boolean): Skip permission checking.
-
-**Realm**
-
-`Server`
+* newInventory (Inventory) - The inventory to transfer to.
+* bBypass (boolean) - Whether to bypass access checks.
 
 **Returns**
 
-* `boolean`: True if the transfer was initiated.
+* boolean - True if transfer started, false otherwise.
+
+**Realm**
+
+`Server.`
 
 **Example Usage**
 
 ```lua
--- Move the item into another container
-item:transfer(targetInv):next(function()
-    print("Transferred successfully")
-end)
+item:transfer(newInventory)
 ```
 
 ---
@@ -946,38 +792,24 @@ end)
 
 **Purpose**
 
-Called when a new instance of this item is created.
+Called when the item is instanced.
 
 **Parameters**
 
-* `invID` (number): Inventory ID the item belongs to or `NULL` when not placed in one.
-
-* `x` (number): Grid X coordinate where the item spawned.
-
-* `y` (number): Grid Y coordinate where the item spawned.
-
-* `item` (Item): The newly created item instance.
-
-**Realm**
-
-`Server`
+* None
 
 **Returns**
 
-* `nil`: This function does not return a value.
+* None
+
+**Realm**
+
+`Server.`
 
 **Example Usage**
 
 ```lua
-function ITEM:onInstanced(invID, x, y, newItem)
-    print(string.format(
-        "Item %s placed at %d,%d in inv %s",
-        newItem.uniqueID,
-        x,
-        y,
-        tostring(invID)
-    ))
-end
+-- Override in your item definition if needed.
 ```
 
 ---
@@ -986,26 +818,24 @@ end
 
 **Purpose**
 
-Runs after this item is networked to `recipient`.
+Called when the item is synced to a client.
 
 **Parameters**
 
-* `recipient` (Player|table|nil): Player or list who received the data, or `nil` when broadcast.
-
-**Realm**
-
-`Server`
+* None
 
 **Returns**
 
-* `nil`: This function does not return a value.
+* None
+
+**Realm**
+
+`Server.`
 
 **Example Usage**
 
 ```lua
-function ITEM:onSync(recipient)
-    print("Sent item to", recipient or "all clients")
-end
+-- Override in your item definition if needed.
 ```
 
 ---
@@ -1014,26 +844,24 @@ end
 
 **Purpose**
 
-Executed after the item is permanently removed.
+Called when the item is removed.
 
 **Parameters**
 
 * None
 
-**Realm**
-
-`Server`
-
 **Returns**
 
-* `nil`: This function does not return a value.
+* None
+
+**Realm**
+
+`Server.`
 
 **Example Usage**
 
 ```lua
-function ITEM:onRemoved()
-    print(self.uniqueID .. " permanently deleted")
-end
+-- Override in your item definition if needed.
 ```
 
 ---
@@ -1042,29 +870,24 @@ end
 
 **Purpose**
 
-Called when the item is restored from the database.
+Called when the item is restored.
 
 **Parameters**
 
-* `inventory` (Inventory|nil): Inventory the item belongs to when loaded, if any.
-
-**Realm**
-
-`Server`
+* None
 
 **Returns**
 
-* `nil`: This function does not return a value.
+* None
+
+**Realm**
+
+`Server.`
 
 **Example Usage**
 
 ```lua
-function ITEM:onRestored(inv)
-    print(self:getName() .. " loaded from the database")
-    if inv then
-        print("Loaded from inventory", inv.id)
-    end
-end
+-- Override in your item definition if needed.
 ```
 
 ---
@@ -1073,25 +896,24 @@ end
 
 **Purpose**
 
-Sends this item's data to a player or list of players, or broadcasts to all.
+Syncs the item instance to a recipient or all clients.
 
 **Parameters**
 
-* `recipient` (Player|table|nil): Target player(s) or `nil` for broadcast (default).
-
-**Realm**
-
-`Server`
+* recipient (Player) - The player to sync to, or nil for all.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+* None
+
+**Realm**
+
+`Server.`
 
 **Example Usage**
 
 ```lua
--- Resend the item data to a specific player
-item:sync(player)
+item:sync(client)
 ```
 
 ---
@@ -1100,33 +922,84 @@ item:sync(player)
 
 **Purpose**
 
-Sets a data field on the item and optionally networks and saves it.
+Sets a data key for the item and syncs it to clients and the database.
 
 **Parameters**
 
-* `key` (string): Data key to modify.
-
-* `value` (any): New value to store.
-
-* `receivers` (Player|table|nil): Who to send the update to (defaults to the owner).
-
-* `noSave` (boolean): Avoid saving to the database (default `false`).
-
-* `noCheckEntity` (boolean): Skip updating the world entity (default `false`).
-
-**Realm**
-
-`Server`
+* key (string) - The data key.
+* value (any) - The value to set.
+* receivers (Player or table) - The recipients to sync to.
+* noSave (boolean) - If true, do not save to the database.
+* noCheckEntity (boolean) - If true, do not update the entity.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+* None
+
+**Realm**
+
+`Server.`
 
 **Example Usage**
 
 ```lua
--- Mark the item as legendary and notify the owner
-item:setData("rarity", "legendary", player)
+item:setData("durability", 50)
+```
+
+---
+
+### addQuantity
+
+**Purpose**
+
+Adds to the item's quantity and updates clients/entities.
+
+**Parameters**
+
+* quantity (number) - The amount to add.
+* receivers (Player or table) - The recipients to sync to.
+* noCheckEntity (boolean) - If true, do not update the entity.
+
+**Returns**
+
+* None
+
+**Realm**
+
+`Server.`
+
+**Example Usage**
+
+```lua
+item:addQuantity(5)
+```
+
+---
+
+### setQuantity
+
+**Purpose**
+
+Sets the item's quantity and updates clients/entities and the database.
+
+**Parameters**
+
+* quantity (number) - The new quantity.
+* receivers (Player or table) - The recipients to sync to.
+* noCheckEntity (boolean) - If true, do not update the entity.
+
+**Returns**
+
+* None
+
+**Realm**
+
+`Server.`
+
+**Example Usage**
+
+```lua
+item:setQuantity(10)
 ```
 
 ---
@@ -1135,31 +1008,106 @@ item:setData("rarity", "legendary", player)
 
 **Purpose**
 
-Processes an interaction action performed by `client` on this item.
+Handles a player interaction with the item.
 
 **Parameters**
 
-* `action` (string): Identifier of the interaction.
-
-* `client` (Player): Player performing the action.
-
-* `entity` (Entity|nil): Entity used for the interaction.
-
-* `data` (table|nil): Extra data passed to the hooks.
-
-**Realm**
-
-`Server`
+* action (string) - The action to perform.
+* client (Player) - The player interacting.
+* entity (Entity) - The entity involved.
+* data (any) - Additional data for the interaction.
 
 **Returns**
 
-* `boolean`: True if the interaction succeeded.
+* boolean - True if the interaction was successful, false otherwise.
+
+**Realm**
+
+`Server.`
 
 **Example Usage**
 
 ```lua
--- Trigger the "use" interaction from code
-item:interact("use", client, nil)
+item:interact("use", client, entity, data)
 ```
 
 ---
+
+### getName
+
+**Purpose**
+
+Returns the name of the item.
+
+**Parameters**
+
+* None
+
+**Returns**
+
+* string - The name of the item.
+
+**Realm**
+
+`Client.`
+
+**Example Usage**
+
+```lua
+print(item:getName())
+```
+
+---
+
+### getDesc
+
+**Purpose**
+
+Returns the description of the item.
+
+**Parameters**
+
+* None
+
+**Returns**
+
+* string - The description of the item.
+
+**Realm**
+
+`Client.`
+
+**Example Usage**
+
+```lua
+print(item:getDesc())
+```
+
+---
+
+### getCategory
+
+**Purpose**
+
+Returns the category of the item with automatic localization.
+
+**Parameters**
+
+* None
+
+**Returns**
+
+* string - The localized category of the item.
+
+**Realm**
+
+`Shared.`
+
+**Example Usage**
+
+```lua
+print("Item category: " .. item:getCategory())
+```
+
+---
+

--- a/gamemode/core/meta/item.lua
+++ b/gamemode/core/meta/item.lua
@@ -10,229 +10,49 @@ ITEM.isStackable = false
 ITEM.quantity = 1
 ITEM.maxQuantity = 1
 ITEM.canSplit = true
---[[
-    isRotated
-
-    Purpose:
-        Checks if the item is currently rotated.
-
-    Returns:
-        boolean - True if the item is rotated, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if item:isRotated() then
-            print("The item is rotated!")
-        end
-]]
 function ITEM:isRotated()
     return self:getData("rotated", false)
 end
 
---[[
-    getWidth
-
-    Purpose:
-        Returns the width of the item, taking into account its rotation.
-
-    Returns:
-        number - The width of the item.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local width = item:getWidth()
-        print("Item width: " .. width)
-]]
 function ITEM:getWidth()
     return self:isRotated() and (self.height or 1) or self.width or 1
 end
 
---[[
-    getHeight
-
-    Purpose:
-        Returns the height of the item, taking into account its rotation.
-
-    Returns:
-        number - The height of the item.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local height = item:getHeight()
-        print("Item height: " .. height)
-]]
 function ITEM:getHeight()
     return self:isRotated() and (self.width or 1) or self.height or 1
 end
 
---[[
-    getQuantity
-
-    Purpose:
-        Returns the current quantity of the item.
-
-    Returns:
-        number - The quantity of the item.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        print("You have " .. item:getQuantity() .. " of this item.")
-]]
 function ITEM:getQuantity()
     if self.id == 0 then return self.maxQuantity end
     return self.quantity
 end
 
---[[
-    eq
-
-    Purpose:
-        Checks if this item is equal to another item by comparing their IDs.
-
-    Parameters:
-        other (Item) - The other item to compare.
-
-    Returns:
-        boolean - True if the items are equal, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if item:eq(otherItem) then
-            print("These items are the same instance.")
-        end
-]]
 function ITEM:eq(other)
     return self:getID() == other:getID()
 end
 
---[[
-    tostring
-
-    Purpose:
-        Returns a string representation of the item.
-
-    Returns:
-        string - The string representation of the item.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        print(item:tostring())
-]]
 function ITEM:tostring()
     return L("item") .. "[" .. self.uniqueID .. "][" .. self.id .. "]"
 end
 
---[[
-    getID
-
-    Purpose:
-        Returns the ID of the item.
-
-    Returns:
-        number - The ID of the item.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        print("Item ID: " .. item:getID())
-]]
 function ITEM:getID()
     return self.id
 end
 
---[[
-    getModel
-
-    Purpose:
-        Returns the model of the item.
-
-    Returns:
-        string - The model path of the item.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        print("Model path: " .. item:getModel())
-]]
 function ITEM:getModel()
     return self.model
 end
 
---[[
-    getSkin
-
-    Purpose:
-        Returns the skin index of the item.
-
-    Returns:
-        number - The skin index.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        print("Skin index: " .. tostring(item:getSkin()))
-]]
 function ITEM:getSkin()
     return self.skin
 end
 
---[[
-    getPrice
-
-    Purpose:
-        Returns the price of the item, using a custom calculation if available.
-
-    Returns:
-        number - The price of the item.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        print("Item price: " .. item:getPrice())
-]]
 function ITEM:getPrice()
     local price = self.price
     if self.calcPrice then price = self:calcPrice(self.price) end
     return price or 0
 end
 
---[[
-    call
-
-    Purpose:
-        Calls a method on the item, temporarily setting the player and entity context.
-
-    Parameters:
-        method (string) - The method name to call.
-        client (Player) - The player context.
-        entity (Entity) - The entity context.
-        ... - Additional arguments to pass to the method.
-
-    Returns:
-        ... - The return values of the called method.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        item:call("onUse", client, entity, arg1, arg2)
-]]
 function ITEM:call(method, client, entity, ...)
     local oldPlayer, oldEntity = self.player, self.entity
     self.player = client or self.player
@@ -249,24 +69,6 @@ function ITEM:call(method, client, entity, ...)
     self.entity = oldEntity
 end
 
---[[
-    getOwner
-
-    Purpose:
-        Returns the player who owns this item.
-
-    Returns:
-        Player - The owner of the item, or nil if not found.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local owner = item:getOwner()
-        if owner then
-            print("Item owner: " .. owner:Name())
-        end
-]]
 function ITEM:getOwner()
     local inventory = lia.inventory.instances[self.invID]
     if inventory and SERVER then return inventory:getRecipients()[1] end
@@ -277,25 +79,6 @@ function ITEM:getOwner()
     end
 end
 
---[[
-    getData
-
-    Purpose:
-        Returns the value of a data key for this item, checking both local and entity data.
-
-    Parameters:
-        key (string) - The data key to retrieve.
-        default (any) - The default value if the key is not found.
-
-    Returns:
-        any - The value of the data key, or the default.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local durability = item:getData("durability", 100)
-]]
 function ITEM:getData(key, default)
     self.data = self.data or {}
     local value = self.data[key]
@@ -308,21 +91,6 @@ function ITEM:getData(key, default)
     return default
 end
 
---[[
-    getAllData
-
-    Purpose:
-        Returns a table containing all data for this item, including entity data.
-
-    Returns:
-        table - A table of all data for the item.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        PrintTable(item:getAllData())
-]]
 function ITEM:getAllData()
     self.data = self.data or {}
     local fullData = table.Copy(self.data)
@@ -335,77 +103,18 @@ function ITEM:getAllData()
     return fullData
 end
 
---[[
-    hook
-
-    Purpose:
-        Registers a hook function for a specific event on this item.
-
-    Parameters:
-        name (string) - The name of the hook/event.
-        func (function) - The function to call.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        item:hook("onUse", function(self, data) print("Used!") end)
-]]
 function ITEM:hook(name, func)
     if name then self.hooks[name] = func end
 end
 
---[[
-    postHook
-
-    Purpose:
-        Registers a post-hook function for a specific event on this item.
-
-    Parameters:
-        name (string) - The name of the post-hook/event.
-        func (function) - The function to call.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        item:postHook("onUse", function(self, result, data) print("Post-use!") end)
-]]
 function ITEM:postHook(name, func)
     if name then self.postHooks[name] = func end
 end
 
---[[
-    onRegistered
-
-    Purpose:
-        Called when the item is registered. Precaches the model if set.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Called automatically when the item is registered.
-]]
 function ITEM:onRegistered()
     if self.model and isstring(self.model) then util.PrecacheModel(self.model) end
 end
 
---[[
-    print
-
-    Purpose:
-        Prints information about the item to the console.
-
-    Parameters:
-        detail (boolean) - Whether to print detailed information.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        item:print(true)
-]]
 function ITEM:print(detail)
     if detail then
         print(Format("%s[%s]: >> [%s](%s,%s)", self.uniqueID, self.id, self.owner, self.gridX, self.gridY))
@@ -414,18 +123,6 @@ function ITEM:print(detail)
     end
 end
 
---[[
-    printData
-
-    Purpose:
-        Prints all data associated with the item to the console.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        item:printData()
-]]
 function ITEM:printData()
     self:print(true)
     lia.information(L("itemData") .. ":")
@@ -435,63 +132,15 @@ function ITEM:printData()
 end
 
 if SERVER then
-    --[[
-        getName
-
-        Purpose:
-            Returns the name of the item.
-
-        Returns:
-            string - The name of the item.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            print(item:getName())
-    ]]
-    function ITEM:getName()
+        function ITEM:getName()
         return self.name
     end
 
-    --[[
-        getDesc
-
-        Purpose:
-            Returns the description of the item.
-
-        Returns:
-            string - The description of the item.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            print(item:getDesc())
-    ]]
-    function ITEM:getDesc()
+        function ITEM:getDesc()
         return self.desc
     end
 
-    --[[
-        removeFromInventory
-
-        Purpose:
-            Removes the item from its inventory.
-
-        Parameters:
-            preserveItem (boolean) - Whether to preserve the item instance.
-
-        Returns:
-            Deferred - A deferred object that resolves when removal is complete.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            item:removeFromInventory(true):next(function() print("Removed!") end)
-    ]]
-    function ITEM:removeFromInventory(preserveItem)
+        function ITEM:removeFromInventory(preserveItem)
         local inventory = lia.inventory.instances[self.invID]
         self.invID = 0
         if inventory then return inventory:removeItem(self:getID(), preserveItem) end
@@ -500,42 +149,12 @@ if SERVER then
         return d
     end
 
-    --[[
-        delete
-
-        Purpose:
-            Deletes the item from the database and calls onRemoved.
-
-        Returns:
-            Deferred - A deferred object that resolves when deletion is complete.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            item:delete():next(function() print("Deleted!") end)
-    ]]
-    function ITEM:delete()
+        function ITEM:delete()
         self:destroy()
         return lia.db.delete("items", "_itemID = " .. self:getID()):next(function() self:onRemoved() end)
     end
 
-    --[[
-        remove
-
-        Purpose:
-            Removes the item from the world and inventory, then deletes it.
-
-        Returns:
-            Deferred - A deferred object that resolves when removal is complete.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            item:remove():next(function() print("Item fully removed!") end)
-    ]]
-    function ITEM:remove()
+        function ITEM:remove()
         local d = deferred.new()
         if IsValid(self.entity) then SafeRemoveEntity(self.entity) end
         self:removeFromInventory():next(function()
@@ -545,19 +164,7 @@ if SERVER then
         return d
     end
 
-    --[[
-        destroy
-
-        Purpose:
-            Destroys the item instance and notifies clients.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            item:destroy()
-    ]]
-    function ITEM:destroy()
+        function ITEM:destroy()
         net.Start("liaItemDelete")
         net.WriteUInt(self:getID(), 32)
         net.Broadcast()
@@ -565,64 +172,17 @@ if SERVER then
         self:onDisposed()
     end
 
-    --[[
-        onDisposed
-
-        Purpose:
-            Called when the item is disposed.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            -- Override in your item definition if needed.
-    ]]
-    function ITEM:onDisposed()
+        function ITEM:onDisposed()
     end
 
-    --[[
-        getEntity
-
-        Purpose:
-            Returns the entity associated with this item.
-
-        Returns:
-            Entity - The entity, or nil if not found.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            local ent = item:getEntity()
-            if ent then print("Entity found!") end
-    ]]
-    function ITEM:getEntity()
+        function ITEM:getEntity()
         local id = self:getID()
         for _, v in ipairs(ents.FindByClass("lia_item")) do
             if v.liaItemID == id then return v end
         end
     end
 
-    --[[
-        spawn
-
-        Purpose:
-            Spawns the item as an entity in the world.
-
-        Parameters:
-            position (Vector or table or Player) - The position or player to drop at.
-            angles (Angle or table) - The angles to spawn with.
-
-        Returns:
-            Entity - The spawned entity, or nil if failed.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            local ent = item:spawn(Vector(0,0,0))
-    ]]
-    function ITEM:spawn(position, angles)
+        function ITEM:spawn(position, angles)
         local instance = lia.item.instances[self.id]
         if instance then
             if IsValid(instance.entity) then
@@ -673,108 +233,26 @@ if SERVER then
         end
     end
 
-    --[[
-        transfer
-
-        Purpose:
-            Transfers the item to a new inventory.
-
-        Parameters:
-            newInventory (Inventory) - The inventory to transfer to.
-            bBypass (boolean) - Whether to bypass access checks.
-
-        Returns:
-            boolean - True if transfer started, false otherwise.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            item:transfer(newInventory)
-    ]]
-    function ITEM:transfer(newInventory, bBypass)
+        function ITEM:transfer(newInventory, bBypass)
         if not bBypass and not newInventory:canAccess("transfer") then return false end
         local inventory = lia.inventory.instances[self.invID]
         inventory:removeItem(self.id, true):next(function() newInventory:add(self) end)
         return true
     end
 
-    --[[
-        onInstanced
-
-        Purpose:
-            Called when the item is instanced.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            -- Override in your item definition if needed.
-    ]]
-    function ITEM:onInstanced()
+        function ITEM:onInstanced()
     end
 
-    --[[
-        onSync
-
-        Purpose:
-            Called when the item is synced to a client.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            -- Override in your item definition if needed.
-    ]]
-    function ITEM:onSync()
+        function ITEM:onSync()
     end
 
-    --[[
-        onRemoved
-
-        Purpose:
-            Called when the item is removed.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            -- Override in your item definition if needed.
-    ]]
-    function ITEM:onRemoved()
+        function ITEM:onRemoved()
     end
 
-    --[[
-        onRestored
-
-        Purpose:
-            Called when the item is restored.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            -- Override in your item definition if needed.
-    ]]
-    function ITEM:onRestored()
+        function ITEM:onRestored()
     end
 
-    --[[
-        sync
-
-        Purpose:
-            Syncs the item instance to a recipient or all clients.
-
-        Parameters:
-            recipient (Player) - The player to sync to, or nil for all.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            item:sync(client)
-    ]]
-    function ITEM:sync(recipient)
+        function ITEM:sync(recipient)
         net.Start("liaItemInstance")
         net.WriteUInt(self:getID(), 32)
         net.WriteString(self.uniqueID)
@@ -790,26 +268,7 @@ if SERVER then
         self:onSync(recipient)
     end
 
-    --[[
-        setData
-
-        Purpose:
-            Sets a data key for the item and syncs it to clients and the database.
-
-        Parameters:
-            key (string) - The data key.
-            value (any) - The value to set.
-            receivers (Player or table) - The recipients to sync to.
-            noSave (boolean) - If true, do not save to the database.
-            noCheckEntity (boolean) - If true, do not update the entity.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            item:setData("durability", 50)
-    ]]
-    function ITEM:setData(key, value, receivers, noSave, noCheckEntity)
+        function ITEM:setData(key, value, receivers, noSave, noCheckEntity)
         self.data = self.data or {}
         self.data[key] = value
         if not noCheckEntity then
@@ -855,45 +314,11 @@ if SERVER then
         self.data.x, self.data.y = x, y
     end
 
-    --[[
-        addQuantity
-
-        Purpose:
-            Adds to the item's quantity and updates clients/entities.
-
-        Parameters:
-            quantity (number) - The amount to add.
-            receivers (Player or table) - The recipients to sync to.
-            noCheckEntity (boolean) - If true, do not update the entity.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            item:addQuantity(5)
-    ]]
-    function ITEM:addQuantity(quantity, receivers, noCheckEntity)
+        function ITEM:addQuantity(quantity, receivers, noCheckEntity)
         self:setQuantity(self:getQuantity() + quantity, receivers, noCheckEntity)
     end
 
-    --[[
-        setQuantity
-
-        Purpose:
-            Sets the item's quantity and updates clients/entities and the database.
-
-        Parameters:
-            quantity (number) - The new quantity.
-            receivers (Player or table) - The recipients to sync to.
-            noCheckEntity (boolean) - If true, do not update the entity.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            item:setQuantity(10)
-    ]]
-    function ITEM:setQuantity(quantity, receivers, noCheckEntity)
+        function ITEM:setQuantity(quantity, receivers, noCheckEntity)
         self.quantity = quantity
         if not noCheckEntity then
             local entity = self:getEntity()
@@ -921,28 +346,7 @@ if SERVER then
         end
     end
 
-    --[[
-        interact
-
-        Purpose:
-            Handles a player interaction with the item.
-
-        Parameters:
-            action (string) - The action to perform.
-            client (Player) - The player interacting.
-            entity (Entity) - The entity involved.
-            data (any) - Additional data for the interaction.
-
-        Returns:
-            boolean - True if the interaction was successful, false otherwise.
-
-        Realm:
-            Server.
-
-        Example Usage:
-            item:interact("use", client, entity, data)
-    ]]
-    function ITEM:interact(action, client, entity, data)
+        function ITEM:interact(action, client, entity, data)
         assert(client:IsPlayer() and IsValid(client), L("itemActionNoPlayer"))
         local canInteract, reason = hook.Run("CanPlayerInteractItem", client, action, self, data)
         if canInteract == false then
@@ -1010,60 +414,15 @@ if SERVER then
         return true
     end
 else
-    --[[
-        getName
-
-        Purpose:
-            Returns the name of the item.
-
-        Returns:
-            string - The name of the item.
-
-        Realm:
-            Client.
-
-        Example Usage:
-            print(item:getName())
-    ]]
-    function ITEM:getName()
+        function ITEM:getName()
         return self.name
     end
 
-    --[[
-        getDesc
-
-        Purpose:
-            Returns the description of the item.
-
-        Returns:
-            string - The description of the item.
-
-        Realm:
-            Client.
-
-        Example Usage:
-            print(item:getDesc())
-    ]]
-    function ITEM:getDesc()
+        function ITEM:getDesc()
         return self.desc
     end
 end
 
---[[
-    getCategory
-
-    Purpose:
-        Returns the category of the item with automatic localization.
-
-    Returns:
-        string - The localized category of the item.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        print("Item category: " .. item:getCategory())
-]]
 function ITEM:getCategory()
     return self.category and L(self.category) or L("misc")
 end


### PR DESCRIPTION
## Summary
- Replace `item` meta documentation with content parsed from code comments
- Strip inline documentation comments from `gamemode/core/meta/item.lua`

## Testing
- `luacheck gamemode/core/meta/item.lua` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: Unable to locate package luacheck)*

------
https://chatgpt.com/codex/tasks/task_e_68988c42764883279c33afb62fd41a03