### PR TITLE
Hide staff character from player selection

### DIFF
--- a/gamemode/core/derma/mainmenu/character.lua
+++ b/gamemode/core/derma/mainmenu/character.lua
@@ -77,7 +77,7 @@ function PANEL:loadBackground()
         self:hideExternalEntities()
         hook.Add("PrePlayerDraw", "liaMainMenuPrePlayerDraw", function() return true end)
         self:updateSelectedCharacter()
-        if not IsValid(self.leftArrow) and #lia.characters > 1 then self:createArrows() end
+        if not IsValid(self.leftArrow) and self.availableCharacters and #self.availableCharacters > 1 then self:createArrows() end
         hook.Add("CalcView", "liaMainMenuCalcView", function(_, _, _, fov)
             local ent = self.modelEntity
             if not IsValid(ent) then return end
@@ -146,13 +146,16 @@ function PANEL:createStartButton()
     local discordURL = lia.config.get("DiscordURL")
     local workshopURL = lia.config.get("Workshop")
     local buttonsData = {}
-    local hasStaffChar = false
+    local hasStaffChar, hasNonStaffChar = false, false
     if lia.characters and #lia.characters > 0 then
         for _, charID in pairs(lia.characters) do
             local character = lia.char.getCharacter(charID)
-            if character and character:getFaction() == FACTION_STAFF then
-                hasStaffChar = true
-                break
+            if character then
+                if character:getFaction() == FACTION_STAFF then
+                    hasStaffChar = true
+                else
+                    hasNonStaffChar = true
+                end
             end
         end
     end
@@ -174,7 +177,7 @@ function PANEL:createStartButton()
         })
     end
 
-    if lia.characters and #lia.characters > 0 then
+    if hasNonStaffChar then
         table.insert(buttonsData, {
             id = "load",
             text = "Load Character",
@@ -184,6 +187,15 @@ function PANEL:createStartButton()
                 end
 
                 self:clickSound()
+                self.availableCharacters = {}
+                for _, charID in pairs(lia.characters or {}) do
+                    local character = lia.char.getCharacter(charID)
+                    if character and character:getFaction() ~= FACTION_STAFF then
+                        table.insert(self.availableCharacters, charID)
+                    end
+                end
+
+                self.currentIndex = 1
                 self.isLoadMode = true
                 self:showContent(true)
                 self:createCharacterSelection()
@@ -390,7 +402,7 @@ function PANEL:createCharacterSelection()
     self.content:Clear()
     self.content:InvalidateLayout(true)
     self:updateSelectedCharacter()
-    if #lia.characters > 1 then self:createArrows() end
+    if self.availableCharacters and #self.availableCharacters > 1 then self:createArrows() end
 end
 
 function PANEL:createCharacterCreation()
@@ -429,7 +441,7 @@ end
 
 function PANEL:updateSelectedCharacter()
     if not self.isLoadMode then return end
-    local chars = lia.characters or {}
+    local chars = self.availableCharacters or {}
     if #chars == 0 then return end
     self.currentIndex = self.currentIndex or 1
     local sel = chars[self.currentIndex] or chars[1]
@@ -443,7 +455,7 @@ end
 
 function PANEL:createSelectedCharacterInfoPanel(character)
     if not character then return end
-    local chars = lia.characters or {}
+    local chars = self.availableCharacters or {}
     local total = #chars
     local index = 1
     for i, cID in ipairs(chars) do
@@ -636,10 +648,11 @@ function PANEL:createArrows()
         btn:SetFont("liaHugeFont")
         btn:SetText(sign)
         btn.DoClick = function()
-            if not self.isLoadMode or not lia.characters or #lia.characters == 0 then return end
+            local chars = self.availableCharacters or {}
+            if not self.isLoadMode or #chars == 0 then return end
             self.currentIndex = self.currentIndex + (sign == "<" and -1 or 1)
-            if self.currentIndex < 1 then self.currentIndex = #lia.characters end
-            if self.currentIndex > #lia.characters then self.currentIndex = 1 end
+            if self.currentIndex < 1 then self.currentIndex = #chars end
+            if self.currentIndex > #chars then self.currentIndex = 1 end
             self:clickSound()
             self:updateSelectedCharacter()
         end


### PR DESCRIPTION
## Summary
- Exclude staff characters from the main character selection menu
- Track non-staff characters separately for navigation

## Testing
- `luacheck gamemode/core/derma/mainmenu/character.lua`

------
https://chatgpt.com/codex/tasks/task_e_689c2d37046883279b3ca544d0dafd2d