### PR TITLE
Handle single spawn entries as tables

### DIFF
--- a/gamemode/modules/spawns/libraries/server.lua
+++ b/gamemode/modules/spawns/libraries/server.lua
@@ -7,6 +7,7 @@ function MODULE:FetchSpawns()
     local result = {}
     for fac, spawns in pairs(factions or {}) do
         local t = {}
+        spawns = istable(spawns) and spawns or {spawns}
         for i = 1, #spawns do
             local spawnData = lia.data.deserialize(spawns[i])
             if isvector(spawnData) then


### PR DESCRIPTION
## Summary
- avoid errors when spawn data is stored as a single value by wrapping non-table entries in a table

## Testing
- `luacheck gamemode/modules/spawns/libraries/server.lua` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: Unable to locate package luacheck)*

------
https://chatgpt.com/codex/tasks/task_e_689f12cd57ec8327ae3294221f05826a