### PR TITLE
Persist staff Discord and add edit command

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -267,6 +267,7 @@ LANGUAGE = {
     areYouSure = "Are you sure?",
     descChangedTarget = "%s has changed %s's character description.",
     staffDescUpdated = "Staff character description updated!",
+    staffdiscordDesc = "Sets your staff Discord username.",
     disconnect = "Disconnect",
     noPerm = "You are not allowed to do this.",
     chgName = "Change Name",

--- a/gamemode/modules/mainmenu/commands.lua
+++ b/gamemode/modules/mainmenu/commands.lua
@@ -1,0 +1,19 @@
+local MODULE = MODULE
+
+lia.command.add("staffdiscord", {
+    desc = "staffdiscordDesc",
+    arguments = {lia.type.string},
+    onRun = function(client, discord)
+        local character = client:getChar()
+        if not character or character:getFaction() ~= FACTION_STAFF then
+            client:notifyLocalized("noStaffChar")
+            return
+        end
+
+        client:setLiliaData("staffDiscord", discord)
+        local description = "A Staff Character, Discord: " .. discord .. ", SteamID: " .. client:SteamID()
+        character:setDesc(description)
+        client:notifyLocalized("staffDescUpdated")
+    end
+})
+

--- a/gamemode/modules/mainmenu/netcalls/server.lua
+++ b/gamemode/modules/mainmenu/netcalls/server.lua
@@ -158,7 +158,15 @@ net.Receive("liaCharDelete", function(_, client)
 end)
 
 hook.Add("PlayerLoadedChar", "StaffCharacterDiscordPrompt", function(client, character)
-    if character:getFaction() == FACTION_STAFF and (character:getDesc() == "" or character:getDesc():find("^A Staff Character")) then
+    if character:getFaction() ~= FACTION_STAFF then return end
+    local storedDiscord = client:getLiliaData("staffDiscord")
+    if storedDiscord and storedDiscord ~= "" then
+        local description = "A Staff Character, Discord: " .. storedDiscord .. ", SteamID: " .. client:SteamID()
+        character:setDesc(description)
+        return
+    end
+
+    if character:getDesc() == "" or character:getDesc():find("^A Staff Character") then
         timer.Simple(2, function()
             if IsValid(client) and client:getChar() == character then
                 net.Start("liaStaffDiscordPrompt")
@@ -172,6 +180,7 @@ net.Receive("liaStaffDiscordResponse", function(_, client)
     local discord = net.ReadString()
     local character = client:getChar()
     if not character or character:getFaction() ~= FACTION_STAFF then return end
+    client:setLiliaData("staffDiscord", discord)
     local steamID = client:SteamID()
     local description = "A Staff Character, Discord: " .. discord .. ", SteamID: " .. steamID
     character:setDesc(description)

--- a/gamemode/modules/teams/libraries/shared.lua
+++ b/gamemode/modules/teams/libraries/shared.lua
@@ -24,5 +24,8 @@ end
 function MODULE:GetDefaultCharDesc(client, faction)
     local info = lia.faction.indices[faction]
     if info and info.GetDefaultDesc then return info:GetDefaultDesc(client) end
-    if faction == FACTION_STAFF then return "A Staff Character, Discord: not provided, SteamID: " .. client:SteamID(), true end
+    if faction == FACTION_STAFF then
+        local discord = SERVER and client:getLiliaData("staffDiscord", "not provided") or "not provided"
+        return "A Staff Character, Discord: " .. discord .. ", SteamID: " .. client:SteamID(), true
+    end
 end


### PR DESCRIPTION
## Summary
- Store staff Discord username in player data and reuse it when staff characters load
- Add `staffdiscord` command so staff can update their stored Discord handle
- Use saved Discord for default staff character description and add language entry

## Testing
- `luacheck gamemode/modules/mainmenu/netcalls/server.lua` *(fails: expected '=' near 'end')*


------
https://chatgpt.com/codex/tasks/task_e_68998fd4e29c8327a9a275bd7935c3ae