### PR TITLE
Fix localization placeholder counting

### DIFF
--- a/gamemode/core/libraries/languages.lua
+++ b/gamemode/core/libraries/languages.lua
@@ -58,11 +58,7 @@ function L(key, ...)
         args[i] = tostring(select(i, ...) or "")
     end
 
-    local needed = 0
-    for _ in template:gmatch("%%s") do
-        needed = needed + 1
-    end
-
+    local needed = select(2, template:gsub("%%[^%%]", ""))
     for i = count + 1, needed do
         args[i] = ""
     end


### PR DESCRIPTION
## Summary
- handle any `%` placeholders in localization strings to avoid missing-argument errors

## Testing
- `luac -p gamemode/core/libraries/languages.lua`


------
https://chatgpt.com/codex/tasks/task_e_6899556c82b88327b4354959a69a3ad4