### PR TITLE
chore: remove comments

### DIFF
--- a/gamemode/modules/protection/netcalls/server.lua
+++ b/gamemode/modules/protection/netcalls/server.lua
@@ -586,7 +586,7 @@ net.Receive("VerifyCheatsResponse", function(_, client)
     end
 end)
 
--- Helper function to get entity display name
+
 local function getEntityDisplayName(ent)
     if not IsValid(ent) then return "Unknown Entity" end
     if ent:GetClass() == "lia_item" and ent.getItemTable then
@@ -632,10 +632,10 @@ net.Receive("liaTeleportToEntity", function(_, client)
         return
     end
 
-    -- Store the player's current position for potential return
+    
     client.previousPosition = client:GetPos()
     
-    -- Teleport the player to the entity
+    
     local entityPos = entity:GetPos()
     local trace = util.TraceLine({
         start = entityPos,


### PR DESCRIPTION
## Summary
- remove leftover comments from protection netcall logic

## Testing
- `find . -name '*.lua' -print0 | xargs -0 -n1 -P8 luac5.1 -p` *(fails: unexpected symbol near '')*


------
https://chatgpt.com/codex/tasks/task_e_689c510e4a888327aed3669c0118ebff