### PR TITLE
docs: migrate player meta comments

### DIFF
--- a/documentation/docs/meta/player.md
+++ b/documentation/docs/meta/player.md
@@ -604,58 +604,32 @@ end
 
 ---
 
-### getTracedEntity
-
-**Purpose**
-
-Returns the entity that the player is looking at within a specified distance.
-
-**Parameters**
-
-* `distance` (`number`): The maximum distance to trace. Defaults to `96`.
-
-**Returns**
-
-* `Entity|nil`: The traced entity, or `nil` if no entity is found.
-
-**Realm**
-
-`Shared`
-
-**Example Usage**
-
-```lua
-local entity = player:getTracedEntity(150)
-if entity then
-    print("Player is looking at: " .. entity:GetClass())
-end
-```
-
----
 
 ### getTrace
 
 **Purpose**
 
-Returns a hull trace in front of the player.
+Performs a hull trace from the player's shoot position in the direction they are looking.
 
 **Parameters**
 
-* `distance` (`number|nil`): Hull length in units. Default is `200`.
-
-**Realm**
-
-`Shared`
+* distance (number) - The maximum distance to trace. Defaults to 200.
 
 **Returns**
 
-* `table`: Trace result.
+table - The trace result table containing hit information.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
--- Use a hull trace for melee attacks
-local tr = player:getTrace(48)
+    local trace = player:getTrace(300)
+    if trace.Hit then
+        print("Hit something at: " .. tostring(trace.HitPos))
+    end
 ```
 
 ---
@@ -664,29 +638,27 @@ local tr = player:getTrace(48)
 
 **Purpose**
 
-Returns the entity the player is looking at within a distance.
+Returns the entity the player is looking at within a specified distance using eye trace.
 
 **Parameters**
 
-* `distance` (`number|nil`): Maximum distance. Default is `150`.
-
-**Realm**
-
-`Shared`
+* distance (number) - The maximum distance to check. Defaults to 150.
 
 **Returns**
 
-* `Entity|nil`: The entity or `nil` if too far.
+Entity or nil - The entity being looked at, or nil if out of range.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
--- Show the name of the object being looked at
-local target = player:getEyeEnt(128)
-
-if IsValid(target) then
-    player:ChatPrint(string.format("Class: %s", target:GetClass()))
-end
+    local entity = player:getEyeEnt(200)
+    if entity then
+        print("Looking at: " .. entity:GetClass())
+    end
 ```
 
 ---
@@ -695,26 +667,24 @@ end
 
 **Purpose**
 
-Sends a plain notification message to the player.
+Sends a notification message to the player.
 
 **Parameters**
 
-* `message` (`string`): Text to display.
-
-**Realm**
-
-`Server`
+* message (string) - The message to display to the player.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
--- Send a welcome notification and log the join event
-player:notify("Welcome to the server!")
-file.Append("welcome.txt", player:SteamID() .. " joined\n")
+    player:notify("Welcome to the server!")
 ```
 
 ---
@@ -723,28 +693,25 @@ file.Append("welcome.txt", player:SteamID() .. " joined\n")
 
 **Purpose**
 
-Sends a localized notification to the player.
+Sends a localized notification message to the player.
 
 **Parameters**
 
-* `message` (`string`): Translation key.
-
-* `...`: Additional parameters for localization.
-
-**Realm**
-
-`Server`
+* message (string) - The localization key for the message.
+* ... (any) - Additional arguments to format the localized message.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
--- Send a localized message including the player's name and score
-local score = player:GetFrags()
-player:notifyLocalized("greeting_key", player:Name(), score)
+    player:notifyLocalized("welcome_message", player:Name())
 ```
 
 ---
@@ -753,52 +720,50 @@ player:notifyLocalized("greeting_key", player:Name(), score)
 
 **Purpose**
 
-Determines whether the player can edit the given vendor.
+Checks if the player can edit the specified vendor.
 
 **Parameters**
 
-* `vendor` (`Entity`): Vendor entity to check.
-
-**Realm**
-
-`Server`
+* vendor (Entity) - The vendor entity to check permissions for.
 
 **Returns**
 
-* `boolean`: `true` if allowed to edit.
+boolean - True if the player can edit the vendor, false otherwise.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-if player:CanEditVendor(vendor) then
-    vendor:OpenEditor(player)
-end
+    if player:CanEditVendor(vendorEntity) then
+        print("Player can edit this vendor")
+    end
 ```
 
 ---
+
 ### isStaff
 
 **Purpose**
 
-Returns `true` if the player belongs to a staff group.
-
-**Parameters**
-
-* None
-
-**Realm**
-
-`Shared`
+Checks if the player is a staff member based on their user group.
 
 **Returns**
 
-* `boolean`: Result from the privilege check.
+boolean - True if the player is staff, false otherwise.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
--- Verify staff permissions for administrative actions
-local result = player:isStaff()
+    if player:isStaff() then
+        print("Player is a staff member")
+    end
 ```
 
 ---
@@ -807,25 +772,22 @@ local result = player:isStaff()
 
 **Purpose**
 
-Checks whether the player is in the VIP group.
-
-**Parameters**
-
-* None
-
-**Realm**
-
-`Shared`
+Checks if the player is a VIP member based on their user group.
 
 **Returns**
 
-* `boolean`: Result from privilege check.
+boolean - True if the player is VIP, false otherwise.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
--- Test if the player has VIP status
-local result = player:isVIP()
+    if player:isVIP() then
+        print("Player is a VIP member")
+    end
 ```
 
 ---
@@ -834,25 +796,22 @@ local result = player:isVIP()
 
 **Purpose**
 
-Determines if the player is currently in the staff faction.
-
-**Parameters**
-
-* None
-
-**Realm**
-
-`Shared`
+Checks if the player is currently on duty as staff.
 
 **Returns**
 
-* `boolean`: `true` if staff faction is active.
+boolean - True if the player is on duty as staff, false otherwise.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
--- Confirm the player is currently in a staff role
-local result = player:isStaffOnDuty()
+    if player:isStaffOnDuty() then
+        print("Player is on duty as staff")
+    end
 ```
 
 ---
@@ -861,25 +820,26 @@ local result = player:isStaffOnDuty()
 
 **Purpose**
 
-Checks if the player's character belongs to the given faction.
+Checks if the player belongs to the specified faction.
 
 **Parameters**
 
-* `faction` (`number`): Faction index to compare.
-
-**Realm**
-
-`Shared`
+* faction (string) - The faction name to check against.
 
 **Returns**
 
-* `boolean`: `true` if the factions match.
+boolean or nil - True if the player belongs to the faction, false or nil otherwise.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
--- Compare the player's faction to a requirement
-local result = player:isFaction(faction)
+    if player:isFaction("police") then
+        print("Player is a police officer")
+    end
 ```
 
 ---
@@ -888,25 +848,26 @@ local result = player:isFaction(faction)
 
 **Purpose**
 
-Returns `true` if the player's character is of the given class.
+Checks if the player belongs to the specified class.
 
 **Parameters**
 
-* `class` (`number`): Class index to compare.
-
-**Realm**
-
-`Shared`
+* class (string) - The class name to check against.
 
 **Returns**
 
-* `boolean`: Whether the character matches the class.
+boolean or nil - True if the player belongs to the class, false or nil otherwise.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
--- Determine if the player's class matches
-local result = player:isClass(class)
+    if player:isClass("medic") then
+        print("Player is a medic")
+    end
 ```
 
 ---
@@ -915,25 +876,26 @@ local result = player:isClass(class)
 
 **Purpose**
 
-Determines if the player has whitelist access for a faction.
+Checks if the player has a whitelist for the specified faction.
 
 **Parameters**
 
-* `faction` (`number`): Faction index.
-
-**Realm**
-
-`Shared`
+* faction (string) - The faction name to check whitelist for.
 
 **Returns**
 
-* `boolean`: True if whitelisted.
+boolean - True if the player has a whitelist for the faction, false otherwise.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
--- Check for whitelist permission on a faction
-local result = player:hasWhitelist(faction)
+    if player:hasWhitelist("police") then
+        print("Player has police whitelist")
+    end
 ```
 
 ---
@@ -942,25 +904,23 @@ local result = player:hasWhitelist(faction)
 
 **Purpose**
 
-Retrieves the class index of the player's character.
-
-**Parameters**
-
-* None
-
-**Realm**
-
-`Shared`
+Returns the player's current class.
 
 **Returns**
 
-* `number|nil`: Class index or nil.
+string or nil - The player's class name, or nil if no character exists.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
--- Retrieve the current class index
-local result = player:getClass()
+    local class = player:getClass()
+    if class then
+        print("Player's class: " .. class)
+    end
 ```
 
 ---
@@ -969,25 +929,26 @@ local result = player:getClass()
 
 **Purpose**
 
-Checks if the player's character is whitelisted for a class.
+Checks if the player has a whitelist for the specified class.
 
 **Parameters**
 
-* `class` (`number`): Class index.
-
-**Realm**
-
-`Shared`
+* class (string) - The class name to check whitelist for.
 
 **Returns**
 
-* `boolean`: True if class whitelist exists.
+boolean - True if the player has a whitelist for the class, false otherwise.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
--- Verify the player is approved for a specific class
-local result = player:hasClassWhitelist(class)
+    if player:hasClassWhitelist("medic") then
+        print("Player has medic class whitelist")
+    end
 ```
 
 ---
@@ -996,25 +957,23 @@ local result = player:hasClassWhitelist(class)
 
 **Purpose**
 
-Returns the class table of the player's current class.
-
-**Parameters**
-
-* None
-
-**Realm**
-
-`Shared`
+Returns the data for the player's current class.
 
 **Returns**
 
-* `table|nil`: Class definition table.
+table or nil - The class data table, or nil if no character or class exists.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
--- Access data table for the player's class
-local result = player:getClassData()
+    local classData = player:getClassData()
+    if classData then
+        print("Class description: " .. classData.description)
+    end
 ```
 
 ---
@@ -1023,25 +982,27 @@ local result = player:getClassData()
 
 **Purpose**
 
-Compatibility helper for retrieving money with DarkRP-style calls.
+Returns DarkRP variable values for the player. Currently only supports "money" variable.
 
 **Parameters**
 
-* `var` (`string`): Currently only supports `"money"`.
-
-**Realm**
-
-`Shared`
+* var (string) - The DarkRP variable name to retrieve. Only "money" is currently supported.
 
 **Returns**
 
-* `number|nil`: Money amount or nil.
+number or nil - The value of the requested variable, or nil if not supported.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
--- Read money amount in a DarkRP-compatible way
-local result = player:getDarkRPVar(var)
+    local money = player:getDarkRPVar("money")
+    if money then
+        print("Player has " .. money .. " money")
+    end
 ```
 
 ---
@@ -1050,25 +1011,21 @@ local result = player:getDarkRPVar(var)
 
 **Purpose**
 
-Convenience function to get the character's money amount.
-
-**Parameters**
-
-* None
-
-**Realm**
-
-`Shared`
+Returns the player's current money amount from their character.
 
 **Returns**
 
-* `number`: Current funds or `0`.
+number - The player's current money amount, or 0 if no character exists.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
--- Fetch the character's stored funds
-local result = player:getMoney()
+    local money = player:getMoney()
+    print("Player has " .. money .. " money")
 ```
 
 ---
@@ -1077,25 +1034,26 @@ local result = player:getMoney()
 
 **Purpose**
 
-Checks if the player has enough money for a purchase.
+Checks if the player can afford a specified amount of money.
 
 **Parameters**
 
-* `amount` (`number`): Cost to test.
-
-**Realm**
-
-`Shared`
+* amount (number) - The amount of money to check.
 
 **Returns**
 
-* `boolean`: True if funds are sufficient.
+boolean - True if the player can afford the amount, false otherwise.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
--- Check if the player has enough money to buy something
-local result = player:canAfford(amount)
+    if player:canAfford(1000) then
+        print("Player can afford 1000")
+    end
 ```
 
 ---
@@ -1104,27 +1062,27 @@ local result = player:canAfford(amount)
 
 **Purpose**
 
-Verifies the player's character meets an attribute level.
+Checks if the player has a skill level at or above the specified level.
 
 **Parameters**
 
-* `skill` (`string`): Attribute ID.
-
-* `level` (`number`): Required level.
-
-**Realm**
-
-`Shared`
+* skill (string) - The skill name to check.
+* level (number) - The minimum skill level required.
 
 **Returns**
 
-* `boolean`: Whether the character satisfies the requirement.
+boolean - True if the player has the required skill level, false otherwise.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
--- Ensure the player meets a single skill requirement
-local result = player:hasSkillLevel(skill, level)
+    if player:hasSkillLevel("strength", 5) then
+        print("Player has strength level 5 or higher")
+    end
 ```
 
 ---
@@ -1133,25 +1091,27 @@ local result = player:hasSkillLevel(skill, level)
 
 **Purpose**
 
-Checks a table of skill requirements against the player.
+Checks if the player meets all the required skill levels for a set of skills.
 
 **Parameters**
 
-* `requiredSkillLevels` (`table`): Mapping of attribute IDs to levels.
-
-**Realm**
-
-`Shared`
+* requiredSkillLevels (table) - Table of skill names mapped to required levels.
 
 **Returns**
 
-* `boolean`: True if all requirements are met.
+boolean - True if the player meets all required skill levels, false otherwise.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
--- Validate multiple skill requirements at once
-local result = player:meetsRequiredSkills(requiredSkillLevels)
+    local required = {strength = 5, agility = 3}
+    if player:meetsRequiredSkills(required) then
+        print("Player meets all skill requirements")
+    end
 ```
 
 ---
@@ -1160,31 +1120,27 @@ local result = player:meetsRequiredSkills(requiredSkillLevels)
 
 **Purpose**
 
-Plays an animation sequence and optionally freezes the player.
+Forces the player to play a specific animation sequence.
 
 **Parameters**
 
-* `sequenceName` (`string`): Sequence to play.
-
-* `callback` (`function|nil`): Called when finished.
-
-* `time` (`number|nil`): Duration override.
-
-* `noFreeze` (`boolean`): Don't freeze movement when true.
-
-**Realm**
-
-`Shared`
+* sequenceName (string) - The name of the sequence to play.
+* callback (function) - Optional callback function to execute when sequence ends.
+* time (number) - Optional duration for the sequence. Defaults to sequence duration.
+* noFreeze (boolean) - If false, freezes player movement during sequence.
 
 **Returns**
 
-* `number|boolean`: Duration or `false` on failure.
+number or boolean - Duration of the sequence if successful, false if failed.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
--- Play an animation while freezing the player
-local result = player:forceSequence(sequenceName, callback, time, noFreeze)
+    local duration = player:forceSequence("sit", function() print("Sit sequence finished") end)
 ```
 
 ---
@@ -1193,25 +1149,20 @@ local result = player:forceSequence(sequenceName, callback, time, noFreeze)
 
 **Purpose**
 
-Stops any forced sequence and restores player movement.
-
-**Parameters**
-
-* None
-
-**Realm**
-
-`Shared`
+Stops the current forced sequence and restores normal player movement.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
--- Stop the player's forced animation sequence
-player:leaveSequence()
+    player:leaveSequence()
 ```
 
 ---
@@ -1220,25 +1171,24 @@ player:leaveSequence()
 
 **Purpose**
 
-Increases the player's stamina value.
+Restores the player's stamina by the specified amount.
 
 **Parameters**
 
-* `amount` (`number`): Amount to restore.
-
-**Realm**
-
-`Server`
+* amount (number) - The amount of stamina to restore.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
--- Give the player extra stamina points
-player:restoreStamina(amount)
+    player:restoreStamina(50)
 ```
 
 ---
@@ -1247,25 +1197,24 @@ player:restoreStamina(amount)
 
 **Purpose**
 
-Reduces the player's stamina value.
+Consumes the specified amount of stamina from the player.
 
 **Parameters**
 
-* `amount` (`number`): Amount to subtract.
-
-**Realm**
-
-`Server`
+* amount (number) - The amount of stamina to consume.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
--- Spend stamina as the player performs an action
-player:consumeStamina(amount)
+    player:consumeStamina(25)
 ```
 
 ---
@@ -1274,26 +1223,24 @@ player:consumeStamina(amount)
 
 **Purpose**
 
-Adds funds to the player's character, clamping to limits.
+Adds the specified amount of money to the player's character.
 
 **Parameters**
 
-* `amount` (`number`): Money to add.
-
-**Realm**
-
-`Server`
+* amount (number) - The amount of money to add.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
--- Reward the player and announce the payout
-player:addMoney(100)
-player:notifyLocalized("questReward", lia.currency.get(100))
+    player:addMoney(1000)
 ```
 
 ---
@@ -1302,25 +1249,24 @@ player:notifyLocalized("questReward", lia.currency.get(100))
 
 **Purpose**
 
-Removes money from the player's character.
+Removes the specified amount of money from the player's character.
 
 **Parameters**
 
-* `amount` (`number`): Amount to subtract.
-
-**Realm**
-
-`Server`
+* amount (number) - The amount of money to remove.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
--- Remove money from the player's character
-player:takeMoney(amount)
+    player:takeMoney(500)
 ```
 
 ---
@@ -1329,25 +1275,20 @@ player:takeMoney(amount)
 
 **Purpose**
 
-Grants whitelist access to every registered class.
-
-**Parameters**
-
-* None
-
-**Realm**
-
-`Server`
+Grants the player access to all available classes.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
--- Unlock every class for the player
-player:WhitelistAllClasses()
+    player:WhitelistAllClasses()
 ```
 
 ---
@@ -1356,24 +1297,20 @@ player:WhitelistAllClasses()
 
 **Purpose**
 
-Whitelists the player for all factions.
-
-**Parameters**
-
-* None
-
-**Realm**
-
-`Server`
+Grants the player access to all available factions.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:WhitelistAllFactions()
+    player:WhitelistAllFactions()
 ```
 
 ---
@@ -1382,25 +1319,20 @@ player:WhitelistAllFactions()
 
 **Purpose**
 
-Convenience method to whitelist all factions and classes.
-
-**Parameters**
-
-* None
-
-**Realm**
-
-`Server`
+Grants the player access to all available factions and classes.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
--- Give the player access to all content
-player:WhitelistEverything()
+    player:WhitelistEverything()
 ```
 
 ---
@@ -1409,24 +1341,24 @@ player:WhitelistEverything()
 
 **Purpose**
 
-Adds a single class to the character's whitelist table.
+Grants the player access to a specific class.
 
 **Parameters**
 
-* `class` (`number`): Class index to whitelist.
-
-**Realm**
-
-`Server`
+* class (string) - The class name to whitelist.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:classWhitelist(CLASS_MEDIC)
+    player:classWhitelist("medic")
 ```
 
 ---
@@ -1435,24 +1367,24 @@ player:classWhitelist(CLASS_MEDIC)
 
 **Purpose**
 
-Removes a class from the character's whitelist table.
+Removes the player's access to a specific class.
 
 **Parameters**
 
-* `class` (`number`): Class index to remove.
-
-**Realm**
-
-`Server`
+* class (string) - The class name to remove whitelist for.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:classUnWhitelist(CLASS_MEDIC)
+    player:classUnWhitelist("medic")
 ```
 
 ---
@@ -1461,26 +1393,25 @@ player:classUnWhitelist(CLASS_MEDIC)
 
 **Purpose**
 
-Sets or clears whitelist permission for a faction.
+Sets the whitelist status for a specific faction for the player.
 
 **Parameters**
 
-* `faction` (`number`): Faction index.
-
-* `whitelisted` (`boolean|nil`): Enable when true, disable when false/nil.
-
-**Realm**
-
-`Server`
+* faction (string) - The faction name to set whitelist for.
+* whitelisted (boolean) - Whether to whitelist or remove whitelist.
 
 **Returns**
 
-* `boolean`: True if the faction exists.
+boolean - True if the operation was successful, false otherwise.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:setWhitelisted(FACTION_POLICE, true)
+    player:setWhitelisted("police", true)
 ```
 
 ---
@@ -1489,24 +1420,24 @@ player:setWhitelisted(FACTION_POLICE, true)
 
 **Purpose**
 
-Loads persistent Lilia data for the player from the database.
+Loads the player's Lilia data from the database.
 
 **Parameters**
 
-* `callback` (`function|nil`): Invoked with the loaded table.
-
-**Realm**
-
-`Server`
+* callback (function) - Optional callback function to execute after loading.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:loadLiliaData(function(data) print(data) end)
+    player:loadLiliaData(function(data) print("Data loaded") end)
 ```
 
 ---
@@ -1515,24 +1446,20 @@ player:loadLiliaData(function(data) print(data) end)
 
 **Purpose**
 
-Saves the player's Lilia data back to the database.
-
-**Parameters**
-
-* None
-
-**Realm**
-
-`Server`
+Saves the player's Lilia data to the database, including online time tracking and other persistent data.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:saveLiliaData()
+    player:saveLiliaData()
 ```
 
 ---
@@ -1541,28 +1468,27 @@ player:saveLiliaData()
 
 **Purpose**
 
-Stores a value in the player's persistent data table.
+Sets a key-value pair in the player's Lilia data and optionally syncs it to the client and saves to database.
 
 **Parameters**
 
-* `key` (`string`): Data key.
-
-* `value` (`any`): Value to store.
-
-* `noNetworking` (`boolean|nil`): Skip network update when true.
-
-**Realm**
-
-`Server`
+* key (string) - The data key to set.
+* value (any) - The value to store.
+* noNetworking (boolean) - If true, doesn't sync to client.
+* noSave (boolean) - If true, doesn't save to database.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:setLiliaData("settings", {foo = true})
+    player:setLiliaData("customFlag", true)
 ```
 
 ---
@@ -1571,26 +1497,25 @@ player:setLiliaData("settings", {foo = true})
 
 **Purpose**
 
-Sends a waypoint to the client at the specified position.
+Sets a waypoint for the player at the specified location.
 
 **Parameters**
 
-* `name` (`string`): Display label.
-
-* `vector` (`Vector`): World position.
-
-**Realm**
-
-`Server`
+* name (string) - The name of the waypoint.
+* vector (Vector) - The position where the waypoint should be set.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:setWaypoint("Objective", vector_origin)
+    player:setWaypoint("Home", Vector(100, 200, 300))
 ```
 
 ---
@@ -1599,26 +1524,25 @@ player:setWaypoint("Objective", vector_origin)
 
 **Purpose**
 
-Alias of `setWaypoint()` for backwards compatibility.
+Sets a waypoint for the player (alias for setWaypoint).
 
 **Parameters**
 
-* `name` (`string`): Display label.
-
-* `vector` (`Vector`): World position.
-
-**Realm**
-
-`Server`
+* name (string) - The name of the waypoint.
+* vector (Vector) - The position where the waypoint should be set.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:setWeighPoint("Target", Vector(100, 100, 0))
+    player:setWeighPoint("Home", Vector(100, 200, 300))
 ```
 
 ---
@@ -1627,28 +1551,26 @@ player:setWeighPoint("Target", Vector(100, 100, 0))
 
 **Purpose**
 
-Creates a waypoint using a custom logo material.
+Sets a waypoint for the player with a custom logo/icon.
 
 **Parameters**
 
-* `name` (`string`): Display label.
-
-* `vector` (`Vector`): World position.
-
-* `logo` (`string`): Material path for the icon.
-
-**Realm**
-
-`Server`
+* name (string) - The name of the waypoint.
+* vector (Vector) - The position where the waypoint should be set.
+* logo (string) - The logo/icon identifier for the waypoint.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:setWaypointWithLogo("Objective", vector_origin, "path/to/icon.png")
+    player:setWaypointWithLogo("Store", Vector(500, 600, 700), "store_icon")
 ```
 
 ---
@@ -1657,54 +1579,25 @@ player:setWaypointWithLogo("Objective", vector_origin, "path/to/icon.png")
 
 **Purpose**
 
-Retrieves a stored value from the player's data table.
+Retrieves a value from the player's Lilia data storage.
 
 **Parameters**
 
-* `key` (`string`): Data key.
-
-* `default` (`any`): Returned if the key is nil.
-
-**Realm**
-
-`Server`
+* key (string) - The data key to retrieve.
+* default (any) - The default value to return if the key doesn't exist.
 
 **Returns**
 
-* `any`: Stored value or default.
+any - The stored value or the default value if not found.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-local settings = player:getLiliaData("settings", {})
-```
-
----
-
-### getData
-
-**Purpose**
-
-Alias of `getLiliaData`.
-
-**Parameters**
-
-* `key` (`string`): Data key.
-
-* `default` (`any`): Returned if the key is nil.
-
-**Realm**
-
-`Server`
-
-**Returns**
-
-* `any`: Stored value or default.
-
-**Example Usage**
-
-```lua
-local settings = player:getData("settings", {})
+    local customFlag = player:getLiliaData("customFlag", false)
 ```
 
 ---
@@ -1713,24 +1606,23 @@ local settings = player:getData("settings", {})
 
 **Purpose**
 
-Returns the entire table of persistent data for the player.
-
-**Parameters**
-
-* None
-
-**Realm**
-
-`Server`
+Returns all of the player's Lilia data as a table.
 
 **Returns**
 
-* `table`: Player data table.
+table - The complete Lilia data table for the player.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-local data = player:getAllLiliaData()
+    local allData = player:getAllLiliaData()
+    for key, value in pairs(allData) do
+        print(key .. ": " .. tostring(value))
+    end
 ```
 
 ---
@@ -1741,25 +1633,21 @@ local data = player:getAllLiliaData()
 
 Returns the flags associated with the player's character.
 
-**Parameters**
+**Returns**
 
-* None
+string - The character's flags, or empty string if no character exists.
 
 **Realm**
 
-`Shared`
-
-**Returns**
-
-* `string`: Character flags or empty string.
+Shared.
 
 **Example Usage**
 
 ```lua
-local flags = player:getFlags()
-if flags:find("a") then
-    print("Player has admin flag")
-end
+    local flags = player:getFlags()
+    if flags:find("a") then
+        print("Player has admin flag")
+    end
 ```
 
 ---
@@ -1768,24 +1656,25 @@ end
 
 **Purpose**
 
-Replaces the character's flag string.
+Sets the flags for the player's character.
 
 **Parameters**
 
-* `flags` (`string`): Flags to assign.
-
-**Realm**
-
-`Shared`
+* flags (string) - The flags to set for the character.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-player:setFlags("ab")
+    player:setFlags("a")
+    print("Player now has admin flag")
 ```
 
 ---
@@ -1794,24 +1683,25 @@ player:setFlags("ab")
 
 **Purpose**
 
-Adds flags to the character.
+Gives flags to the player's character.
 
 **Parameters**
 
-* `flags` (`string`): Flags to add.
-
-**Realm**
-
-`Shared`
+* flags (string) - The flags to give to the character.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-player:giveFlags("a")
+    player:giveFlags("a")
+    print("Player now has admin flag")
 ```
 
 ---
@@ -1820,24 +1710,25 @@ player:giveFlags("a")
 
 **Purpose**
 
-Removes flags from the character.
+Removes flags from the player's character.
 
 **Parameters**
 
-* `flags` (`string`): Flags to remove.
-
-**Realm**
-
-`Shared`
+* flags (string) - The flags to remove from the character.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-player:takeFlags("a")
+    player:takeFlags("a")
+    print("Player no longer has admin flag")
 ```
 
 ---
@@ -1846,24 +1737,21 @@ player:takeFlags("a")
 
 **Purpose**
 
-Gets the player's personal flag string.
-
-**Parameters**
-
-* None
-
-**Realm**
-
-`Shared`
+Returns the player's personal flags.
 
 **Returns**
 
-* `string`: Player-specific flags.
+string - The player's personal flags.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-local pf = player:getPlayerFlags()
+    local flags = player:getPlayerFlags()
+    print("Player flags: " .. flags)
 ```
 
 ---
@@ -1876,20 +1764,21 @@ Sets the player's personal flags.
 
 **Parameters**
 
-* `flags` (`string`): Flags to assign.
-
-**Realm**
-
-`Shared`
+* flags (string) - The flags to set.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-player:setPlayerFlags("v")
+    player:setPlayerFlags("v")
+    print("Player now has VIP flag")
 ```
 
 ---
@@ -1898,26 +1787,26 @@ player:setPlayerFlags("v")
 
 **Purpose**
 
-Checks for any of the specified personal flags.
+Checks if the player has specific personal flags.
 
 **Parameters**
 
-* `flags` (`string`): Flags to check.
-
-**Realm**
-
-`Shared`
+* flags (string) - the flags to check for.
 
 **Returns**
 
-* `boolean`: Whether any flag is present.
+boolean - True if the player has any of the specified flags.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-if player:hasPlayerFlags("v") then
-    print("Player is VIP")
-end
+    if player:hasPlayerFlags("v") then
+        print("Player has VIP flag")
+    end
 ```
 
 ---
@@ -1926,24 +1815,25 @@ end
 
 **Purpose**
 
-Adds personal flags to the player.
+Gives personal flags to the player.
 
 **Parameters**
 
-* `flags` (`string`): Flags to add.
-
-**Realm**
-
-`Shared`
+* flags (string) - The flags to give.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-player:givePlayerFlags("v")
+    player:givePlayerFlags("v")
+    print("Player now has VIP flag")
 ```
 
 ---
@@ -1956,20 +1846,21 @@ Removes personal flags from the player.
 
 **Parameters**
 
-* `flags` (`string`): Flags to remove.
-
-**Realm**
-
-`Shared`
+* flags (string) - The flags to remove.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-player:takePlayerFlags("v")
+    player:takePlayerFlags("v")
+    print("Player no longer has VIP flag")
 ```
 
 ---
@@ -1978,26 +1869,26 @@ player:takePlayerFlags("v")
 
 **Purpose**
 
-Checks both character and personal flags for any of the supplied flags.
+Checks if the player has specific flags (character or personal).
 
 **Parameters**
 
-* `flags` (`string`): Flags to check.
-
-**Realm**
-
-`Shared`
+* flags (string) - The flags to check for.
 
 **Returns**
 
-* `boolean`: True if any flag is present.
+boolean - True if the player has any of the specified flags.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-if player:hasFlags("a") then
-    print("Has admin access")
-end
+    if player:hasFlags("a") then
+        print("Player has admin flag")
+    end
 ```
 
 ---
@@ -2006,24 +1897,24 @@ end
 
 **Purpose**
 
-Associates a ragdoll entity with the player for later retrieval.
+Sets the player's ragdoll entity.
 
 **Parameters**
 
-* `entity` (`Entity`): The ragdoll entity.
-
-**Realm**
-
-`Server`
+* entity (Entity) - The ragdoll entity to set.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:setRagdoll(ragdollEnt)
+    player:setRagdoll(ragdollEntity)
 ```
 
 ---
@@ -2032,28 +1923,25 @@ player:setRagdoll(ragdollEnt)
 
 **Purpose**
 
-Broadcasts animation bone data to all clients.
+Networks animation status to all clients.
 
 **Parameters**
 
-* `active` (`boolean`): Enable or disable manipulation.
-
-* `boneData` (`table`): Map of bone names to angles.
-
-**Realm**
-
-`Server`
+* active (boolean) - Whether the animation is active.
+* boneData (table) - The bone data for the animation.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:NetworkAnimation(true, {
-    ["ValveBiped.Bip01_Head"] = Angle(0, 90, 0)
-})
+    player:NetworkAnimation(true, boneData)
 ```
 
 ---
@@ -2062,28 +1950,26 @@ player:NetworkAnimation(true, {
 
 **Purpose**
 
-Bans the player for a given reason and duration then kicks them.
+Bans the player from the server.
 
 **Parameters**
 
-* `reason` (`string|nil`): Message shown to the player.
-
-* `duration` (`number|nil`): Length in minutes, or `nil` for permanent.
-
-* `banner` (`Player|nil`): Player issuing the ban.
-
-**Realm**
-
-`Server`
+* reason (string) - The reason for the ban.
+* duration (number) - The duration of the ban in seconds.
+* banner (Player) - The player who issued the ban.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:banPlayer("Breaking rules", 60, admin)
+    player:banPlayer("Breaking rules", 3600, adminPlayer)
 ```
 
 ---
@@ -2092,28 +1978,26 @@ player:banPlayer("Breaking rules", 60, admin)
 
 **Purpose**
 
-Displays an action bar for a set duration and optionally runs a callback.
+Sets an action bar for the player with optional callback.
 
 **Parameters**
 
-* `text` (`string|nil`): Text to display, or nil to clear.
-
-* `time` (`number|nil`): How long to show it for in seconds. Defaults to 5. If `time` ≤ 0, the callback runs immediately with no bar.
-
-* `callback` (`function|nil`): Executed when time elapses.
-
-**Realm**
-
-`Server`
+* text (string) - The text to display in the action bar.
+* time (number) - The duration of the action bar.
+* callback (function) - Optional callback function when action completes.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:setAction("Lockpicking", 5)
+    player:setAction("Loading...", 5, function() print("Action complete") end)
 ```
 
 ---
@@ -2122,32 +2006,28 @@ player:setAction("Lockpicking", 5)
 
 **Purpose**
 
-Runs an action only while the player stares at the entity.
+Performs an action that requires the player to stare at an entity.
 
 **Parameters**
 
-* `entity` (`Entity`): Target entity.
-
-* `callback` (`function`): Called when the timer finishes.
-
-* `time` (`number`): Duration in seconds.
-
-* `onCancel` (`function|nil`): Called if gaze breaks.
-
-* `distance` (`number|nil`): Max distance to maintain, defaults to 96.
-
-**Realm**
-
-`Server`
+* entity (Entity) - The entity to stare at.
+* callback (function) - Function to call when action completes.
+* time (number) - Time required to complete the action.
+* onCancel (function) - Function to call if action is cancelled.
+* distance (number) - Maximum distance to perform action.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:doStaredAction(door, function() door:Open() end, 3)
+    player:doStaredAction(targetEntity, function() print("Action done") end, 3)
 ```
 
 ---
@@ -2156,24 +2036,20 @@ player:doStaredAction(door, function() door:Open() end, 3)
 
 **Purpose**
 
-Cancels any running action bar on the player.
-
-**Parameters**
-
-* None
-
-**Realm**
-
-`Server`
+Stops the current action bar.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:stopAction()
+    player:stopAction()
 ```
 
 ---
@@ -2182,30 +2058,27 @@ player:stopAction()
 
 **Purpose**
 
-Prompts the client with a dropdown selection dialog.
+Requests a dropdown selection from the player.
 
 **Parameters**
 
-* `title` (`string`): Window title.
-
-* `subTitle` (`string`): Description text.
-
-* `options` (`table`): Table of options.
-
-* `callback` (`function|nil`): Receives the chosen value.
-
-**Realm**
-
-`Server`
+* title (string) - The title of the dropdown.
+* subTitle (string) - The subtitle of the dropdown.
+* options (table) - The options to choose from.
+* callback (function) - Function to call when selection is made.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:requestDropdown("Choose", "Pick one", {"A", "B"}, print)
+    player:requestDropdown("Choose", "Select an option", {"Option 1", "Option 2"}, callback)
 ```
 
 ---
@@ -2214,32 +2087,28 @@ player:requestDropdown("Choose", "Pick one", {"A", "B"}, print)
 
 **Purpose**
 
-Asks the client to select one or more options from a list.
+Requests multiple option selections from the player.
 
 **Parameters**
 
-* `title` (`string`): Window title.
-
-* `subTitle` (`string`): Description text.
-
-* `options` (`table`): Available options.
-
-* `limit` (`number`): Maximum selections allowed.
-
-* `callback` (`function|nil`): Receives the chosen values.
-
-**Realm**
-
-`Server`
+* title (string) - The title of the request.
+* subTitle (string) - The subtitle of the request.
+* options (table) - The options to choose from.
+* limit (number) - Maximum number of selections allowed.
+* callback (function) - Function to call when selection is made.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:requestOptions("Permissions", "Select", {"A", "B"}, 2, print)
+    player:requestOptions("Choose", "Select options", {"A", "B", "C"}, 2, callback)
 ```
 
 ---
@@ -2248,30 +2117,27 @@ player:requestOptions("Permissions", "Select", {"A", "B"}, 2, print)
 
 **Purpose**
 
-Requests a string from the client.
+Requests a string input from the player.
 
 **Parameters**
 
-* `title` (`string`): Prompt title.
-
-* `subTitle` (`string`): Prompt description.
-
-* `callback` (`function|nil`): Called with the string.
-
-* `default` (`string|nil`): Default value.
-
-**Realm**
-
-`Server`
+* title (string) - The title of the request.
+* subTitle (string) - The subtitle of the request.
+* callback (function) - Function to call when string is entered.
+* default (string) - Default value for the input.
 
 **Returns**
 
-* `Deferred|nil`: Deferred object when no callback supplied.
+Deferred object or nil.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:requestString("Name", "Enter text", print)
+    local deferred = player:requestString("Name", "Enter your name", callback, "Default")
 ```
 
 ---
@@ -2280,28 +2146,26 @@ player:requestString("Name", "Enter text", print)
 
 **Purpose**
 
-Prompts the client for multiple typed values.
+Requests multiple arguments from the player.
 
 **Parameters**
 
-* `title` (`string`): Window title.
-
-* `argTypes` (`table`): Field definitions.
-
-* `callback` (`function|nil`): Called with a table of values.
-
-**Realm**
-
-`Server`
+* title (string) - The title of the request.
+* argTypes (table) - The types of arguments to request.
+* callback (function) - Function to call when arguments are entered.
 
 **Returns**
 
-* `Deferred|nil`: Deferred object when no callback supplied.
+Deferred object or nil.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:requestArguments("Info", {Name = "string", Age = "int"}, print)
+    local deferred = player:requestArguments("Input", {"string", "number"}, callback)
 ```
 
 ---
@@ -2310,32 +2174,28 @@ player:requestArguments("Info", {Name = "string", Age = "int"}, print)
 
 **Purpose**
 
-Displays a yes/no style question to the player.
+Asks the player a yes/no question.
 
 **Parameters**
 
-* `question` (`string`): Main text.
-
-* `option1` (`string`): Text for the first option.
-
-* `option2` (`string`): Text for the second option.
-
-* `manualDismiss` (`boolean`): Require manual closing.
-
-* `callback` (`function`): Called with chosen value.
-
-**Realm**
-
-`Server`
+* question (string) - The question to ask.
+* option1 (string) - The first option text.
+* option2 (string) - The second option text.
+* manualDismiss (boolean) - Whether the player can manually dismiss.
+* callback (function) - Function to call when answer is given.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:binaryQuestion("Proceed?", "Yes", "No", false, print)
+    player:binaryQuestion("Continue?", "Yes", "No", false, callback)
 ```
 
 ---
@@ -2344,29 +2204,25 @@ player:binaryQuestion("Proceed?", "Yes", "No", false, print)
 
 **Purpose**
 
-Prompts the player with multiple buttons that each trigger a server callback.
+Requests button selection from the player.
 
 **Parameters**
 
-* `title` (`string`): Window title.
-
-* `buttons` (`table`): Array where each element contains button text and a callback.
-
-**Realm**
-
-`Server`
+* title (string) - The title of the request.
+* buttons (table) - Table of button data with text and callbacks.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:requestButtons("Select one", {
-    {"A", function(client) print("Chose A") end},
-    {"B", function(client) print("Chose B") end}
-})
+    player:requestButtons("Choose", {{text = "Button 1", callback = func1}, {text = "Button 2", callback = func2}})
 ```
 
 ---
@@ -2375,24 +2231,21 @@ player:requestButtons("Select one", {
 
 **Purpose**
 
-Calculates how long the player has been on the server.
-
-**Parameters**
-
-* None
-
-**Realm**
-
-`Server`
+Returns the player's total play time.
 
 **Returns**
 
-* `number`: Total seconds of play-time.
+number - The player's total play time in seconds.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-print(player:getPlayTime())
+    local playTime = player:getPlayTime()
+    print("Player has played for " .. playTime .. " seconds")
 ```
 
 ---
@@ -2401,24 +2254,21 @@ print(player:getPlayTime())
 
 **Purpose**
 
-Returns how long the player has been connected in the current session.
-
-**Parameters**
-
-* None
-
-**Realm**
-
-`Server`
+Returns the player's current session time.
 
 **Returns**
 
-* `number`: Seconds since the player joined this session.
+number - The current session time in seconds.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-print(player:getSessionTime())
+    local sessionTime = player:getSessionTime()
+    print("Current session: " .. sessionTime .. " seconds")
 ```
 
 ---
@@ -2427,24 +2277,21 @@ print(player:getSessionTime())
 
 **Purpose**
 
-Returns the player's total online time across all sessions.
-
-**Parameters**
-
-* None
-
-**Realm**
-
-`Server`
+Returns the player's total online time including current session.
 
 **Returns**
 
-* `number`: Seconds spent online in total.
+number - The total online time in seconds.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-print(player:getTotalOnlineTime())
+    local totalTime = player:getTotalOnlineTime()
+    print("Total online time: " .. totalTime .. " seconds")
 ```
 
 ---
@@ -2453,24 +2300,21 @@ print(player:getTotalOnlineTime())
 
 **Purpose**
 
-Returns how long ago the player was last seen online.
-
-**Parameters**
-
-* None
-
-**Realm**
-
-`Server`
+Returns a human-readable string of when the player was last online.
 
 **Returns**
 
-* `string`: Human readable time description.
+string - Human-readable time since last online.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-print("Last online:", player:getLastOnline())
+    local lastOnline = player:getLastOnline()
+    print("Last online: " .. lastOnline)
 ```
 
 ---
@@ -2479,24 +2323,21 @@ print("Last online:", player:getLastOnline())
 
 **Purpose**
 
-Provides the timestamp of the player's last connection.
-
-**Parameters**
-
-* None
-
-**Realm**
-
-`Server`
+Returns the timestamp of when the player was last online.
 
 **Returns**
 
-* `number`: Unix time of the last session end.
+number - Unix timestamp of last online time.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-local ts = player:getLastOnlineTime()
+    local lastTime = player:getLastOnlineTime()
+    print("Last online timestamp: " .. lastTime)
 ```
 
 ---
@@ -2505,26 +2346,25 @@ local ts = player:getLastOnlineTime()
 
 **Purpose**
 
-Spawns a ragdoll copy of the player and optionally freezes it.
+Creates a ragdoll entity for the player.
 
 **Parameters**
 
-* `freeze` (`boolean|nil`): Disable physics when `true`.
-
-* `isDead` (`boolean|nil`): Mark as a death ragdoll.
-
-**Realm**
-
-`Server`
+* freeze (boolean) - Whether to freeze the ragdoll physics.
+* isDead (boolean) - Whether this ragdoll represents a dead player.
 
 **Returns**
 
-* `Entity`: The created ragdoll.
+Entity - The created ragdoll entity.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-local rag = player:createRagdoll(true)
+    local ragdoll = player:createRagdoll(false, true)
 ```
 
 ---
@@ -2533,30 +2373,27 @@ local rag = player:createRagdoll(true)
 
 **Purpose**
 
-Toggles the player's ragdoll state for a duration.
+Sets the player's ragdoll state.
 
 **Parameters**
 
-* `state` (`boolean`): Enable or disable ragdoll.
-
-* `time` (`number|nil`): Duration before standing up.
-
-* `getUpGrace` (`number|nil`): Extra time to prevent early stand.
-
-* `getUpMessage` (`string|nil`): Message while downed.
-
-**Realm**
-
-`Server`
+* state (boolean) - Whether to ragdoll the player.
+* time (number) - Time before auto-recovery.
+* getUpGrace (number) - Grace period for getting up.
+* getUpMessage (string) - Message to show during recovery.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:setRagdolled(true, 5)
+    player:setRagdolled(true, 5, 2, "Getting up...")
 ```
 
 ---
@@ -2565,24 +2402,26 @@ player:setRagdolled(true, 5)
 
 **Purpose**
 
-Sends all networked variables to the player.
+Synchronizes all networked variables for this player with the client.
+    Sends global variables and entity-specific variables through networking.
 
 **Parameters**
 
-* None
-
-**Realm**
-
-`Server`
+* None.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:syncVars()
+    -- Sync all variables for a player
+    player:syncVars()
 ```
 
 ---
@@ -2591,26 +2430,85 @@ player:syncVars()
 
 **Purpose**
 
-Sets a networked local variable on the player and triggers the **LocalVarChanged** hook.
+Sets a local variable for this player and synchronizes it to the client.
+    The variable is stored locally and sent through networking.
 
 **Parameters**
 
-* `key` (`string`): Variable name.
-
-* `value` (`any`): Value to set.
-
-**Realm**
-
-`Server`
+* key (string) - The key/name of the variable.
+* value (any) - The value to store.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Server.
 
 **Example Usage**
 
 ```lua
-player:setLocalVar("health", 75)
+    -- Set a local variable for a player
+    player:setLocalVar("customFlag", true)
+```
+
+---
+
+### CanOverrideView
+
+**Purpose**
+
+Determines if the player can override their view (third person).
+    Checks various conditions like ragdoll state, vehicle status, and configuration.
+
+**Parameters**
+
+* None.
+
+**Returns**
+
+boolean - True if the player can override their view, false otherwise.
+
+**Realm**
+
+Client.
+
+**Example Usage**
+
+```lua
+    if player:CanOverrideView() then
+        print("Player can use third person view")
+    end
+```
+
+---
+
+### IsInThirdPerson
+
+**Purpose**
+
+Checks if the player is currently in third person view mode.
+    Considers both global configuration and player preferences.
+
+**Parameters**
+
+* None.
+
+**Returns**
+
+boolean - True if third person is enabled, false otherwise.
+
+**Realm**
+
+Client.
+
+**Example Usage**
+
+```lua
+    if player:IsInThirdPerson() then
+        print("Player is in third person view")
+    end
 ```
 
 ---
@@ -2619,24 +2517,26 @@ player:setLocalVar("health", 75)
 
 **Purpose**
 
-Returns play-time calculated client-side when called on a client.
+Gets the total play time for this player, including current session.
+    Considers character login time and previous play time.
 
 **Parameters**
 
-* None
-
-**Realm**
-
-`Client`
+* None.
 
 **Returns**
 
-* `number`: Seconds of play-time.
+number - Total play time in seconds.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-print(LocalPlayer():getPlayTime())
+    local playTime = player:getPlayTime()
+    print("Total play time: " .. playTime .. " seconds")
 ```
 
 ---
@@ -2645,24 +2545,26 @@ print(LocalPlayer():getPlayTime())
 
 **Purpose**
 
-Returns the player's total online time on the client side.
+Gets the total time this player has been online across all sessions.
+    Includes stored time and current session time.
 
 **Parameters**
 
-* None
-
-**Realm**
-
-`Client`
+* None.
 
 **Returns**
 
-* `number`: Accumulated seconds of play-time.
+number - Total online time in seconds.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-print(LocalPlayer():getTotalOnlineTime())
+    local totalTime = player:getTotalOnlineTime()
+    print("Total online time: " .. totalTime .. " seconds")
 ```
 
 ---
@@ -2671,24 +2573,26 @@ print(LocalPlayer():getTotalOnlineTime())
 
 **Purpose**
 
-Reports how long it has been since the player was last online.
+Gets a human-readable string representing when the player was last online.
+    Returns relative time (e.g., "2 hours ago").
 
 **Parameters**
 
-* None
-
-**Realm**
-
-`Client`
+* None.
 
 **Returns**
 
-* `string`: Friendly time string.
+string - Human-readable time since last online.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-chat.AddText(LocalPlayer():getLastOnline())
+    local lastOnline = player:getLastOnline()
+    print("Last online: " .. lastOnline)
 ```
 
 ---
@@ -2697,24 +2601,26 @@ chat.AddText(LocalPlayer():getLastOnline())
 
 **Purpose**
 
-Gives the Unix timestamp of the player's last session end.
+Gets the timestamp when the player was last online.
+    Returns the raw timestamp value.
 
 **Parameters**
 
-* None
-
-**Realm**
-
-`Client`
+* None.
 
 **Returns**
 
-* `number`: Time value in seconds.
+number - Unix timestamp of last online time.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-local last = LocalPlayer():getLastOnlineTime()
+    local lastTime = player:getLastOnlineTime()
+    print("Last online timestamp: " .. lastTime)
 ```
 
 ---
@@ -2723,28 +2629,30 @@ local last = LocalPlayer():getLastOnlineTime()
 
 **Purpose**
 
-Displays a waypoint on the HUD until the player reaches it.
+Sets a waypoint for the player at the specified location.
+    Creates a HUD element that shows the waypoint and distance.
 
 **Parameters**
 
-* `name` (`string`): Display label.
-
-* `vector` (`Vector`): World position.
-
-* `onReach` (`function|nil`): Called when reached.
-
-**Realm**
-
-`Client`
+* name (string) - The name of the waypoint.
+* vector (Vector) - The position where the waypoint should be set.
+* onReach (function, optional) - Callback function when waypoint is reached.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Client.
 
 **Example Usage**
 
 ```lua
-LocalPlayer():setWaypoint("Home", vector_origin)
+    -- Set a waypoint with callback when reached
+    player:setWaypoint("Home", Vector(100, 200, 300), function()
+        print("Reached home!")
+    end)
 ```
 
 ---
@@ -2753,28 +2661,28 @@ LocalPlayer():setWaypoint("Home", vector_origin)
 
 **Purpose**
 
-Alias of the client version of `setWaypoint`.
+Sets a weight-based waypoint for the player.
+    Similar to setWaypoint but with weight considerations.
 
 **Parameters**
 
-* `name` (`string`): Display label.
-
-* `vector` (`Vector`): World position.
-
-* `onReach` (`function|nil`): Called when reached.
-
-**Realm**
-
-`Client`
+* name (string) - The name/description of the waypoint.
+* vector (Vector) - The position of the waypoint.
+* onReach (function, optional) - Callback function when waypoint is reached.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Client.
 
 **Example Usage**
 
 ```lua
-LocalPlayer():setWeighPoint("Spot", Vector(10, 10, 0))
+    -- Set a weight-based waypoint
+    player:setWeighPoint("Heavy Item", Vector(500, 600, 700))
 ```
 
 ---
@@ -2783,30 +2691,29 @@ LocalPlayer():setWeighPoint("Spot", Vector(10, 10, 0))
 
 **Purpose**
 
-Places a waypoint using a logo material on the client HUD.
+Sets a waypoint with a custom logo/icon for the player.
+    The logo will be displayed alongside the waypoint.
 
 **Parameters**
 
-* `name` (`string`): Display label.
-
-* `vector` (`Vector`): Position to navigate to.
-
-* `logo` (`string`): Material path for the icon.
-
-* `onReach` (`function|nil`): Called when reached.
-
-**Realm**
-
-`Client`
+* name (string) - The name/description of the waypoint.
+* vector (Vector) - The position of the waypoint.
+* logo (string) - The logo/icon identifier.
+* onReach (function, optional) - Callback function when waypoint is reached.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Client.
 
 **Example Usage**
 
 ```lua
-LocalPlayer():setWaypointWithLogo("Loot", Vector(1, 1, 1), "icon.png")
+    -- Set a waypoint with custom logo
+    player:setWaypointWithLogo("Shop", Vector(1000, 2000, 3000), "shop_icon")
 ```
 
 ---
@@ -2815,54 +2722,30 @@ LocalPlayer():setWaypointWithLogo("Loot", Vector(1, 1, 1), "icon.png")
 
 **Purpose**
 
-Client-side accessor for stored player data.
+Retrieves a value from the player's local Lilia data storage.
+    This is the client-side version of getLiliaData.
 
 **Parameters**
 
-* `key` (`string`): Data key.
-
-* `default` (`any`): Fallback value.
-
-**Realm**
-
-`Client`
+* key (string) - The data key to retrieve.
+* default (any) - The default value to return if the key doesn't exist.
 
 **Returns**
 
-* `any`: Stored value or default.
+any - The stored value or the default value if not found.
+
+**Realm**
+
+Client.
 
 **Example Usage**
 
 ```lua
-local data = LocalPlayer():getLiliaData("settings")
-```
-
----
-
-### getData
-
-**Purpose**
-
-Alias of `getLiliaData`.
-
-**Parameters**
-
-* `key` (`string`): Data key.
-
-* `default` (`any`): Fallback value.
-
-**Realm**
-
-`Client`
-
-**Returns**
-
-* `any`: Stored value or default.
-
-**Example Usage**
-
-```lua
-local data = LocalPlayer():getData("settings")
+    -- Get player's local settings
+    local settings = player:getLiliaData("settings", {})
+    if settings then
+        print("Player has custom settings")
+    end
 ```
 
 ---
@@ -2871,24 +2754,310 @@ local data = LocalPlayer():getData("settings")
 
 **Purpose**
 
-Returns the entire local data table for the player.
+Retrieves all stored Lilia data for this player.
+    Returns a table containing all key-value pairs.
 
 **Parameters**
 
-* None
-
-**Realm**
-
-`Client`
+* None.
 
 **Returns**
 
-* `table`: Local data table.
+table - All stored Lilia data.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-local data = LocalPlayer():getAllLiliaData()
+    local allData = player:getAllLiliaData()
+    for key, value in pairs(allData) do
+        print(key .. ": " .. tostring(value))
+    end
+```
+
+---
+
+### getFlags
+
+**Purpose**
+
+Gets the flags associated with this player's character.
+    Returns the character flags if available, otherwise returns an empty string.
+
+**Parameters**
+
+* None.
+
+**Returns**
+
+string - The character flags or empty string if no character.
+
+**Realm**
+
+Shared.
+
+**Example Usage**
+
+```lua
+    local flags = player:getFlags()
+    print("Player flags: " .. flags)
+```
+
+---
+
+### setFlags
+
+**Purpose**
+
+Sets the flags for this player's character.
+    Updates the character flags if a character exists.
+
+**Parameters**
+
+* flags (string) - The flags to set for the character.
+
+**Returns**
+
+None.
+
+**Realm**
+
+Shared.
+
+**Example Usage**
+
+```lua
+    -- Set player character flags
+    player:setFlags("abc")
+```
+
+---
+
+### giveFlags
+
+**Purpose**
+
+Adds flags to this player's character.
+    Appends the new flags to existing character flags.
+
+**Parameters**
+
+* flags (string) - The flags to add to the character.
+
+**Returns**
+
+None.
+
+**Realm**
+
+Shared.
+
+**Example Usage**
+
+```lua
+    -- Give additional flags to player
+    player:giveFlags("d")
+```
+
+---
+
+### takeFlags
+
+**Purpose**
+
+Removes flags from this player's character.
+    Removes the specified flags from existing character flags.
+
+**Parameters**
+
+* flags (string) - The flags to remove from the character.
+
+**Returns**
+
+None.
+
+**Realm**
+
+Shared.
+
+**Example Usage**
+
+```lua
+    -- Remove flags from player
+    player:takeFlags("a")
+```
+
+---
+
+### getPlayerFlags
+
+**Purpose**
+
+Gets the player-specific flags stored in Lilia data.
+    Returns flags that are specific to the player, not the character.
+
+**Parameters**
+
+* None.
+
+**Returns**
+
+string - The player flags or empty string if none set.
+
+**Realm**
+
+Shared.
+
+**Example Usage**
+
+```lua
+    local playerFlags = player:getPlayerFlags()
+    print("Player flags: " .. playerFlags)
+```
+
+---
+
+### setPlayerFlags
+
+**Purpose**
+
+Sets the player-specific flags in Lilia data.
+    Stores flags that are specific to the player, not the character.
+
+**Parameters**
+
+* flags (string) - The player flags to set.
+
+**Returns**
+
+None.
+
+**Realm**
+
+Shared.
+
+**Example Usage**
+
+```lua
+    -- Set player-specific flags
+    player:setPlayerFlags("xyz")
+```
+
+---
+
+### hasPlayerFlags
+
+**Purpose**
+
+Checks if the player has any of the specified player flags.
+    Checks player-specific flags stored in Lilia data.
+
+**Parameters**
+
+* flags (string) - A string of flag characters to check.
+
+**Returns**
+
+boolean - True if the player has at least one of the specified flags, false otherwise.
+
+**Realm**
+
+Shared.
+
+**Example Usage**
+
+```lua
+    if player:hasPlayerFlags("x") then
+        print("Player has flag 'x'")
+    end
+```
+
+---
+
+### givePlayerFlags
+
+**Purpose**
+
+Adds player-specific flags to this player.
+    Adds new flags that the player doesn't already have and runs callbacks.
+
+**Parameters**
+
+* flags (string) - The player flags to add.
+
+**Returns**
+
+None.
+
+**Realm**
+
+Shared.
+
+**Example Usage**
+
+```lua
+    -- Give additional player flags
+    player:givePlayerFlags("xyz")
+```
+
+---
+
+### takePlayerFlags
+
+**Purpose**
+
+Removes player-specific flags from this player.
+    Removes specified flags and runs callbacks for removed flags.
+
+**Parameters**
+
+* flags (string) - The player flags to remove.
+
+**Returns**
+
+None.
+
+**Realm**
+
+Shared.
+
+**Example Usage**
+
+```lua
+    -- Remove player flags
+    player:takePlayerFlags("x")
+```
+
+---
+
+### hasFlags
+
+**Purpose**
+
+Checks if the player has any of the specified flags.
+    Checks both character flags and player flags, and runs hook callbacks.
+
+**Parameters**
+
+* flags (string) - A string of flag characters to check.
+
+**Returns**
+
+boolean - True if the player has at least one of the specified flags, false otherwise.
+
+**Realm**
+
+Shared.
+
+**Example Usage**
+
+```lua
+    if player:hasFlags("a") then
+        print("Player has flag 'a'")
+    end
 ```
 
 ---
@@ -2897,28 +3066,29 @@ local data = LocalPlayer():getAllLiliaData()
 
 **Purpose**
 
-Applies or clears client-side bone angles based on animation data.
+Applies bone angle manipulations for animations on the client side.
+    This is the client-side version of NetworkAnimation.
 
 **Parameters**
 
-* `active` (`boolean`): Enable or disable animation.
-
-* `boneData` (`table`): Bones and angles to apply.
-
-**Realm**
-
-`Client`
+* active (boolean) - Whether the animation is active.
+* boneData (table) - The bone data containing bone names and angles.
 
 **Returns**
 
-* `nil`: This function does not return a value.
+None.
+
+**Realm**
+
+Client.
 
 **Example Usage**
 
 ```lua
-LocalPlayer():NetworkAnimation(true, {
-    ["ValveBiped.Bip01_Head"] = Angle(0, 90, 0)
-})
+    -- Apply bone animation data
+    player:NetworkAnimation(true, {
+        ["ValveBiped.Bip01_Head1"] = Angle(0, 45, 0)
+    })
 ```
 
 ---
@@ -2927,24 +3097,27 @@ LocalPlayer():NetworkAnimation(true, {
 
 **Purpose**
 
-Checks if the player's total play time exceeds a threshold.
+Checks if the player's total play time is greater than the specified time.
+    Compares the player's accumulated play time against the given threshold.
 
 **Parameters**
 
-* `time` (`number`): Time in seconds to compare against.
-
-**Realm**
-
-`Shared`
+* time (number) - The time threshold to compare against in seconds.
 
 **Returns**
 
-* `boolean`: Whether the player has played longer than `time`.
+boolean - True if the player's play time is greater than the specified time, false otherwise.
+
+**Realm**
+
+Shared.
 
 **Example Usage**
 
 ```lua
-if player:playTimeGreaterThan(3600) then
-    print("Played for over an hour")
-end
+    -- Check if player has played for more than 1 hour
+    if player:playTimeGreaterThan(3600) then
+        print("Player has been playing for more than 1 hour")
+    end
 ```
+

--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -127,27 +127,6 @@ function playerMeta:getTracedEntity(distance)
     return targetEntity
 end
 
---[[
-    getTrace
-
-    Purpose:
-        Performs a hull trace from the player's shoot position in the direction they are looking.
-
-    Parameters:
-        distance (number) - The maximum distance to trace. Defaults to 200.
-
-    Returns:
-        table - The trace result table containing hit information.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local trace = player:getTrace(300)
-        if trace.Hit then
-            print("Hit something at: " .. tostring(trace.HitPos))
-        end
-]]
 function playerMeta:getTrace(distance)
     if not distance then distance = 200 end
     local data = {}
@@ -160,98 +139,20 @@ function playerMeta:getTrace(distance)
     return trace
 end
 
---[[
-    getEyeEnt
-
-    Purpose:
-        Returns the entity the player is looking at within a specified distance using eye trace.
-
-    Parameters:
-        distance (number) - The maximum distance to check. Defaults to 150.
-
-    Returns:
-        Entity or nil - The entity being looked at, or nil if out of range.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local entity = player:getEyeEnt(200)
-        if entity then
-            print("Looking at: " .. entity:GetClass())
-        end
-]]
 function playerMeta:getEyeEnt(distance)
     distance = distance or 150
     local e = self:GetEyeTrace().Entity
     return e:GetPos():Distance(self:GetPos()) <= distance and e or nil
 end
 
---[[
-    notify
-
-    Purpose:
-        Sends a notification message to the player.
-
-    Parameters:
-        message (string) - The message to display to the player.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        player:notify("Welcome to the server!")
-]]
 function playerMeta:notify(message)
     lia.notices.notify(message, self)
 end
 
---[[
-    notifyLocalized
-
-    Purpose:
-        Sends a localized notification message to the player.
-
-    Parameters:
-        message (string) - The localization key for the message.
-        ... (any) - Additional arguments to format the localized message.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        player:notifyLocalized("welcome_message", player:Name())
-]]
 function playerMeta:notifyLocalized(message, ...)
     lia.notices.notifyLocalized(message, self, ...)
 end
 
---[[
-    CanEditVendor
-
-    Purpose:
-        Checks if the player can edit the specified vendor.
-
-    Parameters:
-        vendor (Entity) - The vendor entity to check permissions for.
-
-    Returns:
-        boolean - True if the player can edit the vendor, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if player:CanEditVendor(vendorEntity) then
-            print("Player can edit this vendor")
-        end
-]]
 function playerMeta:CanEditVendor(vendor)
     local hookResult = hook.Run("CanPerformVendorEdit", self, vendor)
     if hookResult ~= nil then return hookResult end
@@ -276,89 +177,18 @@ local function groupHasType(groupName, t)
     return false
 end
 
---[[
-    isStaff
-
-    Purpose:
-        Checks if the player is a staff member based on their user group.
-
-    Returns:
-        boolean - True if the player is staff, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if player:isStaff() then
-            print("Player is a staff member")
-        end
-]]
 function playerMeta:isStaff()
     return groupHasType(self:GetUserGroup(), "Staff")
 end
 
---[[
-    isVIP
-
-    Purpose:
-        Checks if the player is a VIP member based on their user group.
-
-    Returns:
-        boolean - True if the player is VIP, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if player:isVIP() then
-            print("Player is a VIP member")
-        end
-]]
 function playerMeta:isVIP()
     return groupHasType(self:GetUserGroup(), "VIP")
 end
 
---[[
-    isStaffOnDuty
-
-    Purpose:
-        Checks if the player is currently on duty as staff.
-
-    Returns:
-        boolean - True if the player is on duty as staff, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if player:isStaffOnDuty() then
-            print("Player is on duty as staff")
-        end
-]]
 function playerMeta:isStaffOnDuty()
     return self:Team() == FACTION_STAFF
 end
 
---[[
-    isFaction
-
-    Purpose:
-        Checks if the player belongs to the specified faction.
-
-    Parameters:
-        faction (string) - The faction name to check against.
-
-    Returns:
-        boolean or nil - True if the player belongs to the faction, false or nil otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if player:isFaction("police") then
-            print("Player is a police officer")
-        end
-]]
 function playerMeta:isFaction(faction)
     local character = self:getChar()
     if not character then return end
@@ -366,26 +196,6 @@ function playerMeta:isFaction(faction)
     return pFaction and pFaction == faction
 end
 
---[[
-    isClass
-
-    Purpose:
-        Checks if the player belongs to the specified class.
-
-    Parameters:
-        class (string) - The class name to check against.
-
-    Returns:
-        boolean or nil - True if the player belongs to the class, false or nil otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if player:isClass("medic") then
-            print("Player is a medic")
-        end
-]]
 function playerMeta:isClass(class)
     local character = self:getChar()
     if not character then return end
@@ -393,26 +203,6 @@ function playerMeta:isClass(class)
     return pClass and pClass == class
 end
 
---[[
-    hasWhitelist
-
-    Purpose:
-        Checks if the player has a whitelist for the specified faction.
-
-    Parameters:
-        faction (string) - The faction name to check whitelist for.
-
-    Returns:
-        boolean - True if the player has a whitelist for the faction, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if player:hasWhitelist("police") then
-            print("Player has police whitelist")
-        end
-]]
 function playerMeta:hasWhitelist(faction)
     local data = lia.faction.indices[faction]
     if data then
@@ -424,49 +214,11 @@ function playerMeta:hasWhitelist(faction)
     return false
 end
 
---[[
-    getClass
-
-    Purpose:
-        Returns the player's current class.
-
-    Returns:
-        string or nil - The player's class name, or nil if no character exists.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local class = player:getClass()
-        if class then
-            print("Player's class: " .. class)
-        end
-]]
 function playerMeta:getClass()
     local character = self:getChar()
     if character then return character:getClass() end
 end
 
---[[
-    hasClassWhitelist
-
-    Purpose:
-        Checks if the player has a whitelist for the specified class.
-
-    Parameters:
-        class (string) - The class name to check whitelist for.
-
-    Returns:
-        boolean - True if the player has a whitelist for the class, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if player:hasClassWhitelist("medic") then
-            print("Player has medic class whitelist")
-        end
-]]
 function playerMeta:hasClassWhitelist(class)
     local char = self:getChar()
     if not char then return false end
@@ -474,24 +226,6 @@ function playerMeta:hasClassWhitelist(class)
     return wl[class] == true
 end
 
---[[
-    getClassData
-
-    Purpose:
-        Returns the data for the player's current class.
-
-    Returns:
-        table or nil - The class data table, or nil if no character or class exists.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local classData = player:getClassData()
-        if classData then
-            print("Class description: " .. classData.description)
-        end
-]]
 function playerMeta:getClassData()
     local character = self:getChar()
     if character then
@@ -503,126 +237,27 @@ function playerMeta:getClassData()
     end
 end
 
---[[
-    getDarkRPVar
-
-    Purpose:
-        Returns DarkRP variable values for the player. Currently only supports "money" variable.
-
-    Parameters:
-        var (string) - The DarkRP variable name to retrieve. Only "money" is currently supported.
-
-    Returns:
-        number or nil - The value of the requested variable, or nil if not supported.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local money = player:getDarkRPVar("money")
-        if money then
-            print("Player has " .. money .. " money")
-        end
-]]
 function playerMeta:getDarkRPVar(var)
     if var ~= "money" then return end
     local char = self:getChar()
     return char:getMoney()
 end
 
---[[
-    getMoney
-
-    Purpose:
-        Returns the player's current money amount from their character.
-
-    Returns:
-        number - The player's current money amount, or 0 if no character exists.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local money = player:getMoney()
-        print("Player has " .. money .. " money")
-]]
 function playerMeta:getMoney()
     local character = self:getChar()
     return character and character:getMoney() or 0
 end
 
---[[
-    canAfford
-
-    Purpose:
-        Checks if the player can afford a specified amount of money.
-
-    Parameters:
-        amount (number) - The amount of money to check.
-
-    Returns:
-        boolean - True if the player can afford the amount, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if player:canAfford(1000) then
-            print("Player can afford 1000")
-        end
-]]
 function playerMeta:canAfford(amount)
     local character = self:getChar()
     return character and character:hasMoney(amount)
 end
 
---[[
-    hasSkillLevel
-
-    Purpose:
-        Checks if the player has a skill level at or above the specified level.
-
-    Parameters:
-        skill (string) - The skill name to check.
-        level (number) - The minimum skill level required.
-
-    Returns:
-        boolean - True if the player has the required skill level, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if player:hasSkillLevel("strength", 5) then
-            print("Player has strength level 5 or higher")
-        end
-]]
 function playerMeta:hasSkillLevel(skill, level)
     local currentLevel = self:getChar():getAttrib(skill, 0)
     return currentLevel >= level
 end
 
---[[
-    meetsRequiredSkills
-
-    Purpose:
-        Checks if the player meets all the required skill levels for a set of skills.
-
-    Parameters:
-        requiredSkillLevels (table) - Table of skill names mapped to required levels.
-
-    Returns:
-        boolean - True if the player meets all required skill levels, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local required = {strength = 5, agility = 3}
-        if player:meetsRequiredSkills(required) then
-            print("Player meets all skill requirements")
-        end
-]]
 function playerMeta:meetsRequiredSkills(requiredSkillLevels)
     if not requiredSkillLevels then return true end
     for skill, level in pairs(requiredSkillLevels) do
@@ -631,27 +266,6 @@ function playerMeta:meetsRequiredSkills(requiredSkillLevels)
     return true
 end
 
---[[
-    forceSequence
-
-    Purpose:
-        Forces the player to play a specific animation sequence.
-
-    Parameters:
-        sequenceName (string) - The name of the sequence to play.
-        callback (function) - Optional callback function to execute when sequence ends.
-        time (number) - Optional duration for the sequence. Defaults to sequence duration.
-        noFreeze (boolean) - If false, freezes player movement during sequence.
-
-    Returns:
-        number or boolean - Duration of the sequence if successful, false if failed.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local duration = player:forceSequence("sit", function() print("Sit sequence finished") end)
-]]
 function playerMeta:forceSequence(sequenceName, callback, time, noFreeze)
     hook.Run("OnPlayerEnterSequence", self, sequenceName, callback, time, noFreeze)
     if not sequenceName then
@@ -684,21 +298,6 @@ function playerMeta:forceSequence(sequenceName, callback, time, noFreeze)
     return false
 end
 
---[[
-    leaveSequence
-
-    Purpose:
-        Stops the current forced sequence and restores normal player movement.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        player:leaveSequence()
-]]
 function playerMeta:leaveSequence()
     hook.Run("OnPlayerLeaveSequence", self)
     net.Start("seqSet")
@@ -712,24 +311,6 @@ function playerMeta:leaveSequence()
 end
 
 if SERVER then
-    --[[
-    restoreStamina
-
-    Purpose:
-        Restores the player's stamina by the specified amount.
-
-    Parameters:
-        amount (number) - The amount of stamina to restore.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:restoreStamina(50)
-    ]]
     function playerMeta:restoreStamina(amount)
         local char = self:getChar()
         local current = self:getLocalVar("stamina", char and char:getMaxStamina() or lia.config.get("DefaultStamina", 100))
@@ -742,24 +323,6 @@ if SERVER then
         end
     end
 
-    --[[
-    consumeStamina
-
-    Purpose:
-        Consumes the specified amount of stamina from the player.
-
-    Parameters:
-        amount (number) - The amount of stamina to consume.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:consumeStamina(25)
-    ]]
     function playerMeta:consumeStamina(amount)
         local char = self:getChar()
         local current = self:getLocalVar("stamina", char and char:getMaxStamina() or lia.config.get("DefaultStamina", 100))
@@ -771,24 +334,6 @@ if SERVER then
         end
     end
 
-    --[[
-    addMoney
-
-    Purpose:
-        Adds the specified amount of money to the player's character.
-
-    Parameters:
-        amount (number) - The amount of money to add.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:addMoney(1000)
-    ]]
     function playerMeta:addMoney(amount)
         local character = self:getChar()
         if not character then return false end
@@ -812,109 +357,28 @@ if SERVER then
         end
     end
 
-    --[[
-    takeMoney
-
-    Purpose:
-        Removes the specified amount of money from the player's character.
-
-    Parameters:
-        amount (number) - The amount of money to remove.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:takeMoney(500)
-    ]]
     function playerMeta:takeMoney(amount)
         local character = self:getChar()
         if character then character:giveMoney(-amount) end
     end
 
-    --[[
-    WhitelistAllClasses
-
-    Purpose:
-        Grants the player access to all available classes.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:WhitelistAllClasses()
-    ]]
     function playerMeta:WhitelistAllClasses()
         for class, _ in pairs(lia.class.list) do
             self:classWhitelist(class)
         end
     end
 
-    --[[
-    WhitelistAllFactions
-
-    Purpose:
-        Grants the player access to all available factions.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:WhitelistAllFactions()
-    ]]
     function playerMeta:WhitelistAllFactions()
         for faction, _ in pairs(lia.faction.indices) do
             self:setWhitelisted(faction, true)
         end
     end
 
-    --[[
-    WhitelistEverything
-
-    Purpose:
-        Grants the player access to all available factions and classes.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:WhitelistEverything()
-    ]]
     function playerMeta:WhitelistEverything()
         self:WhitelistAllFactions()
         self:WhitelistAllClasses()
     end
 
-    --[[
-    classWhitelist
-
-    Purpose:
-        Grants the player access to a specific class.
-
-    Parameters:
-        class (string) - The class name to whitelist.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:classWhitelist("medic")
-    ]]
     function playerMeta:classWhitelist(class)
         local char = self:getChar()
         if not char then return end
@@ -923,24 +387,6 @@ if SERVER then
         char:setClasswhitelists(wl)
     end
 
-    --[[
-    classUnWhitelist
-
-    Purpose:
-        Removes the player's access to a specific class.
-
-    Parameters:
-        class (string) - The class name to remove whitelist for.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:classUnWhitelist("medic")
-    ]]
     function playerMeta:classUnWhitelist(class)
         local char = self:getChar()
         if not char then return end
@@ -949,25 +395,6 @@ if SERVER then
         char:setClasswhitelists(wl)
     end
 
-    --[[
-    setWhitelisted
-
-    Purpose:
-        Sets the whitelist status for a specific faction for the player.
-
-    Parameters:
-        faction (string) - The faction name to set whitelist for.
-        whitelisted (boolean) - Whether to whitelist or remove whitelist.
-
-    Returns:
-        boolean - True if the operation was successful, false otherwise.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:setWhitelisted("police", true)
-    ]]
     function playerMeta:setWhitelisted(faction, whitelisted)
         if not whitelisted then whitelisted = nil end
         local data = lia.faction.indices[faction]
@@ -981,24 +408,6 @@ if SERVER then
         return false
     end
 
-    --[[
-    loadLiliaData
-
-    Purpose:
-        Loads the player's Lilia data from the database.
-
-    Parameters:
-        callback (function) - Optional callback function to execute after loading.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:loadLiliaData(function(data) print("Data loaded") end)
-    ]]
     function playerMeta:loadLiliaData(callback)
         local name = self:steamName()
         local steamID = self:SteamID()
@@ -1037,21 +446,6 @@ if SERVER then
         end)
     end
 
-    --[[
-    saveLiliaData
-
-    Purpose:
-        Saves the player's Lilia data to the database, including online time tracking and other persistent data.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:saveLiliaData()
-    ]]
     function playerMeta:saveLiliaData()
         if self:IsBot() then return end
         local name = self:steamName()
@@ -1072,27 +466,6 @@ if SERVER then
         }, nil, "players", "steamID = " .. lia.db.convertDataType(steamID))
     end
 
-    --[[
-    setLiliaData
-
-    Purpose:
-        Sets a key-value pair in the player's Lilia data and optionally syncs it to the client and saves to database.
-
-    Parameters:
-        key (string) - The data key to set.
-        value (any) - The value to store.
-        noNetworking (boolean) - If true, doesn't sync to client.
-        noSave (boolean) - If true, doesn't save to database.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:setLiliaData("customFlag", true)
-    ]]
     function playerMeta:setLiliaData(key, value, noNetworking, noSave)
         self.liaData = self.liaData or {}
         self.liaData[key] = value
@@ -1106,25 +479,6 @@ if SERVER then
         if not noSave then self:saveLiliaData() end
     end
 
-    --[[
-    setWaypoint
-
-    Purpose:
-        Sets a waypoint for the player at the specified location.
-
-    Parameters:
-        name (string) - The name of the waypoint.
-        vector (Vector) - The position where the waypoint should be set.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:setWaypoint("Home", Vector(100, 200, 300))
-    ]]
     function playerMeta:setWaypoint(name, vector)
         net.Start("setWaypoint")
         net.WriteString(name)
@@ -1132,49 +486,10 @@ if SERVER then
         net.Send(self)
     end
 
-    --[[
-    setWeighPoint
-
-    Purpose:
-        Sets a waypoint for the player (alias for setWaypoint).
-
-    Parameters:
-        name (string) - The name of the waypoint.
-        vector (Vector) - The position where the waypoint should be set.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:setWeighPoint("Home", Vector(100, 200, 300))
-    ]]
     function playerMeta:setWeighPoint(name, vector)
         self:setWaypoint(name, vector)
     end
 
-    --[[
-    setWaypointWithLogo
-
-    Purpose:
-        Sets a waypoint for the player with a custom logo/icon.
-
-    Parameters:
-        name (string) - The name of the waypoint.
-        vector (Vector) - The position where the waypoint should be set.
-        logo (string) - The logo/icon identifier for the waypoint.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:setWaypointWithLogo("Store", Vector(500, 600, 700), "store_icon")
-    ]]
     function playerMeta:setWaypointWithLogo(name, vector, logo)
         net.Start("setWaypointWithLogo")
         net.WriteString(name)
@@ -1183,25 +498,6 @@ if SERVER then
         net.Send(self)
     end
 
-    --[[
-    getLiliaData
-
-    Purpose:
-        Retrieves a value from the player's Lilia data storage.
-
-    Parameters:
-        key (string) - The data key to retrieve.
-        default (any) - The default value to return if the key doesn't exist.
-
-    Returns:
-        any - The stored value or the default value if not found.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local customFlag = player:getLiliaData("customFlag", false)
-    ]]
     function playerMeta:getLiliaData(key, default)
         local data = self.liaData and self.liaData[key]
         if data == nil then return default end
@@ -1209,187 +505,39 @@ if SERVER then
     end
 
     playerMeta.getData = playerMeta.getLiliaData
-    --[[
-    getAllLiliaData
-
-    Purpose:
-        Returns all of the player's Lilia data as a table.
-
-    Returns:
-        table - The complete Lilia data table for the player.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local allData = player:getAllLiliaData()
-        for key, value in pairs(allData) do
-            print(key .. ": " .. tostring(value))
-        end
-    ]]
     function playerMeta:getAllLiliaData()
         self.liaData = self.liaData or {}
         return self.liaData
     end
 
-    --[[
-    getFlags
-
-    Purpose:
-        Returns the flags associated with the player's character.
-
-    Returns:
-        string - The character's flags, or empty string if no character exists.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local flags = player:getFlags()
-        if flags:find("a") then
-            print("Player has admin flag")
-        end
-    ]]
     function playerMeta:getFlags()
         local char = self:getChar()
         return char and char:getFlags() or ""
     end
 
-    --[[
-    setFlags
-
-    Purpose:
-        Sets the flags for the player's character.
-
-    Parameters:
-        flags (string) - The flags to set for the character.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        player:setFlags("a")
-        print("Player now has admin flag")
-]]
     function playerMeta:setFlags(flags)
         local char = self:getChar()
         if char then char:setFlags(flags) end
     end
 
-    --[[
-    giveFlags
-
-    Purpose:
-        Gives flags to the player's character.
-
-    Parameters:
-        flags (string) - The flags to give to the character.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        player:giveFlags("a")
-        print("Player now has admin flag")
-]]
     function playerMeta:giveFlags(flags)
         local char = self:getChar()
         if char then char:giveFlags(flags) end
     end
 
-    --[[
-    takeFlags
-
-    Purpose:
-        Removes flags from the player's character.
-
-    Parameters:
-        flags (string) - The flags to remove from the character.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        player:takeFlags("a")
-        print("Player no longer has admin flag")
-]]
     function playerMeta:takeFlags(flags)
         local char = self:getChar()
         if char then char:takeFlags(flags) end
     end
 
-    --[[
-    getPlayerFlags
-
-    Purpose:
-        Returns the player's personal flags.
-
-    Returns:
-        string - The player's personal flags.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local flags = player:getPlayerFlags()
-        print("Player flags: " .. flags)
-]]
     function playerMeta:getPlayerFlags()
         return self:getLiliaData("playerFlags", "")
     end
 
-    --[[
-    setPlayerFlags
-
-    Purpose:
-        Sets the player's personal flags.
-
-    Parameters:
-        flags (string) - The flags to set.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        player:setPlayerFlags("v")
-        print("Player now has VIP flag")
-]]
     function playerMeta:setPlayerFlags(flags)
         self:setLiliaData("playerFlags", flags)
     end
 
-    --[[
-    hasPlayerFlags
-
-    Purpose:
-        Checks if the player has specific personal flags.
-
-    Parameters:
-        flags (string) - the flags to check for.
-
-    Returns:
-        boolean - True if the player has any of the specified flags.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if player:hasPlayerFlags("v") then
-            print("Player has VIP flag")
-        end
-]]
     function playerMeta:hasPlayerFlags(flags)
         local pFlags = self:getPlayerFlags()
         for i = 1, #flags do
@@ -1398,25 +546,6 @@ if SERVER then
         return false
     end
 
-    --[[
-    givePlayerFlags
-
-    Purpose:
-        Gives personal flags to the player.
-
-    Parameters:
-        flags (string) - The flags to give.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        player:givePlayerFlags("v")
-        print("Player now has VIP flag")
-]]
     function playerMeta:givePlayerFlags(flags)
         local addedFlags = ""
         for i = 1, #flags do
@@ -1431,25 +560,6 @@ if SERVER then
         if addedFlags ~= "" then self:setPlayerFlags(self:getPlayerFlags() .. addedFlags) end
     end
 
-    --[[
-    takePlayerFlags
-
-    Purpose:
-        Removes personal flags from the player.
-
-    Parameters:
-        flags (string) - The flags to remove.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        player:takePlayerFlags("v")
-        print("Player no longer has VIP flag")
-]]
     function playerMeta:takePlayerFlags(flags)
         local oldFlags = self:getPlayerFlags()
         local newFlags = oldFlags
@@ -1465,26 +575,6 @@ if SERVER then
         if newFlags ~= oldFlags then self:setPlayerFlags(newFlags) end
     end
 
-    --[[
-    hasFlags
-
-    Purpose:
-        Checks if the player has specific flags (character or personal).
-
-    Parameters:
-        flags (string) - The flags to check for.
-
-    Returns:
-        boolean - True if the player has any of the specified flags.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if player:hasFlags("a") then
-            print("Player has admin flag")
-        end
-]]
     function playerMeta:hasFlags(flags)
         for i = 1, #flags do
             local flag = flags:sub(i, i)
@@ -1493,47 +583,10 @@ if SERVER then
         return hook.Run("CharHasFlags", self, flags) or false
     end
 
-    --[[
-    setRagdoll
-
-    Purpose:
-        Sets the player's ragdoll entity.
-
-    Parameters:
-        entity (Entity) - The ragdoll entity to set.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:setRagdoll(ragdollEntity)
-]]
     function playerMeta:setRagdoll(entity)
         self.liaRagdoll = entity
     end
 
-    --[[
-    NetworkAnimation
-
-    Purpose:
-        Networks animation status to all clients.
-
-    Parameters:
-        active (boolean) - Whether the animation is active.
-        boneData (table) - The bone data for the animation.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:NetworkAnimation(true, boneData)
-]]
     function playerMeta:NetworkAnimation(active, boneData)
         net.Start("AnimationStatus")
         net.WriteEntity(self)
@@ -1542,26 +595,6 @@ if SERVER then
         net.Broadcast()
     end
 
-    --[[
-    banPlayer
-
-    Purpose:
-        Bans the player from the server.
-
-    Parameters:
-        reason (string) - The reason for the ban.
-        duration (number) - The duration of the ban in seconds.
-        banner (Player) - The player who issued the ban.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:banPlayer("Breaking rules", 3600, adminPlayer)
-]]
     function playerMeta:banPlayer(reason, duration, banner)
         local steamID = self:SteamID()
         lia.db.insertTable({
@@ -1577,26 +610,6 @@ if SERVER then
         self:Kick(L("banMessage", duration or 0, reason or L("genericReason")))
     end
 
-    --[[
-    setAction
-
-    Purpose:
-        Sets an action bar for the player with optional callback.
-
-    Parameters:
-        text (string) - The text to display in the action bar.
-        time (number) - The duration of the action bar.
-        callback (function) - Optional callback function when action completes.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:setAction("Loading...", 5, function() print("Action complete") end)
-]]
     function playerMeta:setAction(text, time, callback)
         if time and time <= 0 then
             if callback then callback(self) end
@@ -1620,28 +633,6 @@ if SERVER then
         if callback then timer.Create("liaAct" .. self:SteamID64(), time, 1, function() if IsValid(self) then callback(self) end end) end
     end
 
-    --[[
-    doStaredAction
-
-    Purpose:
-        Performs an action that requires the player to stare at an entity.
-
-    Parameters:
-        entity (Entity) - The entity to stare at.
-        callback (function) - Function to call when action completes.
-        time (number) - Time required to complete the action.
-        onCancel (function) - Function to call if action is cancelled.
-        distance (number) - Maximum distance to perform action.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:doStaredAction(targetEntity, function() print("Action done") end, 3)
-]]
     function playerMeta:doStaredAction(entity, callback, time, onCancel, distance)
         local uniqueID = "liaStare" .. self:SteamID64()
         local data = {}
@@ -1665,48 +656,12 @@ if SERVER then
         end)
     end
 
-    --[[
-    stopAction
-
-    Purpose:
-        Stops the current action bar.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:stopAction()
-]]
     function playerMeta:stopAction()
         timer.Remove("liaAct" .. self:SteamID64())
         net.Start("actBar")
         net.Send(self)
     end
 
-    --[[
-    requestDropdown
-
-    Purpose:
-        Requests a dropdown selection from the player.
-
-    Parameters:
-        title (string) - The title of the dropdown.
-        subTitle (string) - The subtitle of the dropdown.
-        options (table) - The options to choose from.
-        callback (function) - Function to call when selection is made.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:requestDropdown("Choose", "Select an option", {"Option 1", "Option 2"}, callback)
-]]
     function playerMeta:requestDropdown(title, subTitle, options, callback)
         net.Start("RequestDropdown")
         net.WriteString(title)
@@ -1716,28 +671,6 @@ if SERVER then
         self.dropdownCallback = callback
     end
 
-    --[[
-    requestOptions
-
-    Purpose:
-        Requests multiple option selections from the player.
-
-    Parameters:
-        title (string) - The title of the request.
-        subTitle (string) - The subtitle of the request.
-        options (table) - The options to choose from.
-        limit (number) - Maximum number of selections allowed.
-        callback (function) - Function to call when selection is made.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:requestOptions("Choose", "Select options", {"A", "B", "C"}, 2, callback)
-]]
     function playerMeta:requestOptions(title, subTitle, options, limit, callback)
         net.Start("OptionsRequest")
         net.WriteString(title)
@@ -1748,27 +681,6 @@ if SERVER then
         self.optionsCallback = callback
     end
 
-    --[[
-    requestString
-
-    Purpose:
-        Requests a string input from the player.
-
-    Parameters:
-        title (string) - The title of the request.
-        subTitle (string) - The subtitle of the request.
-        callback (function) - Function to call when string is entered.
-        default (string) - Default value for the input.
-
-    Returns:
-        Deferred object or nil.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        local deferred = player:requestString("Name", "Enter your name", callback, "Default")
-]]
     function playerMeta:requestString(title, subTitle, callback, default)
         local d
         if not isfunction(callback) and default == nil then
@@ -1788,26 +700,6 @@ if SERVER then
         return d
     end
 
-    --[[
-    requestArguments
-
-    Purpose:
-        Requests multiple arguments from the player.
-
-    Parameters:
-        title (string) - The title of the request.
-        argTypes (table) - The types of arguments to request.
-        callback (function) - Function to call when arguments are entered.
-
-    Returns:
-        Deferred object or nil.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        local deferred = player:requestArguments("Input", {"string", "number"}, callback)
-]]
     function playerMeta:requestArguments(title, argTypes, callback)
         local d
         if not isfunction(callback) then
@@ -1825,28 +717,6 @@ if SERVER then
         return d
     end
 
-    --[[
-    binaryQuestion
-
-    Purpose:
-        Asks the player a yes/no question.
-
-    Parameters:
-        question (string) - The question to ask.
-        option1 (string) - The first option text.
-        option2 (string) - The second option text.
-        manualDismiss (boolean) - Whether the player can manually dismiss.
-        callback (function) - Function to call when answer is given.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:binaryQuestion("Continue?", "Yes", "No", false, callback)
-]]
     function playerMeta:binaryQuestion(question, option1, option2, manualDismiss, callback)
         net.Start("BinaryQuestionRequest")
         net.WriteString(question)
@@ -1857,25 +727,6 @@ if SERVER then
         self.binaryQuestionCallback = callback
     end
 
-    --[[
-    requestButtons
-
-    Purpose:
-        Requests button selection from the player.
-
-    Parameters:
-        title (string) - The title of the request.
-        buttons (table) - Table of button data with text and callbacks.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:requestButtons("Choose", {{text = "Button 1", callback = func1}, {text = "Button 2", callback = func2}})
-]]
     function playerMeta:requestButtons(title, buttons)
         self.buttonRequests = self.buttonRequests or {}
         local labels = {}
@@ -1897,22 +748,6 @@ if SERVER then
         net.Send(self)
     end
 
-    --[[
-    getPlayTime
-
-    Purpose:
-        Returns the player's total play time.
-
-    Returns:
-        number - The player's total play time in seconds.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local playTime = player:getPlayTime()
-        print("Player has played for " .. playTime .. " seconds")
-]]
     function playerMeta:getPlayTime()
         local hookResult = hook.Run("getPlayTime", self)
         if hookResult ~= nil then return hookResult end
@@ -1926,107 +761,24 @@ if SERVER then
         return diff + RealTime() - (self.liaJoinTime or RealTime())
     end
 
-    --[[
-    getSessionTime
-
-    Purpose:
-        Returns the player's current session time.
-
-    Returns:
-        number - The current session time in seconds.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local sessionTime = player:getSessionTime()
-        print("Current session: " .. sessionTime .. " seconds")
-]]
     function playerMeta:getSessionTime()
         return RealTime() - (self.liaJoinTime or RealTime())
     end
 
-    --[[
-    getTotalOnlineTime
-
-    Purpose:
-        Returns the player's total online time including current session.
-
-    Returns:
-        number - The total online time in seconds.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local totalTime = player:getTotalOnlineTime()
-        print("Total online time: " .. totalTime .. " seconds")
-]]
     function playerMeta:getTotalOnlineTime()
         local stored = self:getLiliaData("totalOnlineTime", 0)
         return stored + RealTime() - (self.liaJoinTime or RealTime())
     end
 
-    --[[
-    getLastOnline
-
-    Purpose:
-        Returns a human-readable string of when the player was last online.
-
-    Returns:
-        string - Human-readable time since last online.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local lastOnline = player:getLastOnline()
-        print("Last online: " .. lastOnline)
-]]
     function playerMeta:getLastOnline()
         local last = self:getLiliaData("lastOnline", os.time())
         return lia.time.TimeSince(last)
     end
 
-    --[[
-    getLastOnlineTime
-
-    Purpose:
-        Returns the timestamp of when the player was last online.
-
-    Returns:
-        number - Unix timestamp of last online time.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local lastTime = player:getLastOnlineTime()
-        print("Last online timestamp: " .. lastTime)
-]]
     function playerMeta:getLastOnlineTime()
         return self:getLiliaData("lastOnline", os.time())
     end
 
-    --[[
-    createRagdoll
-
-    Purpose:
-        Creates a ragdoll entity for the player.
-
-    Parameters:
-        freeze (boolean) - Whether to freeze the ragdoll physics.
-        isDead (boolean) - Whether this ragdoll represents a dead player.
-
-    Returns:
-        Entity - The created ragdoll entity.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        local ragdoll = player:createRagdoll(false, true)
-]]
     function playerMeta:createRagdoll(freeze, isDead)
         local entity = ents.Create("prop_ragdoll")
         entity:SetPos(self:GetPos())
@@ -2064,27 +816,6 @@ if SERVER then
         return entity
     end
 
-    --[[
-    setRagdolled
-
-    Purpose:
-        Sets the player's ragdoll state.
-
-    Parameters:
-        state (boolean) - Whether to ragdoll the player.
-        time (number) - Time before auto-recovery.
-        getUpGrace (number) - Grace period for getting up.
-        getUpMessage (string) - Message to show during recovery.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        player:setRagdolled(true, 5, 2, "Getting up...")
-]]
     function playerMeta:setRagdolled(state, time, getUpGrace, getUpMessage)
         getUpMessage = getUpMessage or L("wakingUp")
         local hasRagdoll = self:hasRagdoll()
@@ -2182,26 +913,6 @@ if SERVER then
         end
     end
 
-    --[[
-    syncVars
-
-    Purpose:
-        Synchronizes all networked variables for this player with the client.
-        Sends global variables and entity-specific variables through networking.
-
-    Parameters:
-        None.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        -- Sync all variables for a player
-        player:syncVars()
-]]
     function playerMeta:syncVars()
         for entity, data in pairs(lia.net) do
             if entity == "globals" then
@@ -2223,27 +934,6 @@ if SERVER then
         end
     end
 
-    --[[
-    setLocalVar
-
-    Purpose:
-        Sets a local variable for this player and synchronizes it to the client.
-        The variable is stored locally and sent through networking.
-
-    Parameters:
-        key (string) - The key/name of the variable.
-        value (any) - The value to store.
-
-    Returns:
-        None.
-
-    Realm:
-        Server.
-
-    Example Usage:
-        -- Set a local variable for a player
-        player:setLocalVar("customFlag", true)
-]]
     function playerMeta:setLocalVar(key, value)
         if checkBadType(key, value) then return end
         lia.net[self] = lia.net[self] or {}
@@ -2256,27 +946,6 @@ if SERVER then
         hook.Run("LocalVarChanged", self, key, oldValue, value)
     end
 else
-    --[[
-    CanOverrideView
-
-    Purpose:
-        Determines if the player can override their view (third person).
-        Checks various conditions like ragdoll state, vehicle status, and configuration.
-
-    Parameters:
-        None.
-
-    Returns:
-        boolean - True if the player can override their view, false otherwise.
-
-    Realm:
-        Client.
-
-    Example Usage:
-        if player:CanOverrideView() then
-            print("Player can use third person view")
-        end
-]]
     function playerMeta:CanOverrideView()
         local ragdoll = Entity(self:getLocalVar("ragdoll", 0))
         local isInVehicle = self:hasValidVehicle()
@@ -2286,53 +955,12 @@ else
         return lia.option.get("thirdPersonEnabled", false) and lia.config.get("ThirdPersonEnabled", true) and IsValid(self) and self:getChar() and not IsValid(ragdoll)
     end
 
-    --[[
-    IsInThirdPerson
-
-    Purpose:
-        Checks if the player is currently in third person view mode.
-        Considers both global configuration and player preferences.
-
-    Parameters:
-        None.
-
-    Returns:
-        boolean - True if third person is enabled, false otherwise.
-
-    Realm:
-        Client.
-
-    Example Usage:
-        if player:IsInThirdPerson() then
-            print("Player is in third person view")
-        end
-]]
     function playerMeta:IsInThirdPerson()
         local thirdPersonEnabled = lia.config.get("ThirdPersonEnabled", true)
         local tpEnabled = lia.option.get("thirdPersonEnabled", false)
         return tpEnabled and thirdPersonEnabled
     end
 
-    --[[
-    getPlayTime
-
-    Purpose:
-        Gets the total play time for this player, including current session.
-        Considers character login time and previous play time.
-
-    Parameters:
-        None.
-
-    Returns:
-        number - Total play time in seconds.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local playTime = player:getPlayTime()
-        print("Total play time: " .. playTime .. " seconds")
-]]
     function playerMeta:getPlayTime()
         local hookResult = hook.Run("getPlayTime", self)
         if hookResult ~= nil then return hookResult end
@@ -2346,104 +974,20 @@ else
         return diff + RealTime() - (lia.joinTime or 0)
     end
 
-    --[[
-    getTotalOnlineTime
-
-    Purpose:
-        Gets the total time this player has been online across all sessions.
-        Includes stored time and current session time.
-
-    Parameters:
-        None.
-
-    Returns:
-        number - Total online time in seconds.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local totalTime = player:getTotalOnlineTime()
-        print("Total online time: " .. totalTime .. " seconds")
-]]
     function playerMeta:getTotalOnlineTime()
         local stored = self:getLiliaData("totalOnlineTime", 0)
         return stored + RealTime() - (lia.joinTime or 0)
     end
 
-    --[[
-    getLastOnline
-
-    Purpose:
-        Gets a human-readable string representing when the player was last online.
-        Returns relative time (e.g., "2 hours ago").
-
-    Parameters:
-        None.
-
-    Returns:
-        string - Human-readable time since last online.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local lastOnline = player:getLastOnline()
-        print("Last online: " .. lastOnline)
-]]
     function playerMeta:getLastOnline()
         local last = self:getLiliaData("lastOnline", os.time())
         return lia.time.TimeSince(last)
     end
 
-    --[[
-    getLastOnlineTime
-
-    Purpose:
-        Gets the timestamp when the player was last online.
-        Returns the raw timestamp value.
-
-    Parameters:
-        None.
-
-    Returns:
-        number - Unix timestamp of last online time.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local lastTime = player:getLastOnlineTime()
-        print("Last online timestamp: " .. lastTime)
-]]
     function playerMeta:getLastOnlineTime()
         return self:getLiliaData("lastOnline", os.time())
     end
 
-    --[[
-    setWaypoint
-
-    Purpose:
-        Sets a waypoint for the player at the specified location.
-        Creates a HUD element that shows the waypoint and distance.
-
-    Parameters:
-        name (string) - The name of the waypoint.
-        vector (Vector) - The position where the waypoint should be set.
-        onReach (function, optional) - Callback function when waypoint is reached.
-
-    Returns:
-        None.
-
-    Realm:
-        Client.
-
-    Example Usage:
-        -- Set a waypoint with callback when reached
-        player:setWaypoint("Home", Vector(100, 200, 300), function()
-            print("Reached home!")
-        end)
-]]
     function playerMeta:setWaypoint(name, vector, onReach)
         hook.Add("HUDPaint", "WeighPoint", function()
             if not IsValid(self) then
@@ -2470,55 +1014,10 @@ else
         end)
     end
 
-    --[[
-    setWeighPoint
-
-    Purpose:
-        Sets a weight-based waypoint for the player.
-        Similar to setWaypoint but with weight considerations.
-
-    Parameters:
-        name (string) - The name/description of the waypoint.
-        vector (Vector) - The position of the waypoint.
-        onReach (function, optional) - Callback function when waypoint is reached.
-
-    Returns:
-        None.
-
-    Realm:
-        Client.
-
-    Example Usage:
-        -- Set a weight-based waypoint
-        player:setWeighPoint("Heavy Item", Vector(500, 600, 700))
-]]
     function playerMeta:setWeighPoint(name, vector, onReach)
         self:setWaypoint(name, vector, onReach)
     end
 
-    --[[
-    setWaypointWithLogo
-
-    Purpose:
-        Sets a waypoint with a custom logo/icon for the player.
-        The logo will be displayed alongside the waypoint.
-
-    Parameters:
-        name (string) - The name/description of the waypoint.
-        vector (Vector) - The position of the waypoint.
-        logo (string) - The logo/icon identifier.
-        onReach (function, optional) - Callback function when waypoint is reached.
-
-    Returns:
-        None.
-
-    Realm:
-        Client.
-
-    Example Usage:
-        -- Set a waypoint with custom logo
-        player:setWaypointWithLogo("Shop", Vector(1000, 2000, 3000), "shop_icon")
-]]
     function playerMeta:setWaypointWithLogo(name, vector, logo, onReach)
         if not isstring(name) or not isvector(vector) then return end
         local logoMaterial
@@ -2559,30 +1058,6 @@ else
         end)
     end
 
-    --[[
-    getLiliaData
-
-    Purpose:
-        Retrieves a value from the player's local Lilia data storage.
-        This is the client-side version of getLiliaData.
-
-    Parameters:
-        key (string) - The data key to retrieve.
-        default (any) - The default value to return if the key doesn't exist.
-
-    Returns:
-        any - The stored value or the default value if not found.
-
-    Realm:
-        Client.
-
-    Example Usage:
-        -- Get player's local settings
-        local settings = player:getLiliaData("settings", {})
-        if settings then
-            print("Player has custom settings")
-        end
-]]
     function playerMeta:getLiliaData(key, default)
         local data = lia.localData and lia.localData[key]
         if data == nil then
@@ -2593,202 +1068,39 @@ else
     end
 
     playerMeta.getData = playerMeta.getLiliaData
-    --[[
-    getAllLiliaData
-
-    Purpose:
-        Retrieves all stored Lilia data for this player.
-        Returns a table containing all key-value pairs.
-
-    Parameters:
-        None.
-
-    Returns:
-        table - All stored Lilia data.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local allData = player:getAllLiliaData()
-        for key, value in pairs(allData) do
-            print(key .. ": " .. tostring(value))
-        end
-]]
     function playerMeta:getAllLiliaData()
         lia.localData = lia.localData or {}
         return lia.localData
     end
 
-    --[[
-    getFlags
-
-    Purpose:
-        Gets the flags associated with this player's character.
-        Returns the character flags if available, otherwise returns an empty string.
-
-    Parameters:
-        None.
-
-    Returns:
-        string - The character flags or empty string if no character.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local flags = player:getFlags()
-        print("Player flags: " .. flags)
-]]
     function playerMeta:getFlags()
         local char = self:getChar()
         return char and char:getFlags() or ""
     end
 
-    --[[
-    setFlags
-
-    Purpose:
-        Sets the flags for this player's character.
-        Updates the character flags if a character exists.
-
-    Parameters:
-        flags (string) - The flags to set for the character.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Set player character flags
-        player:setFlags("abc")
-]]
     function playerMeta:setFlags(flags)
         local char = self:getChar()
         if char then char:setFlags(flags) end
     end
 
-    --[[
-    giveFlags
-
-    Purpose:
-        Adds flags to this player's character.
-        Appends the new flags to existing character flags.
-
-    Parameters:
-        flags (string) - The flags to add to the character.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Give additional flags to player
-        player:giveFlags("d")
-]]
     function playerMeta:giveFlags(flags)
         local char = self:getChar()
         if char then char:giveFlags(flags) end
     end
 
-    --[[
-    takeFlags
-
-    Purpose:
-        Removes flags from this player's character.
-        Removes the specified flags from existing character flags.
-
-    Parameters:
-        flags (string) - The flags to remove from the character.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Remove flags from player
-        player:takeFlags("a")
-]]
     function playerMeta:takeFlags(flags)
         local char = self:getChar()
         if char then char:takeFlags(flags) end
     end
 
-    --[[
-    getPlayerFlags
-
-    Purpose:
-        Gets the player-specific flags stored in Lilia data.
-        Returns flags that are specific to the player, not the character.
-
-    Parameters:
-        None.
-
-    Returns:
-        string - The player flags or empty string if none set.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        local playerFlags = player:getPlayerFlags()
-        print("Player flags: " .. playerFlags)
-]]
     function playerMeta:getPlayerFlags()
         return self:getLiliaData("playerFlags", "")
     end
 
-    --[[
-    setPlayerFlags
-
-    Purpose:
-        Sets the player-specific flags in Lilia data.
-        Stores flags that are specific to the player, not the character.
-
-    Parameters:
-        flags (string) - The player flags to set.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Set player-specific flags
-        player:setPlayerFlags("xyz")
-]]
     function playerMeta:setPlayerFlags(flags)
         self:setLiliaData("playerFlags", flags)
     end
 
-    --[[
-    hasPlayerFlags
-
-    Purpose:
-        Checks if the player has any of the specified player flags.
-        Checks player-specific flags stored in Lilia data.
-
-    Parameters:
-        flags (string) - A string of flag characters to check.
-
-    Returns:
-        boolean - True if the player has at least one of the specified flags, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if player:hasPlayerFlags("x") then
-            print("Player has flag 'x'")
-        end
-]]
     function playerMeta:hasPlayerFlags(flags)
         local pFlags = self:getPlayerFlags()
         for i = 1, #flags do
@@ -2797,26 +1109,6 @@ else
         return false
     end
 
-    --[[
-    givePlayerFlags
-
-    Purpose:
-        Adds player-specific flags to this player.
-        Adds new flags that the player doesn't already have and runs callbacks.
-
-    Parameters:
-        flags (string) - The player flags to add.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Give additional player flags
-        player:givePlayerFlags("xyz")
-]]
     function playerMeta:givePlayerFlags(flags)
         local addedFlags = ""
         for i = 1, #flags do
@@ -2831,26 +1123,6 @@ else
         if addedFlags ~= "" then self:setPlayerFlags(self:getPlayerFlags() .. addedFlags) end
     end
 
-    --[[
-    takePlayerFlags
-
-    Purpose:
-        Removes player-specific flags from this player.
-        Removes specified flags and runs callbacks for removed flags.
-
-    Parameters:
-        flags (string) - The player flags to remove.
-
-    Returns:
-        None.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Remove player flags
-        player:takePlayerFlags("x")
-]]
     function playerMeta:takePlayerFlags(flags)
         local oldFlags = self:getPlayerFlags()
         local newFlags = oldFlags
@@ -2866,27 +1138,6 @@ else
         if newFlags ~= oldFlags then self:setPlayerFlags(newFlags) end
     end
 
-    --[[
-    hasFlags
-
-    Purpose:
-        Checks if the player has any of the specified flags.
-        Checks both character flags and player flags, and runs hook callbacks.
-
-    Parameters:
-        flags (string) - A string of flag characters to check.
-
-    Returns:
-        boolean - True if the player has at least one of the specified flags, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        if player:hasFlags("a") then
-            print("Player has flag 'a'")
-        end
-]]
     function playerMeta:hasFlags(flags)
         for i = 1, #flags do
             local flag = flags:sub(i, i)
@@ -2895,29 +1146,6 @@ else
         return hook.Run("CharHasFlags", self, flags) or false
     end
 
-    --[[
-    NetworkAnimation
-
-    Purpose:
-        Applies bone angle manipulations for animations on the client side.
-        This is the client-side version of NetworkAnimation.
-
-    Parameters:
-        active (boolean) - Whether the animation is active.
-        boneData (table) - The bone data containing bone names and angles.
-
-    Returns:
-        None.
-
-    Realm:
-        Client.
-
-    Example Usage:
-        -- Apply bone animation data
-        player:NetworkAnimation(true, {
-            ["ValveBiped.Bip01_Head1"] = Angle(0, 45, 0)
-        })
-]]
     function playerMeta:NetworkAnimation(active, boneData)
         for name, ang in pairs(boneData) do
             local i = self:LookupBone(name)
@@ -2926,28 +1154,6 @@ else
     end
 end
 
---[[
-    playTimeGreaterThan
-
-    Purpose:
-        Checks if the player's total play time is greater than the specified time.
-        Compares the player's accumulated play time against the given threshold.
-
-    Parameters:
-        time (number) - The time threshold to compare against in seconds.
-
-    Returns:
-        boolean - True if the player's play time is greater than the specified time, false otherwise.
-
-    Realm:
-        Shared.
-
-    Example Usage:
-        -- Check if player has played for more than 1 hour
-        if player:playTimeGreaterThan(3600) then
-            print("Player has been playing for more than 1 hour")
-        end
-]]
 function playerMeta:playTimeGreaterThan(time)
     local playTime = self:getPlayTime()
     if not playTime or not time then return false end


### PR DESCRIPTION
## Summary
- migrate Player meta documentation comments into documentation
- remove inline comments from player meta file

## Testing
- `luac -p gamemode/core/meta/player.lua`


------
https://chatgpt.com/codex/tasks/task_e_689968e5a4588327a0c606598dbff72a