### PR TITLE
feat: allow character rotation with A and D

### DIFF
--- a/gamemode/core/derma/mainmenu/character.lua
+++ b/gamemode/core/derma/mainmenu/character.lua
@@ -790,6 +790,24 @@ function PANEL:Think()
         self.logo:MoveToFront()
         self:UpdateLogoPosition()
     end
+
+    if self.isLoadMode and IsValid(self.modelEntity) then
+        local ang = self.modelEntity:GetAngles()
+        local rotate = 0
+
+        if input.IsKeyDown(KEY_A) then
+            rotate = rotate + FrameTime() * 120
+        end
+
+        if input.IsKeyDown(KEY_D) then
+            rotate = rotate - FrameTime() * 120
+        end
+
+        if rotate ~= 0 then
+            ang.y = ang.y + rotate
+            self.modelEntity:SetAngles(ang)
+        end
+    end
 end
 
 vgui.Register("liaCharacter", PANEL, "EditablePanel")


### PR DESCRIPTION
## Summary
- enable rotating selected character using A and D keys

## Testing
- `luacheck gamemode/core/derma/mainmenu/character.lua` *(fails: command not found)*
- `luac -p gamemode/core/derma/mainmenu/character.lua`


------
https://chatgpt.com/codex/tasks/task_e_6899f23dc69c8327b3673295ba1138b7