### PR TITLE
refactor: relocate version manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,8 @@ jobs:
       - run: |
           curl -L -o site/modules.json https://raw.githubusercontent.com/LiliaFramework/Modules/gh-pages/modules.json
       - run: |
-          echo "{\"version\":\"${VERSION}\"}" > site/version.json
+          mkdir -p site/docs/versioning
+          echo "{\"version\":\"${VERSION}\"}" > site/docs/versioning/modules.json
       - run: |
           cd site
           git config user.name github-actions

--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -816,7 +816,7 @@ end
 
 local publicURL = "https://raw.githubusercontent.com/LiliaFramework/Modules/refs/heads/gh-pages/modules.json"
 local privateURL = "https://raw.githubusercontent.com/bleonheart/bleonheart.github.io/main/modules.json"
-local versionURL = "https://raw.githubusercontent.com/LiliaFramework/LiliaFramework.github.io/main/version.json"
+local versionURL = "https://raw.githubusercontent.com/LiliaFramework/LiliaFramework.github.io/main/docs/versioning/modules.json"
 local function checkPublicModules()
     local hasPublic = false
     for uniqueID in pairs(lia.module.list) do


### PR DESCRIPTION
## Summary
- write version manifest to documentation docs versioning modules.json
- adjust server updater to fetch version info from new modules path

## Testing
- `luacheck gamemode` *(fails: accessing undefined variables)*

------
https://chatgpt.com/codex/tasks/task_e_689e264c6f888327bf0091a0242e28df