### PR TITLE
Skip redundant adminstick subcategory menus

### DIFF
--- a/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
@@ -190,6 +190,14 @@ end
 local function GetOrCreateSubCategoryMenu(parent, categoryKey, subcategoryKey, store)
     local category = adminStickCategories[categoryKey]
     if not category or not category.subcategories or not category.subcategories[subcategoryKey] then return parent end
+
+    local count = 0
+    for _ in pairs(category.subcategories) do
+        count = count + 1
+        if count > 1 then break end
+    end
+    if count <= 1 then return parent end
+
     local subcategory = category.subcategories[subcategoryKey]
     local fullKey = categoryKey .. "_" .. subcategoryKey
     if not store[fullKey] then


### PR DESCRIPTION
## Summary
- avoid creating an admin stick subcategory menu when only a single subcategory exists

## Testing
- `luacheck gamemode/modules/administration/submodules/adminstick/libraries/client.lua` *(fails: 295 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689c0977d46c8327b15c842e0235ef48