### PR TITLE
feat: add comprehensive search for settings

### DIFF
--- a/gamemode/core/libraries/config.lua
+++ b/gamemode/core/libraries/config.lua
@@ -1401,9 +1401,10 @@ hook.Add("PopulateConfigurationButtons", "liaConfigPopulate", function(pages)
                 local opt = lia.config.stored[k]
                 local n = opt.name or ""
                 local d = opt.desc or ""
+                local cat = opt.category or L("misc")
                 local ln, ld = n:lower(), d:lower()
-                if filter == "" or ln:find(filter, 1, true) or ld:find(filter, 1, true) then
-                    local cat = opt.category or L("misc")
+                local lk, lc = k:lower(), cat:lower()
+                if filter == "" or ln:find(filter, 1, true) or ld:find(filter, 1, true) or lk:find(filter, 1, true) or lc:find(filter, 1, true) then
                     categories[cat] = categories[cat] or {}
                     categories[cat][#categories[cat] + 1] = {
                         key = k,

--- a/gamemode/core/libraries/option.lua
+++ b/gamemode/core/libraries/option.lua
@@ -381,9 +381,10 @@ hook.Add("PopulateConfigurationButtons", "liaOptionsPopulate", function(pages)
             if not opt.visible or isfunction(opt.visible) and opt.visible() then
                 local name = opt.name
                 local desc = opt.desc or ""
+                local catName = opt.data and opt.data.category or L("misc")
                 local ln, ld = name:lower(), desc:lower()
-                if filter == "" or ln:find(filter, 1, true) or ld:find(filter, 1, true) then
-                    local catName = opt.data and opt.data.category or L("misc")
+                local lk, lc = key:lower(), catName:lower()
+                if filter == "" or ln:find(filter, 1, true) or ld:find(filter, 1, true) or lk:find(filter, 1, true) or lc:find(filter, 1, true) then
                     categories[catName] = categories[catName] or {}
                     categories[catName][#categories[catName] + 1] = {
                         key = key,


### PR DESCRIPTION
## Summary
- broaden option search to include key and category names
- expand config search to match by key and category

## Testing
- `tail -c +4 gamemode/core/libraries/option.lua | luac -p -`
- `luac -p gamemode/core/libraries/config.lua`


------
https://chatgpt.com/codex/tasks/task_e_6899869d01148327b34da80cf2d490ce