### PR TITLE
Guard character flag functions against missing player flag methods

### DIFF
--- a/gamemode/core/meta/character.lua
+++ b/gamemode/core/meta/character.lua
@@ -55,7 +55,10 @@ end
 function characterMeta:hasFlags(flagStr)
     local flags = self:getFlags()
     local ply = self:getPlayer()
-    local playerFlags = ply and ply:getPlayerFlags() or ""
+    local playerFlags = ""
+    if IsValid(ply) and ply.getPlayerFlags then
+        playerFlags = ply:getPlayerFlags()
+    end
     for i = 1, #flagStr do
         local flag = flagStr:sub(i, i)
         if flags:find(flag, 1, true) or playerFlags:find(flag, 1, true) then return true end
@@ -358,9 +361,14 @@ if SERVER then
         hook.Run("OnCharVarChanged", self, "flags", oldFlags, flags)
         local ply = self:getPlayer()
         if not IsValid(ply) then return end
+        local plyFlags = ""
+        if ply.getPlayerFlags then
+            plyFlags = ply:getPlayerFlags()
+        end
+
         for i = 1, #oldFlags do
             local flag = oldFlags:sub(i, i)
-            if not flags:find(flag, 1, true) and not ply:getPlayerFlags():find(flag, 1, true) then
+            if not flags:find(flag, 1, true) and not plyFlags:find(flag, 1, true) then
                 local info = lia.flag.list[flag]
                 if info and info.callback then info.callback(ply, false) end
             end
@@ -394,11 +402,16 @@ if SERVER then
         local oldFlags = self:getFlags()
         local newFlags = oldFlags
         local ply = self:getPlayer()
+        local plyFlags = ""
+        if IsValid(ply) and ply.getPlayerFlags then
+            plyFlags = ply:getPlayerFlags()
+        end
+
         for i = 1, #flags do
             local flag = flags:sub(i, i)
             local info = lia.flag.list[flag]
             if info and info.callback and IsValid(ply) then
-                local hasOther = ply:getPlayerFlags():find(flag, 1, true)
+                local hasOther = plyFlags:find(flag, 1, true)
                 if not hasOther then info.callback(ply, false) end
             end
 


### PR DESCRIPTION
## Summary
- Avoid calling `getPlayerFlags` when the method is unavailable
- Safely cache player flags in `setFlags` and `takeFlags`
- Remove inline comments to keep implementation concise

## Testing
- `luacheck gamemode/core/meta/character.lua`


------
https://chatgpt.com/codex/tasks/task_e_689fa84d52a88327befe8211192904de