### PR TITLE
Exclude staff characters from max character limit

### DIFF
--- a/documentation/docs/hooks/gamemode_hooks.md
+++ b/documentation/docs/hooks/gamemode_hooks.md
@@ -1356,15 +1356,16 @@ end)
 
 **Purpose**
 
-Checks if the local player may start creating a character. Determines if the player may create a new character.
+Checks if a player may start creating a character. Determines if the player may create a new character.
 
 **Parameters**
 
-- `player` (`Player`): Local player.
+- `player` (`Player`): The player attempting to create a character.
+- `data` (`table`|nil): Optional character data being created. Only supplied on the server.
 
 **Realm**
 
-`Client`
+`Shared`
 
 **Returns**
 
@@ -1456,7 +1457,8 @@ Override to change how many characters a player can have. Returns the maximum nu
 
 **Parameters**
 
-- `player` (`Player`): Local player.
+- `player` (`Player`): The player attempting to create a character.
+- `data` (`table`|nil): Optional character data being created. Only supplied on the server.
 
 **Realm**
 

--- a/gamemode/modules/mainmenu/module.lua
+++ b/gamemode/modules/mainmenu/module.lua
@@ -127,7 +127,11 @@ else
     end)
 end
 
-function MODULE:CanPlayerCreateChar(client)
+function MODULE:CanPlayerCreateChar(client, data)
+    -- allow staff characters to bypass the max character limit
+    local isStaffCharacter = istable(data) and data.faction == FACTION_STAFF
+    if isStaffCharacter then return true end
+
     if SERVER then
         local count = #client.liaCharList or 0
         local maxChars = hook.Run("GetMaxPlayerChar", client) or lia.config.get("MaxCharacters")

--- a/gamemode/modules/mainmenu/netcalls/server.lua
+++ b/gamemode/modules/mainmenu/netcalls/server.lua
@@ -90,7 +90,6 @@ net.Receive("liaCharChoose", function(_, client)
 end)
 
 net.Receive("liaCharCreate", function(_, client)
-    if hook.Run("CanPlayerCreateChar", client) == false then return end
     local function response(id, message, ...)
         net.Start("liaCharCreate")
         net.WriteUInt(id or 0, 32)
@@ -103,6 +102,8 @@ net.Receive("liaCharCreate", function(_, client)
     for _ = 1, numValues do
         data[net.ReadString()] = net.ReadType()
     end
+
+    if hook.Run("CanPlayerCreateChar", client, data) == false then return response(nil, "maxCharactersReached") end
 
     local originalData = table.Copy(data)
     local newData = {}


### PR DESCRIPTION
## Summary
- Allow staff characters to be created even when a player is at the regular character limit
- Check character data before enforcing max character count on creation
- Document the optional character data passed to `CanPlayerCreateChar`

## Testing
- `luacheck gamemode/modules/mainmenu/module.lua gamemode/modules/mainmenu/netcalls/server.lua` *(fails: command not found)*
- `luac -p gamemode/modules/mainmenu/module.lua gamemode/modules/mainmenu/netcalls/server.lua` *(fails: '=' expected near 'end')*

------
https://chatgpt.com/codex/tasks/task_e_6899752686c88327b10a90f68b2c58b3