### PR TITLE
feat: add inventory size overrides

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -66,6 +66,7 @@ LANGUAGE = {
     mePossessiveFormat = "**%s's %s",
     setInventorySizeDesc = "Force set a characters's custom inventory size",
     updateInventorySizeDesc = "Update a player's inventory size based on default settings",
+    setInventorySizeOverrideDesc = "Set a character's inventory size and save override",
     targetNotFound = "Target not found",
     invalidWidthHeight = "Invalid width or height",
     widthHeightOutOfRange = "Width must be %s–%s and height must be %s–%s",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -66,6 +66,7 @@ LANGUAGE = {
     mePossessiveFormat = "**%s de %s",
     setInventorySizeDesc = "Force la taille d'inventaire personnalisée d'un personnage",
     updateInventorySizeDesc = "Met à jour la taille d'inventaire d'un joueur selon les paramètres par défaut",
+    setInventorySizeOverrideDesc = "Définit la taille d'inventaire d'un personnage et enregistre le remplacement",
     targetNotFound = "Cible non trouvée",
     invalidWidthHeight = "Largeur ou hauteur invalide",
     widthHeightOutOfRange = "La largeur doit être comprise entre %s–%s et la hauteur entre %s–%s",

--- a/gamemode/languages/german.lua
+++ b/gamemode/languages/german.lua
@@ -66,6 +66,7 @@ LANGUAGE = {
     mePossessiveFormat = "**%ss %s",
     setInventorySizeDesc = "Setzt die benutzerdefinierte Inventargröße eines Charakters.",
     updateInventorySizeDesc = "Aktualisiert die Inventargröße eines Spielers basierend auf den Standardeinstellungen.",
+    setInventorySizeOverrideDesc = "Legt die Inventargröße eines Charakters fest und speichert die Überschreibung",
     targetNotFound = "Ziel nicht gefunden",
     invalidWidthHeight = "Ungültige Breite oder Höhe",
     widthHeightOutOfRange = "Breite muss %s–%s und Höhe muss %s–%s sein",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -66,6 +66,7 @@ LANGUAGE = {
     mePossessiveFormat = "**%s de %s",
     setInventorySizeDesc = "Força o tamanho personalizado do inventário de um personagem",
     updateInventorySizeDesc = "Atualiza o tamanho do inventário de um jogador com base nas definições padrão",
+    setInventorySizeOverrideDesc = "Define o tamanho do inventário de um personagem e guarda a substituição",
     targetNotFound = "Alvo não encontrado",
     invalidWidthHeight = "Largura ou altura inválida",
     widthHeightOutOfRange = "A largura deve ser %s–%s e a altura deve ser %s–%s",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -66,6 +66,7 @@ LANGUAGE = {
     mePossessiveFormat = "**%s: %s",
     setInventorySizeDesc = "Принудительно установить размер инвентаря персонажа",
     updateInventorySizeDesc = "Обновить размер инвентаря игрока по умолчанию",
+    setInventorySizeOverrideDesc = "Установить размер инвентаря персонажа и сохранить переопределение",
     targetNotFound = "Цель не найдена",
     invalidWidthHeight = "Недопустимая ширина или высота",
     widthHeightOutOfRange = "Ширина должна быть %s–%s, высота — %s–%s",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -66,6 +66,7 @@ LANGUAGE = {
     mePossessiveFormat = "**%s de %s",
     setInventorySizeDesc = "Forzar el tamaño de inventario personalizado de un personaje",
     updateInventorySizeDesc = "Actualiza el tamaño de inventario de un jugador según la configuración predeterminada",
+    setInventorySizeOverrideDesc = "Establece el tamaño de inventario de un personaje y guarda la anulación",
     targetNotFound = "Objetivo no encontrado",
     invalidWidthHeight = "Ancho o alto inválido",
     widthHeightOutOfRange = "El ancho debe ser %s–%s y el alto debe ser %s–%s",

--- a/gamemode/modules/inventory/commands.lua
+++ b/gamemode/modules/inventory/commands.lua
@@ -26,7 +26,7 @@
             return
         end
 
-        local dw, dh = hook.Run("GetDefaultInventorySize", target)
+        local dw, dh = hook.Run("GetDefaultInventorySize", target, char)
         dw = dw or lia.config.get("invW")
         dh = dh or lia.config.get("invH")
         local w, h = inv:getSize()
@@ -37,6 +37,7 @@
 
         inv:setSize(dw, dh)
         inv:sync(target)
+        char:setData("invSizeOverride", nil)
         client:notifyLocalized("updatedInventorySize", target:Name(), dw, dh)
         lia.log.add(client, "invUpdateSize", target:Name(), dw, dh)
     end
@@ -88,4 +89,56 @@ lia.command.add("setinventorysize", {
         lia.log.add(client, "invSetSize", target:Name(), w, h)
         client:notifyLocalized("setInventorySizeNotify", target:Name(), w, h)
     end
+})
+
+lia.command.add("setinventorysizeoverride", {
+    adminOnly = true,
+    desc = "setInventorySizeOverrideDesc",
+    arguments = {
+        {
+            name = "name",
+            type = "player"
+        },
+        {
+            name = "width",
+            type = "string"
+        },
+        {
+            name = "height",
+            type = "string"
+        },
+    },
+    onRun = function(client, args)
+        local target = lia.util.findPlayer(client, args[1])
+        if not target or not IsValid(target) then
+            client:notifyLocalized("targetNotFound")
+            return
+        end
+
+        local w, h = tonumber(args[2]), tonumber(args[3])
+        if not w or not h then
+            client:notifyLocalized("invalidWidthHeight")
+            return
+        end
+
+        local minW, maxW, minH, maxH = 1, 10, 1, 10
+        if w < minW or w > maxW or h < minH or h > maxH then
+            client:notifyLocalized("widthHeightOutOfRange", minW, maxW, minH, maxH)
+            return
+        end
+
+        local char = target:getChar()
+        local inv = char and char:getInv()
+        if inv then
+            inv:setSize(w, h)
+            inv:sync(target)
+        end
+
+        if char then
+            char:setData("invSizeOverride", {w, h})
+        end
+
+        lia.log.add(client, "invSetSize", target:Name(), w, h)
+        client:notifyLocalized("setInventorySizeNotify", target:Name(), w, h)
+    end,
 })

--- a/gamemode/modules/inventory/config.lua
+++ b/gamemode/modules/inventory/config.lua
@@ -1,10 +1,13 @@
-﻿lia.config.add("invW", "invWidth", 6, function(_, newW)
+lia.config.add("invW", "invWidth", 6, function(_, newW)
     if not SERVER then return end
     for _, client in player.Iterator() do
         if not IsValid(client) then continue end
-        local inv = client:getChar():getInv()
-        local dw, dh = hook.Run("GetDefaultInventorySize", client)
-        dw = dw or newW
+        local char = client:getChar()
+        if not char or char:getData("invSizeOverride") then continue end
+        local inv = char:getInv()
+        if not inv then continue end
+        local dw, dh = hook.Run("GetDefaultInventorySize", client, char)
+        dw = dw or lia.config.get("invW")
         dh = dh or lia.config.get("invH")
         local w, h = inv:getSize()
         if w ~= dw or h ~= dh then
@@ -14,7 +17,7 @@
     end
 
     local json = util.TableToJSON({newW})
-    lia.db.query("UPDATE lia_invdata SET value = '" .. lia.db.escape(json) .. "' " .. "WHERE key = 'w' AND invID IN (SELECT invID FROM lia_inventories WHERE charID IS NOT NULL)")
+    lia.db.query("UPDATE lia_invdata SET value = '" .. lia.db.escape(json) .. "' WHERE key = 'w' AND invID IN (SELECT invID FROM lia_inventories WHERE charID IS NOT NULL)")
 end, {
     desc = "invWidthDesc",
     category = "character",
@@ -27,10 +30,13 @@ lia.config.add("invH", "invHeight", 4, function(_, newH)
     if not SERVER then return end
     for _, client in player.Iterator() do
         if not IsValid(client) then continue end
-        local inv = client:getChar():getInv()
-        local dw, dh = hook.Run("GetDefaultInventorySize", client)
+        local char = client:getChar()
+        if not char or char:getData("invSizeOverride") then continue end
+        local inv = char:getInv()
+        if not inv then continue end
+        local dw, dh = hook.Run("GetDefaultInventorySize", client, char)
         dw = dw or lia.config.get("invW")
-        dh = dh or newH
+        dh = dh or lia.config.get("invH")
         local w, h = inv:getSize()
         if w ~= dw or h ~= dh then
             inv:setSize(dw, dh)
@@ -39,7 +45,7 @@ lia.config.add("invH", "invHeight", 4, function(_, newH)
     end
 
     local json = util.TableToJSON({newH})
-    lia.db.query("UPDATE lia_invdata SET value = '" .. lia.db.escape(json) .. "' " .. "WHERE key = 'h' AND invID IN (SELECT invID FROM lia_inventories WHERE charID IS NOT NULL)")
+    lia.db.query("UPDATE lia_invdata SET value = '" .. lia.db.escape(json) .. "' WHERE key = 'h' AND invID IN (SELECT invID FROM lia_inventories WHERE charID IS NOT NULL)")
 end, {
     desc = "invHeightDesc",
     category = "character",
@@ -47,3 +53,4 @@ end, {
     min = 1,
     max = 10
 })
+


### PR DESCRIPTION
## Summary
- add persistent inventory size overrides with highest priority
- provide `setinventorysizeoverride` admin command
- respect overrides when configs change or characters load

## Testing
- `luacheck gamemode/modules/inventory/commands.lua gamemode/modules/inventory/libraries/server.lua gamemode/modules/inventory/config.lua gamemode/languages/english.lua gamemode/languages/german.lua gamemode/languages/russian.lua gamemode/languages/spanish.lua gamemode/languages/portuguese.lua gamemode/languages/french.lua` *(fails: 304 warnings / 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_689b407344c08327ba80f73a2920bc35