### PR TITLE
Verify and fix meta documentation

### DIFF
--- a/documentation/docs/meta/.pages
+++ b/documentation/docs/meta/.pages
@@ -2,7 +2,6 @@ arrange:
   - character.md
   - entity.md
   - inventory.md
-  - gridinv.md
   - item.md
   - player.md
   - panel.md

--- a/documentation/docs/meta/panel.md
+++ b/documentation/docs/meta/panel.md
@@ -28,6 +28,18 @@ Sets up the panel to automatically listen for inventory changes and call appropr
 
 Client.
 
+**Notes**
+
+This method listens for the following inventory events:
+- InventoryInitialized
+- InventoryDeleted
+- InventoryDataChanged
+- InventoryItemAdded
+- InventoryItemRemoved
+- ItemDataChanged
+
+When these events occur, corresponding methods on the panel will be called (e.g., InventoryItemAdded, InventoryItemRemoved, etc.).
+
 **Example Usage**
 
 ```lua

--- a/documentation/docs/meta/tool.md
+++ b/documentation/docs/meta/tool.md
@@ -543,11 +543,15 @@ Gets the tool's owner (player).
 
 **Returns**
 
-* `owner` (*Player*): The tool's owner.
+* `owner` (*Player|nil*): The tool's owner, or nil if not found.
 
 **Realm**
 
 Shared.
+
+**Notes**
+
+This method first tries to get the owner from the tool's SWEP (self:GetSWEP().Owner), and falls back to the tool's internal Owner field if that fails.
 
 **Example Usage**
 
@@ -584,11 +588,15 @@ Gets the tool's weapon entity.
 
 **Returns**
 
-* `weapon` (*Entity*): The weapon entity.
+* `weapon` (*Entity|nil*): The weapon entity, or nil if not found.
 
 **Realm**
 
 Shared.
+
+**Notes**
+
+This method first tries to get the weapon from the tool's SWEP (self:GetSWEP().Weapon), and falls back to the tool's internal Weapon field if that fails.
 
 **Example Usage**
 


### PR DESCRIPTION
Synchronize meta documentation by adding details, correcting return types, and refining navigation.

This PR ensures `panel.md` and `tool.md` accurately reflect their Lua counterparts, including fallback logic and `nil` return possibilities. It also removes the `gridinv.md` entry from navigation, as GridInv methods are now correctly integrated into `inventory.md`.

---
<a href="https://cursor.com/background-agent?bcId=bc-addf7c7b-eadd-485b-adec-2295cf5a00c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-addf7c7b-eadd-485b-adec-2295cf5a00c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

