### PR TITLE
Ensure interaction menu callbacks persist

### DIFF
--- a/gamemode/modules/interactionmenu/libraries/client.lua
+++ b/gamemode/modules/interactionmenu/libraries/client.lua
@@ -118,6 +118,7 @@ local function openMenu(options, isInteraction, titleText, closeKey, netMsg)
             if entry.opt.runServer then
                 net.Start(netMsg)
                 net.WriteString(entry.name)
+                if isInteraction then net.WriteEntity(ent) end
                 net.SendToServer()
             end
         end

--- a/gamemode/modules/interactionmenu/libraries/server.lua
+++ b/gamemode/modules/interactionmenu/libraries/server.lua
@@ -24,6 +24,11 @@ net.Receive("TransferMoneyFromP2P", function(_, sender)
     target:notifyLocalized("moneyTransferReceived", lia.currency.get(amount), senderName)
 end)
 
+local function isWithinRange(client, entity)
+    if not IsValid(client) or not IsValid(entity) then return false end
+    return entity:GetPos():DistToSqr(client:GetPos()) < 250 * 250
+end
+
 net.Receive("RunOption", function(_, ply)
     if lia.config.get("DisableCheaterActions", true) and ply:getNetVar("cheater", false) then
         lia.log.add(ply, "cheaterAction", L("cheaterActionUseInteractionMenu"))
@@ -33,8 +38,10 @@ net.Receive("RunOption", function(_, ply)
 
     local name = net.ReadString()
     local opt = MODULE.Interactions[name]
-    local tracedEntity = ply:getTracedEntity()
-    if opt and opt.runServer and IsValid(tracedEntity) then opt.onRun(ply, tracedEntity) end
+    local tracedEntity = net.ReadEntity()
+    if opt and opt.runServer and IsValid(tracedEntity) and tracedEntity:IsPlayer() and isWithinRange(ply, tracedEntity) then
+        opt.onRun(ply, tracedEntity)
+    end
 end)
 
 net.Receive("RunLocalOption", function(_, ply)


### PR DESCRIPTION
## Summary
- Send the targeted entity with interaction menu requests so server always receives it
- Validate entity range server-side before running option callbacks

## Testing
- `luacheck gamemode/modules/interactionmenu/libraries/client.lua gamemode/modules/interactionmenu/libraries/server.lua` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68996a535e6c83278ab9f9c7a9c9bbab