### PR TITLE
Derive module visibility from uniqueID prefix

### DIFF
--- a/documentation/docs/definitions/module.md
+++ b/documentation/docs/definitions/module.md
@@ -27,11 +27,9 @@ A `MODULE` table defines a self-contained add-on for the Lilia framework. Each f
 | `Dependencies` | `table` | `nil` | Files or directories included before the module loads. |
 | `folder` | `string` | `""` | Filesystem path where the module resides. |
 | `path` | `string` | `""` | Absolute path to the module’s root directory. |
-| `uniqueID` | `string` | `""` | Internal identifier for the module list. |
+| `uniqueID` | `string` | `""` | Internal identifier for the module list. Prefix with `public_` or `private_` to opt into version checks. |
 | `loading` | `boolean` | `false` | True while the module is in the process of loading. |
 | `ModuleLoaded` | `function` | `nil` | Callback run after module finishes loading. |
-| `Public` | `boolean` | `false` | Participates in public version checks. |
-| `Private` | `boolean` | `false` | Uses private version checking. |
 
 ---
 
@@ -127,42 +125,6 @@ Version number used for compatibility checks.
 
 ```lua
 MODULE.version = 1.0
-```
-
----
-
-#### `Public`
-
-**Type:**
-
-`boolean`
-
-**Description:**
-
-When true, the module participates in public version checks.
-
-**Example Usage:**
-
-```lua
-MODULE.Public = true
-```
-
----
-
-#### `Private`
-
-**Type:**
-
-`boolean`
-
-**Description:**
-
-When true, the module uses private version checking.
-
-**Example Usage:**
-
-```lua
-MODULE.Private = true
 ```
 
 ---
@@ -362,7 +324,7 @@ print(MODULE.path)
 
 **Description:**
 
-Identifier used internally for the module list.
+Identifier used internally for the module list. Prefix with `public_` or `private_` to enable public or private version checks.
 
 **Example Usage:**
 
@@ -419,7 +381,7 @@ When loading a module from a directory, Lilia automatically scans for common sub
 A complete example showing common fields in use:
 
 ```lua
--- example/gamemode/modules/myfeature/module.lua
+-- example/gamemode/modules/public_myfeature/module.lua
 MODULE.name = "My Feature"
 MODULE.author = "76561198012345678"
 MODULE.discord = "@example"
@@ -427,7 +389,6 @@ MODULE.version = 1.0
 MODULE.desc = "Adds an example feature used to demonstrate module creation."
 
 MODULE.enabled = true
-MODULE.Public = true
 
 MODULE.WorkshopContent = {
     "1234567890"

--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -816,6 +816,16 @@ local publicURL = "https://raw.githubusercontent.com/LiliaFramework/Modules/refs
 local privateURL = "https://raw.githubusercontent.com/bleonheart/bleonheart.github.io/main/modules.json"
 local versionURL = "https://raw.githubusercontent.com/LiliaFramework/LiliaFramework.github.io/main/version.json"
 local function checkPublicModules()
+    local hasPublic = false
+    for uniqueID in pairs(lia.module.list) do
+        if string.StartsWith(uniqueID, "public_") then
+            hasPublic = true
+            break
+        end
+    end
+
+    if not hasPublic then return end
+
     fetchURL(publicURL, function(body, code)
         if code ~= 200 then
             lia.updater(L("moduleListHTTPError", code))
@@ -828,27 +838,39 @@ local function checkPublicModules()
             return
         end
 
-        for _, info in ipairs(lia.module.versionChecks) do
-            local match
-            for _, m in ipairs(remote) do
-                if m.public_uniqueID == info.uniqueID then
-                    match = m
-                    break
+        for uniqueID, mod in pairs(lia.module.list) do
+            if string.StartsWith(uniqueID, "public_") then
+                local match
+                for _, m in ipairs(remote) do
+                    if m.public_uniqueID == uniqueID then
+                        match = m
+                        break
+                    end
                 end
-            end
 
-            if not match then
-                lia.updater(L("moduleUniqueIDNotFound", info.uniqueID))
-            elseif not match.version then
-                lia.updater(L("moduleNoRemoteVersion", info.name))
-            elseif info.version and versionCompare(info.version, match.version) < 0 then
-                lia.updater(L("moduleOutdated", info.name, match.version))
+                if not match then
+                    lia.updater(L("moduleUniqueIDNotFound", uniqueID))
+                elseif not match.version then
+                    lia.updater(L("moduleNoRemoteVersion", mod.name))
+                elseif mod.version and versionCompare(mod.version, match.version) < 0 then
+                    lia.updater(L("moduleOutdated", mod.name, match.version))
+                end
             end
         end
     end, function(err) lia.updater(L("moduleListError", err)) end)
 end
 
 local function checkPrivateModules()
+    local hasPrivate = false
+    for uniqueID in pairs(lia.module.list) do
+        if string.StartsWith(uniqueID, "private_") then
+            hasPrivate = true
+            break
+        end
+    end
+
+    if not hasPrivate then return end
+
     fetchURL(privateURL, function(body, code)
         if code ~= 200 then
             lia.updater(L("privateModuleListHTTPError", code))
@@ -861,11 +883,13 @@ local function checkPrivateModules()
             return
         end
 
-        for _, info in ipairs(lia.module.privateVersionChecks) do
-            for _, m in ipairs(remote) do
-                if m.private_uniqueID == info.uniqueID and m.version and info.version and versionCompare(info.version, m.version) < 0 then
-                    lia.updater(L("privateModuleOutdated", info.name))
-                    break
+        for uniqueID, mod in pairs(lia.module.list) do
+            if string.StartsWith(uniqueID, "private_") then
+                for _, m in ipairs(remote) do
+                    if m.private_uniqueID == uniqueID and m.version and mod.version and versionCompare(mod.version, m.version) < 0 then
+                        lia.updater(L("privateModuleOutdated", mod.name))
+                        break
+                    end
                 end
             end
         end
@@ -907,8 +931,8 @@ end
 function GM:InitializedModules()
     if self.UpdateCheckDone then return end
     timer.Simple(0, function()
-        if lia.module.versionChecks then checkPublicModules() end
-        if lia.module.privateVersionChecks then checkPrivateModules() end
+        checkPublicModules()
+        checkPrivateModules()
         checkFrameworkVersion()
     end)
 

--- a/gamemode/core/libraries/modularity.lua
+++ b/gamemode/core/libraries/modularity.lua
@@ -152,24 +152,6 @@ function lia.module.load(uniqueID, path, isSingleFile, variable, skipSubmodules)
         lia.module.list[uniqueID] = MODULE
         if not skipSubmodules then loadSubmodules(path) end
         if MODULE.ModuleLoaded then MODULE:ModuleLoaded() end
-        if MODULE.Public then
-            lia.module.versionChecks = lia.module.versionChecks or {}
-            table.insert(lia.module.versionChecks, {
-                uniqueID = MODULE.uniqueID,
-                name = MODULE.name,
-                localVersion = MODULE.version,
-            })
-        end
-
-        if MODULE.Private then
-            lia.module.privateVersionChecks = lia.module.privateVersionChecks or {}
-            table.insert(lia.module.privateVersionChecks, {
-                uniqueID = MODULE.uniqueID,
-                name = MODULE.name,
-                localVersion = MODULE.version,
-            })
-        end
-
         if string.StartsWith(path, engine.ActiveGamemode() .. "/modules") then lia.bootstrap(L("module"), L("moduleFinishedLoading", MODULE.name)) end
         _G[variable] = prev
     end


### PR DESCRIPTION
## Summary
- detect public and private modules via `MODULE.uniqueID` prefix
- document the new uniqueID naming convention
- dynamically gather modules for version checks instead of caching lists

## Testing
- `~/.luarocks/bin/luacheck gamemode/core/libraries/modularity.lua gamemode/core/hooks/server.lua | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689b1cb511b88327ab0f005421287556