### PR TITLE
Fix staff and flag checks on bots

### DIFF
--- a/gamemode/core/meta/character.lua
+++ b/gamemode/core/meta/character.lua
@@ -55,7 +55,11 @@ end
 function characterMeta:hasFlags(flagStr)
     local flags = self:getFlags()
     local ply = self:getPlayer()
-    local playerFlags = ply and ply:getPlayerFlags() or ""
+    local playerFlags = ""
+
+    if IsValid(ply) and ply.getPlayerFlags then
+        playerFlags = ply:getPlayerFlags() or ""
+    end
     for i = 1, #flagStr do
         local flag = flagStr:sub(i, i)
         if flags:find(flag, 1, true) or playerFlags:find(flag, 1, true) then return true end

--- a/gamemode/modules/recognition/libraries/shared.lua
+++ b/gamemode/modules/recognition/libraries/shared.lua
@@ -22,7 +22,10 @@ function MODULE:isCharRecognized(character, id)
         if factionID == otherFactionID and otherFaction.MemberToMemberAutoRecognition then return true end
     end
 
-    if client:isStaffOnDuty() or otherClient:isStaffOnDuty() then return true end
+    if (IsValid(client) and client.isStaffOnDuty and client:isStaffOnDuty()) or
+        (IsValid(otherClient) and otherClient.isStaffOnDuty and otherClient:isStaffOnDuty()) then
+        return true
+    end
     local recognized = character:getRecognition() or ""
     if recognized:find("," .. id .. ",", 1, true) then return true end
     return false


### PR DESCRIPTION
## Summary
- Avoid calling player-specific methods when the character's entity is not a real player
- Safely verify staff-on-duty status before recognition checks

## Testing
- `luacheck gamemode/core/meta/character.lua gamemode/modules/recognition/libraries/shared.lua | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689c387b796083279869b667aa7ca1c8