### PR TITLE
Hide free door price display

### DIFF
--- a/gamemode/modules/doors/libraries/client.lua
+++ b/gamemode/modules/doors/libraries/client.lua
@@ -16,7 +16,7 @@
         local ownable = not entity:getNetVar("noSell", false)
         lia.util.drawText(entity:getNetVar("title", entity:getNetVar("name", IsValid(owner) and L("doorTitleOwned") or (not classesRaw or classesRaw == "[]") and not entity:getNetVar("factions") and L("doorTitle") or "")), x, y, ColorAlpha(color_white, alpha), 1, 1)
         y = y + 20
-        if ownable then
+        if ownable and price > 0 then
             lia.util.drawText(L("price") .. ": " .. lia.currency.get(price), x, y, ColorAlpha(color_white, alpha), 1, 1)
             y = y + 20
         end


### PR DESCRIPTION
## Summary
- Only show door price text when the door costs more than zero

## Testing
- `tail -c +4 gamemode/modules/doors/libraries/client.lua | luac -p -`


------
https://chatgpt.com/codex/tasks/task_e_689c38f9309483279e4eb3a152ec756c