### PR TITLE
fix: ensure valid target before sending character data

### DIFF
--- a/gamemode/core/meta/character.lua
+++ b/gamemode/core/meta/character.lua
@@ -154,7 +154,10 @@ function characterMeta:setData(k, v, noReplication, receiver)
                 net.WriteType(data)
             end
 
-            net.Send(receiver or self:getPlayer())
+            local target = receiver or self:getPlayer()
+            if IsValid(target) then
+                net.Send(target)
+            end
         end
 
         if istable(k) then


### PR DESCRIPTION
## Summary
- guard character data network calls from nil recipients

## Testing
- `luacheck gamemode/core/meta/character.lua | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689c2d31e3b0832792235efd4e592ac5