### PR TITLE
Log invalid angles during entity creation

### DIFF
--- a/gamemode/core/hooks/server.lua
+++ b/gamemode/core/hooks/server.lua
@@ -667,7 +667,16 @@ function GM:LoadData()
                         end
                     end
 
-                    if isangle(decodedAng) then createdEnt:SetAngles(decodedAng) end
+                    if isangle(decodedAng) then
+                        local ok, err = pcall(createdEnt.SetAngles, createdEnt, decodedAng)
+                        if not ok then
+                            lia.error(string.format("Failed to SetAngles for entity '%s' at %s. Angle: %s (%s) - %s", tostring(cls), tostring(decodedPos), tostring(decodedAng), type(decodedAng), err))
+                            lia.error(debug.traceback())
+                        end
+                    else
+                        lia.error(string.format("Invalid angle for entity '%s' at %s: %s (%s)", tostring(cls), tostring(decodedPos), tostring(decodedAng), type(decodedAng)))
+                        lia.error(debug.traceback())
+                    end
                 end
 
                 if ent.model then createdEnt:SetModel(ent.model) end


### PR DESCRIPTION
## Summary
- wrap `SetAngles` in `pcall` and log class, position, angle, and stack trace when the angle is invalid

## Testing
- `luacheck gamemode/core/hooks/server.lua` *(fails: 443 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689f12be1324832785cdd2a7501a87b5