### PR TITLE
feat: expand admin stick categories

### DIFF
--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -25,7 +25,7 @@ lia.command.add("plygetplaytime", {
     },
     AdminStick = {
         Name = "adminStickGetPlayTimeName",
-        Category = "moderationTools",
+        Category = "moderation",
         SubCategory = "misc",
         Icon = "icon16/time.png"
     },
@@ -149,8 +149,8 @@ lia.command.add("sendtositroom", {
     },
     AdminStick = {
         Name = "sendToSitRoom",
-        Category = "moderationTools",
-        SubCategory = "misc",
+        Category = "moderation",
+        SubCategory = "moderationTools",
         Icon = "icon16/arrow_down.png"
     },
     onRun = function(client, arguments)
@@ -197,8 +197,8 @@ lia.command.add("returnsitroom", {
     },
     AdminStick = {
         Name = "returnFromSitroom",
-        Category = "moderationTools",
-        SubCategory = "misc",
+        Category = "moderation",
+        SubCategory = "moderationTools",
         Icon = "icon16/arrow_up.png"
     },
     onRun = function(client, arguments)
@@ -302,6 +302,7 @@ lia.command.add("charlist", {
     AdminStick = {
         Name = "adminStickOpenCharListName",
         Category = "characterManagement",
+        SubCategory = "adminStickSubCategoryGetInfos",
         Icon = "icon16/user_gray.png"
     },
     onRun = function(client, arguments)
@@ -1543,8 +1544,8 @@ lia.command.add("flaggiveall", {
     },
     AdminStick = {
         Name = "adminStickGiveAllFlagsName",
-        Category = "characterManagement",
-        SubCategory = "flagsManagement",
+        Category = "flagManagement",
+        SubCategory = "characterFlags",
         Icon = "icon16/flag_blue.png"
     },
     onRun = function(client, arguments)
@@ -1574,8 +1575,8 @@ lia.command.add("flagtakeall", {
     },
     AdminStick = {
         Name = "adminStickTakeAllFlagsName",
-        Category = "characterManagement",
-        SubCategory = "flagsManagement",
+        Category = "flagManagement",
+        SubCategory = "characterFlags",
         Icon = "icon16/flag_green.png"
     },
     onRun = function(client, arguments)
@@ -1683,6 +1684,12 @@ lia.command.add("pflaggiveall", {
             type = "player"
         },
     },
+    AdminStick = {
+        Name = "adminStickGiveAllPlayerFlagsName",
+        Category = "flagManagement",
+        SubCategory = "playerFlags",
+        Icon = "icon16/flag_orange.png"
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1707,6 +1714,12 @@ lia.command.add("pflagtakeall", {
             name = "name",
             type = "player"
         },
+    },
+    AdminStick = {
+        Name = "adminStickTakeAllPlayerFlagsName",
+        Category = "flagManagement",
+        SubCategory = "playerFlags",
+        Icon = "icon16/flag_red.png"
     },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
@@ -1778,8 +1791,8 @@ lia.command.add("charvoicetoggle", {
     },
     AdminStick = {
         Name = "toggleVoice",
-        Category = "moderationTools",
-        SubCategory = "misc",
+        Category = "moderation",
+        SubCategory = "moderationTools",
         Icon = "icon16/sound_mute.png"
     },
     onRun = function(client, arguments)
@@ -2620,8 +2633,8 @@ lia.command.add("forcesay", {
     },
     AdminStick = {
         Name = "adminStickForceSayName",
-        Category = "moderationTools",
-        SubCategory = "misc",
+        Category = "moderation",
+        SubCategory = "moderationTools",
         Icon = "icon16/comments.png"
     },
     onRun = function(client, arguments)
@@ -2981,8 +2994,8 @@ lia.command.add("exportprivileges", {
     },
     AdminStick = {
         Name = "Export Privileges",
-        Category = "moderationTools",
-        SubCategory = "misc",
+        Category = "administration",
+        SubCategory = "permissions",
         Icon = "icon16/table_save.png"
     },
     onRun = function(client, arguments)

--- a/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
@@ -42,6 +42,22 @@ MODULE.adminStickCategories = MODULE.adminStickCategories or {
             whitelists = {
                 name = L("adminStickSubCategoryWhitelists"),
                 icon = "icon16/group_add.png"
+            },
+            items = {
+                name = L("items"),
+                icon = "icon16/box.png"
+            },
+            adminStickSubCategoryBans = {
+                name = L("adminStickSubCategoryBans"),
+                icon = "icon16/lock.png"
+            },
+            adminStickSubCategorySetInfos = {
+                name = L("adminStickSubCategorySetInfos"),
+                icon = "icon16/pencil.png"
+            },
+            adminStickSubCategoryGetInfos = {
+                name = L("adminStickSubCategoryGetInfos"),
+                icon = "icon16/magnifier.png"
             }
         }
     },
@@ -106,6 +122,20 @@ MODULE.adminStickCategories = MODULE.adminStickCategories or {
                 icon = "icon16/comment.png"
             }
         }
+    },
+    administration = {
+        name = L("adminStickCategoryAdministration"),
+        icon = "icon16/lock.png",
+        subcategories = {
+            server = {
+                name = "Server",
+                icon = "icon16/cog.png"
+            },
+            permissions = {
+                name = "Permissions",
+                icon = "icon16/key.png"
+            }
+        }
     }
 }
 
@@ -116,7 +146,8 @@ MODULE.adminStickCategoryOrder = MODULE.adminStickCategoryOrder or {
     "flagManagement",
     "doorManagement",
     "teleportation",
-    "utility"
+    "utility",
+    "administration"
 }
 
 function MODULE:addAdminStickCategory(key, data, index)
@@ -144,8 +175,8 @@ local subMenuIcons = {
     misc = "icon16/application_view_tile.png",
     [playerInfoLabel] = "icon16/information.png",
     characterManagement = "icon16/user_gray.png",
+    flagManagement = "icon16/flag_blue.png",
     attributes = "icon16/chart_line.png",
-    flagsManagement = "icon16/flag_blue.png",
     charFlagsTitle = "icon16/flag_green.png",
     playerFlagsTitle = "icon16/flag_orange.png",
     [giveFlagsLabel] = "icon16/flag_blue.png",
@@ -155,6 +186,7 @@ local subMenuIcons = {
     doorSettings = "icon16/cog.png",
     doorMaintenance = "icon16/wrench.png",
     doorInformation = "icon16/information.png",
+    administration = "icon16/lock.png",
     items = "icon16/box.png",
     ooc = "icon16/comment.png",
     adminStickSubCategoryBans = "icon16/lock.png",
@@ -166,6 +198,8 @@ local subMenuIcons = {
     adminStickUnwhitelistName = "icon16/group_delete.png",
     adminStickClassWhitelistName = "icon16/user_add.png",
     adminStickClassUnwhitelistName = "icon16/user_delete.png",
+    server = "icon16/cog.png",
+    permissions = "icon16/key.png",
 }
 
 local function GetSubMenuIcon(name)
@@ -262,6 +296,8 @@ local function CreateOrganizedAdminStickMenu(tgt, stores)
             elseif categoryKey == "doorManagement" and tgt:isDoor() then
                 hasContent = true
             elseif categoryKey == "teleportation" and tgt:IsPlayer() and (cl:hasPrivilege("alwaysSpawnAdminStick") or cl:isStaffOnDuty()) then
+                hasContent = true
+            elseif categoryKey == "administration" and tgt:IsPlayer() then
                 hasContent = true
             elseif categoryKey == "utility" and tgt:IsPlayer() then
                 hasContent = true
@@ -914,6 +950,21 @@ local function AddCommandToMenu(menu, data, key, tgt, name, stores)
             subcategoryKey = "classes"
         elseif sub == "whitelists" then
             subcategoryKey = "whitelists"
+        elseif sub == "items" then
+            subcategoryKey = "items"
+        elseif sub == "adminStickSubCategoryBans" then
+            subcategoryKey = "adminStickSubCategoryBans"
+        elseif sub == "adminStickSubCategorySetInfos" then
+            subcategoryKey = "adminStickSubCategorySetInfos"
+        elseif sub == "adminStickSubCategoryGetInfos" then
+            subcategoryKey = "adminStickSubCategoryGetInfos"
+        end
+    elseif cat == "flagManagement" then
+        categoryKey = "flagManagement"
+        if sub == "characterFlags" then
+            subcategoryKey = "characterFlags"
+        elseif sub == "playerFlags" then
+            subcategoryKey = "playerFlags"
         end
     elseif cat == "doorManagement" then
         categoryKey = "doorManagement"
@@ -937,6 +988,13 @@ local function AddCommandToMenu(menu, data, key, tgt, name, stores)
         if sub == "commands" then subcategoryKey = "commands"
         elseif sub == "items" then subcategoryKey = "items"
         elseif sub == "ooc" then subcategoryKey = "ooc"
+        end
+    elseif cat == "administration" then
+        categoryKey = "administration"
+        if sub == "server" then
+            subcategoryKey = "server"
+        elseif sub == "permissions" then
+            subcategoryKey = "permissions"
         end
     end
 

--- a/gamemode/modules/administration/submodules/tickets/commands.lua
+++ b/gamemode/modules/administration/submodules/tickets/commands.lua
@@ -71,7 +71,7 @@ lia.command.add("plyviewclaims", {
     },
     AdminStick = {
         Name = "viewTicketClaims",
-        Category = "moderationTools",
+        Category = "moderation",
         SubCategory = "misc",
         Icon = "icon16/page_white_text.png"
     },

--- a/gamemode/modules/administration/submodules/warns/commands.lua
+++ b/gamemode/modules/administration/submodules/warns/commands.lua
@@ -14,7 +14,7 @@ lia.command.add("warn", {
     },
     AdminStick = {
         Name = "warnPlayer",
-        Category = "moderationTools",
+        Category = "moderation",
         SubCategory = "warnings",
         Icon = "icon16/error.png"
     },
@@ -56,7 +56,7 @@ lia.command.add("viewwarns", {
     },
     AdminStick = {
         Name = "viewPlayerWarnings",
-        Category = "moderationTools",
+        Category = "moderation",
         SubCategory = "warnings",
         Icon = "icon16/eye.png"
     },

--- a/gamemode/modules/chatbox/commands.lua
+++ b/gamemode/modules/chatbox/commands.lua
@@ -9,7 +9,7 @@
     },
     AdminStick = {
         Name = "banOOCStickName",
-        Category = "moderationTools",
+        Category = "utility",
         SubCategory = "ooc",
         Icon = "icon16/sound_mute.png"
     },
@@ -37,7 +37,7 @@ lia.command.add("unbanooc", {
     },
     AdminStick = {
         Name = "unbanOOCStickName",
-        Category = "moderationTools",
+        Category = "utility",
         SubCategory = "ooc",
         Icon = "icon16/sound.png"
     },

--- a/gamemode/modules/recognition/commands.lua
+++ b/gamemode/modules/recognition/commands.lua
@@ -16,8 +16,8 @@ lia.command.add("recogwhisper", {
     desc = "recogWhisperDesc",
     AdminStick = {
         Name = "recogWhisperStickName",
-        Category = "moderationTools",
-        SubCategory = "misc",
+        Category = "moderation",
+        SubCategory = "moderationTools",
         Icon = "icon16/eye.png"
     },
     onRun = function(client, arguments) runCommand(client, arguments, "whisper") end
@@ -34,8 +34,8 @@ lia.command.add("recognormal", {
     desc = "recogNormalDesc",
     AdminStick = {
         Name = "recogNormalStickName",
-        Category = "moderationTools",
-        SubCategory = "misc",
+        Category = "moderation",
+        SubCategory = "moderationTools",
         Icon = "icon16/eye.png"
     },
     onRun = function(client, arguments) runCommand(client, arguments, "normal") end
@@ -52,8 +52,8 @@ lia.command.add("recogyell", {
     desc = "recogYellDesc",
     AdminStick = {
         Name = "recogYellStickName",
-        Category = "moderationTools",
-        SubCategory = "misc",
+        Category = "moderation",
+        SubCategory = "moderationTools",
         Icon = "icon16/eye.png"
     },
     onRun = function(client, arguments) runCommand(client, arguments, "yell") end
@@ -76,8 +76,8 @@ lia.command.add("recogbots", {
     desc = "recogBotsDesc",
     AdminStick = {
         Name = "recogBotsStickName",
-        Category = "moderationTools",
-        SubCategory = "misc",
+        Category = "moderation",
+        SubCategory = "moderationTools",
         Icon = "icon16/eye.png"
     },
     onRun = function(_, arguments)


### PR DESCRIPTION
## Summary
- route flag operations to a dedicated Flag Management category and handle player vs character flags separately
- categorize character list viewing under character information tools

## Testing
- `luacheck gamemode/modules/administration/submodules/adminstick/libraries/client.lua gamemode/modules/administration/commands.lua` *(890 warnings, 0 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c13a5030483279b86bd420d371b23