### PR TITLE
Guard against invalid player when saving spawn data

### DIFF
--- a/gamemode/modules/spawns/libraries/server.lua
+++ b/gamemode/modules/spawns/libraries/server.lua
@@ -90,8 +90,10 @@ end
 
 function MODULE:CharPreSave(character)
     local client = character:getPlayer()
+    if not IsValid(client) then return end
+
     local InVehicle = client:hasValidVehicle()
-    if IsValid(client) and not InVehicle and client:Alive() then
+    if not InVehicle and client:Alive() then
         character:setLastPos({
             pos = client:GetPos(),
             ang = client:EyeAngles(),


### PR DESCRIPTION
## Summary
- Avoid nil player errors in `CharPreSave` by ensuring the character's player exists before accessing vehicle or position data

## Testing
- `luacheck gamemode/modules/spawns/libraries/server.lua` (warnings remain)
- `luac -p gamemode/modules/spawns/libraries/server.lua` *(fails: unexpected symbol near '')*


------
https://chatgpt.com/codex/tasks/task_e_689971fc2b3c8327a27d936da8ccfce4