### PR TITLE
Remove all comments

### DIFF
--- a/gamemode/core/libraries/database.lua
+++ b/gamemode/core/libraries/database.lua
@@ -295,12 +295,11 @@ end
 
 function lia.db.loadTables()
     local function done()
-        lia.db.addDatabaseFields()
-        lia.db.tablesLoaded = true
-        hook.Run("LiliaTablesLoaded")
-        -- Signal that the database schema is ready for modules to perform any post-load queries
-        hook.Run("OnDatabaseLoaded")
-    end
+    lia.db.addDatabaseFields()
+    lia.db.tablesLoaded = true
+    hook.Run("LiliaTablesLoaded")
+    hook.Run("OnDatabaseLoaded")
+end
 
     if lia.db.module == "sqlite" then
         lia.db.query([[

--- a/gamemode/modules/inventory/submodules/storage/libraries/server.lua
+++ b/gamemode/modules/inventory/submodules/storage/libraries/server.lua
@@ -52,8 +52,6 @@ function MODULE:CanPlayerSpawnStorage(client, _, info)
     if not info.invType or not lia.inventory.types[info.invType] then return false end
 end
 
--- Implemented via GetEntitySaveData gate; see below.
-
 function MODULE:StorageItemRemoved()
     self:SaveData()
 end
@@ -100,8 +98,6 @@ end
 
 function MODULE:GetEntitySaveData(ent)
     if ent:GetClass() ~= "lia_storage" then return end
-    -- Allow external control over saving storage-specific data
-    -- Returning false from the hook will skip saving storage data (id/password)
     local inventory = ent:getInv()
     local canSave = hook.Run("CanSaveData", ent, inventory)
     if canSave == false then return end
@@ -132,7 +128,6 @@ function MODULE:OnEntityLoaded(ent, data)
     end
 end
 
--- Provide a SaveData implementation to persist storage entities immediately
 function MODULE:SaveData()
     for _, ent in ipairs(ents.FindByClass("lia_storage")) do
         hook.Run("UpdateEntityPersistence", ent)


### PR DESCRIPTION
## Summary
- remove commentary around storage persistence functions
- drop database schema readiness comment

## Testing
- `find gamemode -name '*.lua' -print0 | xargs -0 -n1 luac -p` *(fails: syntax error near 'end' in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_689e247521908327a0ef20d1c352eaee