### PR TITLE
Add player flag management and admin stick support

### DIFF
--- a/gamemode/languages/english.lua
+++ b/gamemode/languages/english.lua
@@ -670,6 +670,7 @@ LANGUAGE = {
     adminStickGiveAllFlagsName = "Give All Flags",
     adminStickCheckMoneyName = "Check Money",
     adminStickGetCharFlagsName = "Get Character Flags",
+    adminStickGetPlayerFlagsName = "Get Player Flags",
     adminStickFactionWhitelistName = "Faction Whitelist",
     adminStickUnwhitelistName = "Unwhitelist Player",
     adminStickClassWhitelistName = "Class Whitelist",

--- a/gamemode/languages/french.lua
+++ b/gamemode/languages/french.lua
@@ -668,6 +668,7 @@ LANGUAGE = {
     adminStickGiveAllFlagsName = "Donner tous les drapeaux",
     adminStickCheckMoneyName = "Vérifier l'argent",
     adminStickGetCharFlagsName = "Obtenir drapeaux personnage",
+    adminStickGetPlayerFlagsName = "Obtenir drapeaux joueur",
     adminStickFactionWhitelistName = "Liste blanche de faction",
     adminStickUnwhitelistName = "Retirer de la liste blanche",
     adminStickClassWhitelistName = "Liste blanche de classe",

--- a/gamemode/languages/german.lua
+++ b/gamemode/languages/german.lua
@@ -668,6 +668,7 @@ LANGUAGE = {
     adminStickGiveAllFlagsName = "Alle Flags geben",
     adminStickCheckMoneyName = "Geld prüfen",
     adminStickGetCharFlagsName = "Charakter-Flags abrufen",
+    adminStickGetPlayerFlagsName = "Spieler-Flags abrufen",
     adminStickFactionWhitelistName = "Fraktions-Whitelist",
     adminStickUnwhitelistName = "Spieler von Whitelist entfernen",
     adminStickClassWhitelistName = "Klassen-Whitelist",

--- a/gamemode/languages/portuguese.lua
+++ b/gamemode/languages/portuguese.lua
@@ -668,6 +668,7 @@ LANGUAGE = {
     adminStickGiveAllFlagsName = "Dar Todas as Flags",
     adminStickCheckMoneyName = "Ver Dinheiro",
     adminStickGetCharFlagsName = "Obter Flags do Personagem",
+    adminStickGetPlayerFlagsName = "Obter Flags do Jogador",
     adminStickFactionWhitelistName = "Whitelist de Facção",
     adminStickUnwhitelistName = "Remover Whitelist do Jogador",
     adminStickClassWhitelistName = "Whitelist de Classe",

--- a/gamemode/languages/russian.lua
+++ b/gamemode/languages/russian.lua
@@ -668,6 +668,7 @@ LANGUAGE = {
     adminStickGiveAllFlagsName = "Выдать все флаги",
     adminStickCheckMoneyName = "Проверить деньги",
     adminStickGetCharFlagsName = "Получить флаги персонажа",
+    adminStickGetPlayerFlagsName = "Получить флаги игрока",
     adminStickFactionWhitelistName = "Вайтлист фракции",
     adminStickUnwhitelistName = "Убрать из вайтлиста",
     adminStickClassWhitelistName = "Вайтлист класса",

--- a/gamemode/languages/spanish.lua
+++ b/gamemode/languages/spanish.lua
@@ -668,6 +668,7 @@ LANGUAGE = {
     adminStickGiveAllFlagsName = "Dar Todos los Flags",
     adminStickCheckMoneyName = "Revisar Dinero",
     adminStickGetCharFlagsName = "Obtener Flags de Personaje",
+    adminStickGetPlayerFlagsName = "Obtener Flags de Jugador",
     adminStickFactionWhitelistName = "Whitelist de Facción",
     adminStickUnwhitelistName = "Quitar Whitelist de Jugador",
     adminStickClassWhitelistName = "Whitelist de Clase",

--- a/gamemode/modules/administration/commands.lua
+++ b/gamemode/modules/administration/commands.lua
@@ -1684,6 +1684,12 @@ lia.command.add("pflaggiveall", {
             type = "player"
         },
     },
+    AdminStick = {
+        Name = "adminStickGiveAllFlagsName",
+        Category = "flagManagement",
+        SubCategory = "playerFlags",
+        Icon = "icon16/flag_blue.png"
+    },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -1708,6 +1714,12 @@ lia.command.add("pflagtakeall", {
             name = "name",
             type = "player"
         },
+    },
+    AdminStick = {
+        Name = "adminStickTakeAllFlagsName",
+        Category = "flagManagement",
+        SubCategory = "playerFlags",
+        Icon = "icon16/flag_green.png"
     },
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
@@ -2758,6 +2770,41 @@ lia.command.add("checkflags", {
             client:notifyLocalized("noFlags", target:Name())
         end
     end
+})
+
+lia.command.add("pcheckflags", {
+    adminOnly = true,
+    desc = "checkFlagsDesc",
+    arguments = {
+        {
+            name = "name",
+            type = "player"
+        },
+    },
+    AdminStick = {
+        Name = "adminStickGetPlayerFlagsName",
+        Category = "characterManagement",
+        SubCategory = "adminStickSubCategoryGetInfos",
+        Icon = "icon16/flag_orange.png"
+    },
+    onRun = function(client, arguments)
+        local target = lia.util.findPlayer(client, arguments[1])
+        if not target or not IsValid(target) then
+            client:notifyLocalized("targetNotFound")
+            return
+        end
+
+        local flags = target:getPlayerFlags()
+        if flags and #flags > 0 then
+            local flagTable = {}
+            for i = 1, #flags do
+                flagTable[#flagTable + 1] = flags:sub(i, i)
+            end
+            client:ChatPrint(L("playerFlags", target:Name(), table.concat(flagTable, ", ")))
+        else
+            client:notifyLocalized("noFlags", target:Name())
+        end
+    end,
 })
 
 lia.command.add("chargetname", {

--- a/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
@@ -67,6 +67,10 @@ MODULE.adminStickCategories = MODULE.adminStickCategories or {
             characterFlags = {
                 name = L("adminStickSubCategoryCharacterFlags"),
                 icon = "icon16/flag_green.png"
+            },
+            playerFlags = {
+                name = L("adminStickSubCategoryPlayerFlags"),
+                icon = "icon16/flag_orange.png"
             }
         }
     },
@@ -810,6 +814,98 @@ local function IncludeFlagManagement(tgt, menu, stores)
         Derma_Message(L("currentCharFlags") .. ": " .. (flagList ~= "" and flagList or L("none")), L("charFlags"), L("ok"))
         AdminStickIsOpen = false
     end):SetIcon("icon16/information.png")
+
+    local pf = GetOrCreateSubCategoryMenu(flagCategory, "flagManagement", "playerFlags", stores)
+    local pGive = GetOrCreateSubMenu(pf, giveFlagsLabel, stores, "flagManagement", "playerFlags")
+    local pTake = GetOrCreateSubMenu(pf, takeFlagsLabel, stores, "flagManagement", "playerFlags")
+    local toGiveP, toTakeP = {}, {}
+    for fl in pairs(lia.flag.list) do
+        if not tgt:hasPlayerFlags(fl) then
+            table.insert(toGiveP, {
+                name = L("giveFlagFormat", fl),
+                cmd = 'say /pflaggive ' .. QuoteArgs(GetIdentifier(tgt), fl),
+                icon = "icon16/flag_blue.png",
+            })
+        else
+            table.insert(toTakeP, {
+                name = L("takeFlagFormat", fl),
+                cmd = 'say /pflagtake ' .. QuoteArgs(GetIdentifier(tgt), fl),
+                icon = "icon16/flag_red.png",
+            })
+        end
+    end
+
+    table.sort(toGiveP, function(a, b) return a.name < b.name end)
+    table.sort(toTakeP, function(a, b) return a.name < b.name end)
+    for _, f in ipairs(toGiveP) do
+        pGive:AddOption(L(f.name), function()
+            cl:ConCommand(f.cmd)
+            AdminStickIsOpen = false
+        end):SetIcon(f.icon)
+    end
+
+    for _, f in ipairs(toTakeP) do
+        pTake:AddOption(L(f.name), function()
+            cl:ConCommand(f.cmd)
+            AdminStickIsOpen = false
+        end):SetIcon(f.icon)
+    end
+
+    pf:AddOption(L("modifyPlayerFlags"), function()
+        local currentFlags = tgt:getPlayerFlags()
+        Derma_StringRequest(L("modifyPlayerFlags"), L("modifyFlagsDesc"), currentFlags, function(text)
+            text = string.gsub(text or "", "%s", "")
+            net.Start("liaModifyFlags")
+            net.WriteString(tgt:SteamID())
+            net.WriteString(text)
+            net.WriteBool(true)
+            net.SendToServer()
+        end)
+
+        AdminStickIsOpen = false
+    end):SetIcon("icon16/flag_orange.png")
+
+    pf:AddOption(L("giveAllPlayerFlags"), function()
+        local allFlags = ""
+        for fl in pairs(lia.flag.list) do
+            allFlags = allFlags .. fl
+        end
+
+        if allFlags ~= "" then
+            net.Start("liaModifyFlags")
+            net.WriteString(tgt:SteamID())
+            net.WriteString(allFlags)
+            net.WriteBool(true)
+            net.SendToServer()
+        end
+
+        AdminStickIsOpen = false
+    end):SetIcon("icon16/flag_blue.png")
+
+    pf:AddOption(L("takeAllPlayerFlags"), function()
+        net.Start("liaModifyFlags")
+        net.WriteString(tgt:SteamID())
+        net.WriteString("")
+        net.WriteBool(true)
+        net.SendToServer()
+        AdminStickIsOpen = false
+    end):SetIcon("icon16/flag_red.png")
+
+    pf:AddOption(L("listPlayerFlags"), function()
+        local currentFlags = tgt:getPlayerFlags() or ""
+        local flagList = ""
+        if currentFlags ~= "" then
+            for i = 1, #currentFlags do
+                local flag = currentFlags:sub(i, i)
+                flagList = flagList .. flag .. " "
+            end
+
+            flagList = flagList:trim()
+        end
+
+        Derma_Message(L("currentPlayerFlags") .. ": " .. (flagList ~= "" and flagList or L("none")), L("playerFlagsTitle"), L("ok"))
+        AdminStickIsOpen = false
+    end):SetIcon("icon16/information.png")
 end
 
 local function AddCommandToMenu(menu, data, key, tgt, name, stores)
@@ -842,7 +938,11 @@ local function AddCommandToMenu(menu, data, key, tgt, name, stores)
         end
     elseif cat == "flagManagement" then
         categoryKey = "flagManagement"
-        if sub == "characterFlags" then subcategoryKey = "characterFlags" end
+        if sub == "characterFlags" then
+            subcategoryKey = "characterFlags"
+        elseif sub == "playerFlags" then
+            subcategoryKey = "playerFlags"
+        end
     elseif cat == "doorManagement" then
         categoryKey = "doorManagement"
         if sub == "doorActions" then


### PR DESCRIPTION
## Summary
- add player flag check command and translations
- extend admin stick with player flag subcategory and actions
- expose player flag commands in admin stick menu

## Testing
- `luacheck gamemode/modules/administration/commands.lua gamemode/modules/administration/submodules/adminstick/libraries/client.lua gamemode/languages/english.lua gamemode/languages/german.lua gamemode/languages/spanish.lua gamemode/languages/french.lua gamemode/languages/russian.lua gamemode/languages/portuguese.lua` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689c8337a6948327ab1967918355776a