### PR TITLE
Fix privilege category registration for tools and properties

### DIFF
--- a/gamemode/modules/administration/submodules/permissions/libraries/shared.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/shared.lua
@@ -9,7 +9,7 @@ function MODULE:InitializedModules()
                 Name = L("accessPropertyPrivilege", prop.MenuLabel),
                 ID = "property_" .. tostring(name),
                 MinAccess = "admin",
-                Category = "properties"
+                Category = "categoryStaffManagement"
             })
         end
     end
@@ -21,7 +21,7 @@ function MODULE:InitializedModules()
                     Name = L("accessToolPrivilege", tool:gsub("^%l", string.upper)),
                     ID = "tool_" .. tostring(tool),
                     MinAccess = defaultUserTools[string.lower(tool)] and "user" or "admin",
-                    Category = "tools"
+                    Category = "categoryStaffTools"
                 })
             end
         end


### PR DESCRIPTION
## Summary
- Use staff-oriented categories when registering property and tool privileges

## Testing
- `luacheck gamemode/modules/administration/submodules/permissions/libraries/shared.lua`


------
https://chatgpt.com/codex/tasks/task_e_689e864ddf4c8327ba1908f3661a6af2