### PR TITLE
fix: only close character menu after successful switch

### DIFF
--- a/gamemode/core/derma/mainmenu/character.lua
+++ b/gamemode/core/derma/mainmenu/character.lua
@@ -568,10 +568,14 @@ function PANEL:createSelectedCharacterInfoPanel(character)
         if character:isBanned() then
             local characterName = character:getName()
             Derma_Query(L("pkDialogMessage", characterName), L("permaKillTitle"), L("iAcknowledge"), function() end)
-        else
-            lia.module.list["mainmenu"]:chooseCharacter(character:getID()):catch(function(err) if err and err ~= "" then LocalPlayer():notifyLocalized(err) end end)
-            self:Remove()
+            return
         end
+
+        lia.module.list["mainmenu"]:chooseCharacter(character:getID()):next(function()
+            if IsValid(self) then self:Remove() end
+        end):catch(function(err)
+            if err and err ~= "" then LocalPlayer():notifyLocalized(err) end
+        end)
     end
 
     self.deleteBtn = self:Add("liaSmallButton")


### PR DESCRIPTION
## Summary
- ensure character menu closes only after character switch succeeds

## Testing
- `luacheck gamemode/core/derma/mainmenu/character.lua`

------
https://chatgpt.com/codex/tasks/task_e_689975e44dd88327b34da4c88c3756a5