### PR TITLE
Remove stray comments from codebase

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -650,7 +650,6 @@ function GM:LoadData()
 
                 createdEnt:SetPos(decodedPos)
                 if decodedAng then
-                    -- Ensure decodedAng is a valid Angle object
                     if not isangle(decodedAng) then
                         if isvector(decodedAng) then
                             decodedAng = Angle(decodedAng.x, decodedAng.y, decodedAng.z)
@@ -668,7 +667,6 @@ function GM:LoadData()
                         end
                     end
                     
-                    -- Final safety check before setting angles
                     if isangle(decodedAng) then
                         createdEnt:SetAngles(decodedAng)
                     end
@@ -719,7 +717,6 @@ function GM:LoadData()
                             local position = positions[itemID]
                             local ang = angles[itemID]
                             if itemTable and itemID and position then
-                                -- Ensure ang is a valid Angle object before spawning
                                 if ang and not isangle(ang) then
                                     if isvector(ang) then
                                         ang = Angle(ang.x, ang.y, ang.z)
@@ -737,7 +734,6 @@ function GM:LoadData()
                                     end
                                 end
                                 
-                                -- Final safety check before spawning
                                 if not isangle(ang) then
                                     ang = angle_zero
                                 end

--- a/gamemode/modules/administration/submodules/permissions/libraries/shared.lua
+++ b/gamemode/modules/administration/submodules/permissions/libraries/shared.lua
@@ -33,19 +33,15 @@ local function registerDynamicPrivileges()
 end
 
 function MODULE:InitializedModules()
-    -- Initial pass right after modules load
     registerDynamicPrivileges()
-    -- Schedule a delayed pass to catch late-registered properties/tools
     timer.Simple(1, registerDynamicPrivileges)
 end
 
 function MODULE:OnAdminSystemLoaded()
-    -- Ensure privileges exist after admin system fully loads from DB/CAMI
     registerDynamicPrivileges()
 end
 
 function MODULE:OnReloaded()
-    -- Hot-reload safety
     registerDynamicPrivileges()
 end
 

--- a/gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/init.lua
+++ b/gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/init.lua
@@ -1,4 +1,4 @@
-﻿-- Helper function to safely send network messages to receivers
+﻿
 local function safeSendToReceivers(entity, netName)
     if entity.receivers and #entity.receivers > 0 then
         net.Send(entity.receivers)
@@ -24,7 +24,6 @@ function ENT:Use(activator)
     end
 
     lia.log.add(activator, "vendorAccess", self:getNetVar("name"))
-    -- Ensure receivers is initialized
     self.receivers = self.receivers or {}
     self.receivers[#self.receivers + 1] = activator
     activator.liaVendor = self
@@ -307,7 +306,6 @@ function ENT:sync(client)
 end
 
 function ENT:addReceiver(client, noSync)
-    -- Ensure receivers is initialized
     self.receivers = self.receivers or {}
     if not table.HasValue(self.receivers, client) then self.receivers[#self.receivers + 1] = client end
     if noSync then return end

--- a/gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/shared.lua
+++ b/gamemode/modules/inventory/submodules/vendor/entities/entities/lia_vendor/shared.lua
@@ -36,7 +36,6 @@ function ENT:Initialize()
         return
     end
 
-    -- Ensure receivers is always initialized
     self.receivers = self.receivers or {}
     
     self:SetModel("models/mossman.mdl")


### PR DESCRIPTION
## Summary
- Drop leftover comment lines in server hook, vendor entity, and permissions modules

## Testing
- `find . -name '*.lua' -print0 | xargs -0 -n1 luac -p` *(fails: unexpected symbol near '')*

------
https://chatgpt.com/codex/tasks/task_e_689e89c690348327a51aa2f5887692f3