### PR TITLE
feat: validate privilege parameters

### DIFF
--- a/gamemode/core/libraries/admin.lua
+++ b/gamemode/core/libraries/admin.lua
@@ -217,6 +217,11 @@ local function camiBootstrapFromExisting()
 end
 
 function lia.administrator.hasAccess(ply, privilege)
+    if not isstring(privilege) then
+        lia.error("hasAccess expected a string privilege, got " .. tostring(privilege))
+        return false
+    end
+
     local grp = "user"
     if isstring(ply) then
         grp = ply

--- a/gamemode/core/libraries/commands.lua
+++ b/gamemode/core/libraries/commands.lua
@@ -96,7 +96,13 @@ function lia.command.hasAccess(client, command, data)
     local accessLevels = superAdminOnly and "superadmin" or adminOnly and "admin" or "user"
     local privilegeName = data.privilege and L(data.privilege) or accessLevels == "user" and L("globalAccess") or L("accessTo", command)
     local hasAccess = true
-    if accessLevels ~= "user" then hasAccess = client:hasPrivilege(privilegeID) end
+    if accessLevels ~= "user" then
+        if not isstring(privilegeID) then
+            lia.error("Command '" .. tostring(command) .. "' has invalid privilege ID type: " .. tostring(privilegeID))
+            return false, privilegeName
+        end
+        hasAccess = client:hasPrivilege(privilegeID)
+    end
     local hookResult = hook.Run("CanPlayerUseCommand", client, command)
     if hookResult ~= nil then return hookResult, privilegeName end
     local char = IsValid(client) and client.getChar and client:getChar()

--- a/gamemode/core/meta/player.lua
+++ b/gamemode/core/meta/player.lua
@@ -18,6 +18,11 @@ do
 end
 
 function playerMeta:hasPrivilege(privilegeName)
+    if not isstring(privilegeName) then
+        lia.error("hasPrivilege expected a string, got " .. tostring(privilegeName))
+        return false
+    end
+
     return lia.administrator.hasAccess(self, privilegeName)
 end
 


### PR DESCRIPTION
## Summary
- Add type checks for privilege name parameters
- Guard command privilege lookup to catch invalid IDs
- Validate privilege argument in admin access checks

## Testing
- `luacheck gamemode/core/meta/player.lua gamemode/core/libraries/commands.lua gamemode/core/libraries/admin.lua` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: Unable to locate package luacheck)*

------
https://chatgpt.com/codex/tasks/task_e_689b0e076e6483278d2942417a5b6977