### PR TITLE
fix: guard player flag lookups

### DIFF
--- a/gamemode/core/meta/character.lua
+++ b/gamemode/core/meta/character.lua
@@ -55,11 +55,18 @@ end
 function characterMeta:hasFlags(flagStr)
     local flags = self:getFlags()
     local ply = self:getPlayer()
-    local playerFlags = ply and ply:getPlayerFlags() or ""
+    local playerFlags = ""
+    if ply and isfunction(ply.getPlayerFlags) then
+        playerFlags = ply:getPlayerFlags() or ""
+    end
+
     for i = 1, #flagStr do
         local flag = flagStr:sub(i, i)
-        if flags:find(flag, 1, true) or playerFlags:find(flag, 1, true) then return true end
+        if flags:find(flag, 1, true) or playerFlags:find(flag, 1, true) then
+            return true
+        end
     end
+
     return false
 end
 
@@ -358,9 +365,13 @@ if SERVER then
         hook.Run("OnCharVarChanged", self, "flags", oldFlags, flags)
         local ply = self:getPlayer()
         if not IsValid(ply) then return end
+        local playerFlags = ""
+        if isfunction(ply.getPlayerFlags) then
+            playerFlags = ply:getPlayerFlags() or ""
+        end
         for i = 1, #oldFlags do
             local flag = oldFlags:sub(i, i)
-            if not flags:find(flag, 1, true) and not ply:getPlayerFlags():find(flag, 1, true) then
+            if not flags:find(flag, 1, true) and not playerFlags:find(flag, 1, true) then
                 local info = lia.flag.list[flag]
                 if info and info.callback then info.callback(ply, false) end
             end
@@ -394,11 +405,15 @@ if SERVER then
         local oldFlags = self:getFlags()
         local newFlags = oldFlags
         local ply = self:getPlayer()
+        local playerFlags = ""
+        if IsValid(ply) and isfunction(ply.getPlayerFlags) then
+            playerFlags = ply:getPlayerFlags() or ""
+        end
         for i = 1, #flags do
             local flag = flags:sub(i, i)
             local info = lia.flag.list[flag]
             if info and info.callback and IsValid(ply) then
-                local hasOther = ply:getPlayerFlags():find(flag, 1, true)
+                local hasOther = playerFlags:find(flag, 1, true)
                 if not hasOther then info.callback(ply, false) end
             end
 

--- a/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
+++ b/gamemode/modules/administration/submodules/adminstick/libraries/client.lua
@@ -852,7 +852,7 @@ local function IncludeFlagManagement(tgt, menu, stores)
     end
 
     pf:AddOption(L("modifyPlayerFlags"), function()
-        local currentFlags = tgt:getPlayerFlags()
+        local currentFlags = (isfunction(tgt.getPlayerFlags) and tgt:getPlayerFlags()) or ""
         Derma_StringRequest(L("modifyPlayerFlags"), L("modifyFlagsDesc"), currentFlags, function(text)
             text = string.gsub(text or "", "%s", "")
             net.Start("liaModifyFlags")
@@ -892,7 +892,7 @@ local function IncludeFlagManagement(tgt, menu, stores)
     end):SetIcon("icon16/flag_red.png")
 
     pf:AddOption(L("listPlayerFlags"), function()
-        local currentFlags = tgt:getPlayerFlags() or ""
+        local currentFlags = (isfunction(tgt.getPlayerFlags) and tgt:getPlayerFlags()) or ""
         local flagList = ""
         if currentFlags ~= "" then
             for i = 1, #currentFlags do


### PR DESCRIPTION
## Summary
- avoid calling undefined `getPlayerFlags` in character flag checks
- ensure admin stick UI tolerates missing player flag methods

## Testing
- `luacheck gamemode/core/meta/character.lua`
- `luacheck gamemode/modules/administration/submodules/adminstick/libraries/client.lua`


------
https://chatgpt.com/codex/tasks/task_e_689fa02c2e90832785a997c612025eb0