### PR TITLE
Fix admin stick category detection for non-player targets

### DIFF
--- a/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
@@ -223,7 +223,7 @@ local function CreateOrganizedAdminStickMenu(tgt, stores)
             
             if categoryKey == "playerInformation" and tgt:IsPlayer() then
                 hasContent = true
-            elseif categoryKey == "moderation" and (cl:hasPrivilege("alwaysSpawnAdminStick") or cl:isStaffOnDuty()) then
+            elseif categoryKey == "moderation" and tgt:IsPlayer() and (cl:hasPrivilege("alwaysSpawnAdminStick") or cl:isStaffOnDuty()) then
                 hasContent = true
             elseif categoryKey == "characterManagement" and tgt:IsPlayer() and (cl:hasPrivilege("manageTransfers") or cl:hasPrivilege("manageClasses") or cl:hasPrivilege("manageWhitelists") or cl:hasPrivilege("manageCharacterInformation")) then
                 hasContent = true
@@ -231,10 +231,10 @@ local function CreateOrganizedAdminStickMenu(tgt, stores)
                 hasContent = true
             elseif categoryKey == "doorManagement" and tgt:isDoor() then
                 hasContent = true
-            elseif categoryKey == "teleportation" and (cl:hasPrivilege("alwaysSpawnAdminStick") or cl:isStaffOnDuty()) then
+            elseif categoryKey == "teleportation" and tgt:IsPlayer() and (cl:hasPrivilege("alwaysSpawnAdminStick") or cl:isStaffOnDuty()) then
                 hasContent = true
-            elseif categoryKey == "utility" then
-                hasContent = true 
+            elseif categoryKey == "utility" and tgt:IsPlayer() then
+                hasContent = true
             end
 
             if hasContent then GetOrCreateCategoryMenu(menu, categoryKey, stores) end


### PR DESCRIPTION
## Summary
- show moderation, teleportation, and utility categories only when targeting players

## Testing
- `luacheck gamemode/modules/administration/submodules/adminstick/libraries/client.lua` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: Unable to locate package luacheck)*

------
https://chatgpt.com/codex/tasks/task_e_689c0ace19308327a9d3be4512ac8172