### PR TITLE
Allow instant staff character switching

### DIFF
--- a/gamemode/modules/protection/libraries/server.lua
+++ b/gamemode/modules/protection/libraries/server.lua
@@ -8,19 +8,22 @@ local function LogCheaterAction(client, action)
     client:notify("Maybe you shouldn't have cheated")
 end
 
-function MODULE:CanPlayerSwitchChar(client, character)
+function MODULE:CanPlayerSwitchChar(client, character, newCharacter)
     if not client:isStaffOnDuty() then
-        local damageCooldown = lia.config.get("OnDamageCharacterSwitchCooldownTimer", 15)
-        local switchCooldown = lia.config.get("CharacterSwitchCooldownTimer", 5)
-        if damageCooldown > 0 and client.LastDamaged and client.LastDamaged > CurTime() - damageCooldown then
-            lia.log.add(client, "permissionDenied", L("logSwitchCharRecentDamage"))
-            return false, L("tookDamageSwitchCooldown")
-        end
+        local switchingToStaff = newCharacter and newCharacter:getFaction() == FACTION_STAFF
+        if not switchingToStaff then
+            local damageCooldown = lia.config.get("OnDamageCharacterSwitchCooldownTimer", 15)
+            local switchCooldown = lia.config.get("CharacterSwitchCooldownTimer", 5)
+            if damageCooldown > 0 and client.LastDamaged and client.LastDamaged > CurTime() - damageCooldown then
+                lia.log.add(client, "permissionDenied", L("logSwitchCharRecentDamage"))
+                return false, L("tookDamageSwitchCooldown")
+            end
 
-        local loginTime = character:getLoginTime()
-        if switchCooldown > 0 and loginTime + switchCooldown > os.time() then
-            lia.log.add(client, "permissionDenied", L("logSwitchCharCooldown"))
-            return false, L("switchCooldown")
+            local loginTime = character:getLoginTime()
+            if switchCooldown > 0 and loginTime + switchCooldown > os.time() then
+                lia.log.add(client, "permissionDenied", L("logSwitchCharCooldown"))
+                return false, L("switchCooldown")
+            end
         end
     end
     return true


### PR DESCRIPTION
## Summary
- allow switching to staff characters without cooldown

## Testing
- `luac -p gamemode/modules/protection/libraries/server.lua`


------
https://chatgpt.com/codex/tasks/task_e_689c2d2bbff08327b44ecfb75801ddff