### PR TITLE
Use liaDListView in table UI

### DIFF
--- a/gamemode/core/libraries/util.lua
+++ b/gamemode/core/libraries/util.lua
@@ -638,13 +638,17 @@ else
 
     function lia.util.CreateTableUI(title, columns, data, options, charID)
         local frameWidth, frameHeight = ScrW() * 0.8, ScrH() * 0.8
-        local frame = vgui.Create("DFrame")
-        frame:SetTitle(title and L(title) or L("tableListTitle"))
+        local frame = vgui.Create("liaDListView")
+        frame:SetWindowTitle(title and L(title) or L("tableListTitle"))
         frame:SetSize(frameWidth, frameHeight)
         frame:Center()
         frame:MakePopup()
-        local listView = vgui.Create("DListView", frame)
+        if IsValid(frame.topBar) then frame.topBar:Remove() end
+        if IsValid(frame.statusBar) then frame.statusBar:Remove() end
+        local listView = frame.listView
         listView:Dock(FILL)
+        listView:Clear()
+        if listView.ClearColumns then listView:ClearColumns() end
         for _, colInfo in ipairs(columns or {}) do
             local localizedName = colInfo.name and L(colInfo.name) or L("na")
             local col = listView:AddColumn(localizedName)


### PR DESCRIPTION
## Summary
- build table UI with `liaDListView` instead of raw `DFrame` and `DListView`
- remove unused top/status bars and adapt list construction

## Testing
- `luacheck gamemode/core/libraries/util.lua` *(fails: `expected '=' near 'end'`)*

------
https://chatgpt.com/codex/tasks/task_e_689b46d1d5448327a1781895c48e3971